### PR TITLE
PHP 8.0 support #20

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /laminas-mkdoc-theme/
 /phpunit.xml
 /vendor/
+.phpunit.result.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,42 +6,30 @@ cache:
 
 env:
   global:
-    - COMPOSER_ARGS="--no-interaction"
+    - COMPOSER_ARGS="--no-interaction --ignore-platform-reqs"
     - COVERAGE_DEPS="php-coveralls/php-coveralls"
 
 matrix:
   fast_finish: true
   include:
-    - php: 5.6
+    - php: 7.3
       env:
         - DEPS=lowest
-    - php: 5.6
-      env:
-        - DEPS=latest
-    - php: 7
-      env:
-        - DEPS=lowest
-    - php: 7
-      env:
-        - DEPS=latest
-    - php: 7.1
-      env:
-        - DEPS=lowest
-    - php: 7.1
+    - php: 7.3
       env:
         - DEPS=latest
         - CS_CHECK=true
         - TEST_COVERAGE=true
-    - php: 7.2
+    - php: 7.4
       env:
         - DEPS=lowest
-    - php: 7.2
+    - php: 7.4
       env:
         - DEPS=latest
-    - php: 7.3
+    - php: 'nightly'
       env:
         - DEPS=lowest
-    - php: 7.3
+    - php: 'nightly'
       env:
         - DEPS=latest
 
@@ -49,7 +37,7 @@ before_install:
   - if [[ $TEST_COVERAGE != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi
 
 install:
-  - travis_retry composer install $COMPOSER_ARGS --ignore-platform-reqs
+  - travis_retry composer install $COMPOSER_ARGS
   - if [[ $LEGACY_DEPS != '' ]]; then travis_retry composer update $COMPOSER_ARGS --with-dependencies $LEGACY_DEPS ; fi
   - if [[ $DEPS == 'latest' ]]; then travis_retry composer update $COMPOSER_ARGS ; fi
   - if [[ $DEPS == 'lowest' ]]; then travis_retry composer update $COMPOSER_ARGS --prefer-lowest --prefer-stable ; fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Added
 
-- Nothing.
+- [#21](https://github.com/laminas/laminas-inputfilter/pull/21) Add PHP 8.0 support
 
 ### Changed
 

--- a/composer.json
+++ b/composer.json
@@ -25,16 +25,17 @@
         }
     },
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.3 || ~8.0.0",
         "laminas/laminas-filter": "^2.9.1",
-        "laminas/laminas-servicemanager": "^2.7.10 || ^3.3.1",
-        "laminas/laminas-stdlib": "^2.7 || ^3.0",
+        "laminas/laminas-servicemanager": "^3.3.1",
+        "laminas/laminas-stdlib": "^3.0",
         "laminas/laminas-validator": "^2.11",
         "laminas/laminas-zendframework-bridge": "^1.0"
     },
     "require-dev": {
         "laminas/laminas-coding-standard": "~1.0.0",
-        "phpunit/phpunit": "^5.7.27 || ^6.5.14 || ^7.5.15",
+        "phpspec/prophecy-phpunit": "^2.0",
+        "phpunit/phpunit": "^9.4.2",
         "psr/http-message": "^1.0"
     },
     "suggest": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,17 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
-         bootstrap="vendor/autoload.php"
-         colors="true">
-    <testsuites>
-        <testsuite name="laminas-inputfilter Test Suite">
-            <directory>./test</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">src</directory>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" bootstrap="vendor/autoload.php" colors="true">
+  <coverage processUncoveredFiles="true">
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+  </coverage>
+  <testsuites>
+    <testsuite name="laminas-inputfilter Test Suite">
+      <directory>./test</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/test/ArrayInputTest.php
+++ b/test/ArrayInputTest.php
@@ -16,7 +16,7 @@ use Laminas\InputFilter\Exception\InvalidArgumentException;
  */
 class ArrayInputTest extends InputTest
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->input = new ArrayInput('foo');
     }

--- a/test/BaseInputFilterTest.php
+++ b/test/BaseInputFilterTest.php
@@ -19,7 +19,8 @@ use Laminas\InputFilter\InputFilterInterface;
 use Laminas\InputFilter\InputInterface;
 use Laminas\InputFilter\UnfilteredDataInterface;
 use PHPUnit\Framework\TestCase;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject;
+use ReflectionObject;
 use stdClass;
 
 /**
@@ -32,7 +33,7 @@ class BaseInputFilterTest extends TestCase
      */
     protected $inputFilter;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->inputFilter = new BaseInputFilter();
     }
@@ -134,7 +135,11 @@ class BaseInputFilterTest extends TestCase
         $inputFilter->add($nestedInput, 'fooInput');
 
         $inputFilter->setValidationGroup(['fooInput' => 'foo']);
-        $this->assertAttributeEquals(['fooInput'], 'validationGroup', $inputFilter);
+
+        $r = new ReflectionObject($inputFilter);
+        $p = $r->getProperty('validationGroup');
+        $p->setAccessible(true);
+        $this->assertEquals(['fooInput'], $p->getValue($inputFilter));
     }
 
     public function testSetValidationGroupAllowsSpecifyingArrayOfInputsToNestedInputFilter()
@@ -155,8 +160,11 @@ class BaseInputFilterTest extends TestCase
 
         $inputFilter->setValidationGroup(['nested' => ['nested-input1', 'nested-input2']]);
 
-        $this->assertAttributeEquals(['nested'], 'validationGroup', $inputFilter);
-        $this->assertAttributeEquals(['nested-input1', 'nested-input2'], 'validationGroup', $nestedInputFilter);
+        $r = new ReflectionObject($inputFilter);
+        $p = $r->getProperty('validationGroup');
+        $p->setAccessible(true);
+        $this->assertEquals(['nested'], $p->getValue($inputFilter));
+        $this->assertEquals(['nested-input1', 'nested-input2'], $p->getValue($nestedInputFilter));
     }
 
     public function testSetValidationGroupThrowExceptionIfInputFilterNotExists()
@@ -618,7 +626,7 @@ class BaseInputFilterTest extends TestCase
     {
         $baseInputFilter = new BaseInputFilter();
 
-        self::assertInternalType('array', $baseInputFilter->getUnfilteredData());
+        self::assertIsArray($baseInputFilter->getUnfilteredData());
     }
 
     public function testSetUnfilteredDataReturnsBaseInputFilter()

--- a/test/CollectionInputFilterTest.php
+++ b/test/CollectionInputFilterTest.php
@@ -18,7 +18,7 @@ use Laminas\InputFilter\InputFilter;
 use Laminas\Validator\Digits;
 use Laminas\Validator\NotEmpty;
 use PHPUnit\Framework\TestCase;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject;
 use stdClass;
 
 /**
@@ -31,7 +31,7 @@ class CollectionInputFilterTest extends TestCase
      */
     protected $inputFilter;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->inputFilter = new CollectionInputFilter();
     }

--- a/test/FactoryTest.php
+++ b/test/FactoryTest.php
@@ -24,8 +24,9 @@ use Laminas\InputFilter\InputProviderInterface;
 use Laminas\ServiceManager;
 use Laminas\Validator;
 use PHPUnit\Framework\TestCase;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use ReflectionProperty;
 
 /**
@@ -33,6 +34,8 @@ use ReflectionProperty;
  */
 class FactoryTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function testCreateInputWithInvalidDataTypeThrowsInvalidArgumentException()
     {
         $factory = $this->createDefaultFactory();

--- a/test/FileInput/HttpServerFileInputDecoratorTest.php
+++ b/test/FileInput/HttpServerFileInputDecoratorTest.php
@@ -22,7 +22,7 @@ class HttpServerFileInputDecoratorTest extends InputTest
     /** @var HttpServerFileInputDecorator */
     protected $input;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->input = new FileInput('foo');
         // Upload validator does not work in CLI test environment, disable

--- a/test/FileInput/PsrFileInputDecoratorTest.php
+++ b/test/FileInput/PsrFileInputDecoratorTest.php
@@ -13,6 +13,7 @@ use Laminas\InputFilter\FileInput\PsrFileInputDecorator;
 use Laminas\Validator;
 use LaminasTest\InputFilter\InputTest;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Http\Message\UploadedFileInterface;
 
 /**
@@ -21,10 +22,12 @@ use Psr\Http\Message\UploadedFileInterface;
  */
 class PsrFileInputDecoratorTest extends InputTest
 {
+    use ProphecyTrait;
+
     /** @var PsrFileInputDecorator */
     protected $input;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->input = new FileInput('foo');
         // Upload validator does not work in CLI test environment, disable

--- a/test/InputFilterAbstractServiceFactoryTest.php
+++ b/test/InputFilterAbstractServiceFactoryTest.php
@@ -55,30 +55,17 @@ class InputFilterAbstractServiceFactoryTest extends TestCase
 
     public function testCannotCreateServiceIfNoConfigServicePresent()
     {
-        if (method_exists($this->services, 'configure')) {
-            // v3
-            $method = 'canCreate';
-            $args = [$this->getCompatContainer(), 'filter'];
-        } else {
-            // v2
-            $method = 'canCreateServiceWithName';
-            $args = [$this->getCompatContainer(), 'filter', 'filter'];
-        }
+        $method = 'canCreate';
+        $args   = [$this->getCompatContainer(), 'filter'];
         $this->assertFalse(call_user_func_array([$this->factory, $method], $args));
     }
 
     public function testCannotCreateServiceIfConfigServiceDoesNotHaveInputFiltersConfiguration()
     {
         $this->services->setService('config', []);
-        if (method_exists($this->services, 'configure')) {
-            // v3
-            $method = 'canCreate';
-            $args = [$this->getCompatContainer(), 'filter'];
-        } else {
-            // v2
-            $method = 'canCreateServiceWithName';
-            $args = [$this->getCompatContainer(), 'filter', 'filter'];
-        }
+        $method = 'canCreate';
+        $args = [$this->getCompatContainer(), 'filter'];
+
         $this->assertFalse(call_user_func_array([$this->factory, $method], $args));
     }
 
@@ -87,15 +74,8 @@ class InputFilterAbstractServiceFactoryTest extends TestCase
         $this->services->setService('config', [
             'input_filter_specs' => [],
         ]);
-        if (method_exists($this->services, 'configure')) {
-            // v3
-            $method = 'canCreate';
-            $args = [$this->getCompatContainer(), 'filter'];
-        } else {
-            // v2
-            $method = 'canCreateServiceWithName';
-            $args = [$this->getCompatContainer(), 'filter', 'filter'];
-        }
+        $method = 'canCreate';
+        $args   = [$this->getCompatContainer(), 'filter'];
         $this->assertFalse(call_user_func_array([$this->factory, $method], $args));
     }
 
@@ -106,15 +86,8 @@ class InputFilterAbstractServiceFactoryTest extends TestCase
                 'filter' => [],
             ],
         ]);
-        if (method_exists($this->services, 'configure')) {
-            // v3
-            $method = 'canCreate';
-            $args = [$this->getCompatContainer(), 'filter'];
-        } else {
-            // v2
-            $method = 'canCreateServiceWithName';
-            $args = [$this->getCompatContainer(), 'filter', 'filter'];
-        }
+        $method = 'canCreate';
+        $args   = [$this->getCompatContainer(), 'filter'];
         $this->assertTrue(call_user_func_array([$this->factory, $method], $args));
     }
 
@@ -125,15 +98,8 @@ class InputFilterAbstractServiceFactoryTest extends TestCase
                 'filter' => [],
             ],
         ]);
-        if (method_exists($this->services, 'configure')) {
-            // v3
-            $method = '__invoke';
-            $args = [$this->getCompatContainer(), 'filter'];
-        } else {
-            // v2
-            $method = 'createServiceWithName';
-            $args = [$this->getCompatContainer(), 'filter', 'filter'];
-        }
+        $method = '__invoke';
+        $args   = [$this->getCompatContainer(), 'filter'];
         $filter = call_user_func_array([$this->factory, $method], $args);
         $this->assertInstanceOf(InputFilterInterface::class, $filter);
     }
@@ -172,16 +138,8 @@ class InputFilterAbstractServiceFactoryTest extends TestCase
             ],
         ]);
 
-
-        if (method_exists($this->services, 'configure')) {
-            // v3
-            $method = '__invoke';
-            $args = [$this->getCompatContainer(), 'filter'];
-        } else {
-            // v2
-            $method = 'createServiceWithName';
-            $args = [$this->getCompatContainer(), 'filter', 'filter'];
-        }
+        $method = '__invoke';
+        $args = [$this->getCompatContainer(), 'filter'];
         $inputFilter = call_user_func_array([$this->factory, $method], $args);
         $this->assertTrue($inputFilter->has('input'));
 
@@ -239,19 +197,12 @@ class InputFilterAbstractServiceFactoryTest extends TestCase
     /**
      * Returns appropriate instance to pass to `canCreate()` et al depending on SM version
      *
-     * v3 passes the 'creationContext' (ie the root SM) to the AbstractFactory, whereas v2 passes the PluginManager
+     * v3 passes the 'creationContext' (ie the root SM) to the AbstractFactory
      */
     protected function getCompatContainer()
     {
-        if (method_exists($this->services, 'configure')) {
-            // v3
-            return $this->services;
-        } else {
-            // v2
-            return $this->filters;
-        }
+        return $this->services;
     }
-
 
     /**
      * @depends testCreatesInputFilterInstance
@@ -264,15 +215,7 @@ class InputFilterAbstractServiceFactoryTest extends TestCase
             ],
         ]);
         $this->filters->addAbstractFactory(TestAsset\FooAbstractFactory::class);
-
-        if (method_exists($this->filters, 'configure')) {
-            // laminas-servicemanager v3 usage
-            $filter = $this->factory->__invoke($this->services, 'filter');
-        } else {
-            // laminas-servicemanager v2 usage
-            $filter = $this->factory->createServiceWithName($this->filters, 'filter', 'filter');
-        }
-
+        $filter = $this->factory->__invoke($this->services, 'filter');
         $inputFilterManager = $filter->getFactory()->getInputFilterManager();
 
         $this->assertInstanceOf('Laminas\InputFilter\InputFilterPluginManager', $inputFilterManager);
@@ -289,18 +232,9 @@ class InputFilterAbstractServiceFactoryTest extends TestCase
                 'filter' => [],
             ],
         ]);
-        if (method_exists($this->services, 'configure')) {
-            // v3
-            $canCreate = 'canCreate';
-            $create = '__invoke';
-            $args = [$this->services, 'filter'];
-        } else {
-            // v2
-            $canCreate = 'canCreateServiceWithName';
-            $create = 'createServiceWithName';
-            $args = [$this->services, 'filter', 'filter'];
-        }
-
+        $canCreate = 'canCreate';
+        $create = '__invoke';
+        $args = [$this->services, 'filter'];
         $this->assertTrue(call_user_func_array([$this->factory, $canCreate], $args));
         $inputFilter = call_user_func_array([$this->factory, $create], $args);
         $this->assertInstanceOf(InputFilterInterface::class, $inputFilter);

--- a/test/InputFilterAbstractServiceFactoryTest.php
+++ b/test/InputFilterAbstractServiceFactoryTest.php
@@ -19,13 +19,16 @@ use Laminas\Validator;
 use Laminas\Validator\ValidatorInterface;
 use Laminas\Validator\ValidatorPluginManager;
 use PHPUnit\Framework\TestCase;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 /**
  * @covers \Laminas\InputFilter\InputFilterAbstractServiceFactory
  */
 class InputFilterAbstractServiceFactoryTest extends TestCase
 {
+    use ProphecyTrait;
+
     /**
      * @var ServiceManager
      */
@@ -41,7 +44,7 @@ class InputFilterAbstractServiceFactoryTest extends TestCase
      */
     protected $factory;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->services = new ServiceManager();
         $this->filters  = new InputFilterPluginManager($this->services);
@@ -368,7 +371,7 @@ class InputFilterAbstractServiceFactoryTest extends TestCase
         $this->assertCount(1, $filters);
 
         $callback = $filters->getFilters()->top();
-        $this->assertInternalType('array', $callback);
+        $this->assertIsArray($callback);
         $this->assertSame($filter, $callback[0]);
     }
 }

--- a/test/InputFilterAwareTraitTest.php
+++ b/test/InputFilterAwareTraitTest.php
@@ -22,13 +22,16 @@ class InputFilterAwareTraitTest extends TestCase
     {
         $object = $this->getObjectForTrait(InputFilterAwareTrait::class);
 
-        $this->assertAttributeEquals(null, 'inputFilter', $object);
+        $r = new \ReflectionObject($object);
+        $p = $r->getProperty('inputFilter');
+        $p->setAccessible(true);
+        $this->assertNull($p->getValue($object));
 
         $inputFilter = new InputFilter;
 
         $object->setInputFilter($inputFilter);
 
-        $this->assertAttributeEquals($inputFilter, 'inputFilter', $object);
+        $this->assertSame($inputFilter, $p->getValue($object));
     }
 
     public function testGetInputFilter()

--- a/test/InputFilterAwareTraitTest.php
+++ b/test/InputFilterAwareTraitTest.php
@@ -11,6 +11,7 @@ namespace LaminasTest\InputFilter;
 use Laminas\InputFilter\InputFilter;
 use Laminas\InputFilter\InputFilterAwareTrait;
 use PHPUnit\Framework\TestCase;
+use ReflectionObject;
 
 /**
  * @requires PHP 5.4
@@ -22,7 +23,7 @@ class InputFilterAwareTraitTest extends TestCase
     {
         $object = $this->getObjectForTrait(InputFilterAwareTrait::class);
 
-        $r = new \ReflectionObject($object);
+        $r = new ReflectionObject($object);
         $p = $r->getProperty('inputFilter');
         $p->setAccessible(true);
         $this->assertNull($p->getValue($object));

--- a/test/InputFilterPluginManagerCompatibilityTest.php
+++ b/test/InputFilterPluginManagerCompatibilityTest.php
@@ -39,26 +39,4 @@ class InputFilterPluginManagerCompatibilityTest extends TestCase
         // InputFilterManager accepts multiple instance types
         return;
     }
-
-    public function testConstructorArgumentsAreOptionalUnderV2()
-    {
-        $plugins = $this->getPluginManager();
-        if (method_exists($plugins, 'configure')) {
-            $this->markTestSkipped('laminas-servicemanager v3 plugin managers require a container argument');
-        }
-
-        $plugins = new InputFilterPluginManager();
-        $this->assertInstanceOf(InputFilterPluginManager::class, $plugins);
-    }
-
-    public function testConstructorAllowsConfigInstanceAsFirstArgumentUnderV2()
-    {
-        $plugins = $this->getPluginManager();
-        if (method_exists($plugins, 'configure')) {
-            $this->markTestSkipped('laminas-servicemanager v3 plugin managers require a container argument');
-        }
-
-        $plugins = new InputFilterPluginManager(new Config([]));
-        $this->assertInstanceOf(InputFilterPluginManager::class, $plugins);
-    }
 }

--- a/test/InputFilterPluginManagerFactoryTest.php
+++ b/test/InputFilterPluginManagerFactoryTest.php
@@ -30,16 +30,10 @@ class InputFilterPluginManagerFactoryTest extends TestCase
         $filters = $factory($container, InputFilterPluginManagerFactory::class);
         $this->assertInstanceOf(InputFilterPluginManager::class, $filters);
 
-        if (method_exists($filters, 'configure')) {
-            // laminas-servicemanager v3
-            $r = new ReflectionObject($filters);
-            $p = $r->getProperty('creationContext');
-            $p->setAccessible(true);
-            $this->assertSame($container, $p->getValue($filters));
-        } else {
-            // laminas-servicemanager v2
-            $this->assertSame($container, $filters->getServiceLocator());
-        }
+        $r = new ReflectionObject($filters);
+        $p = $r->getProperty('creationContext');
+        $p->setAccessible(true);
+        $this->assertSame($container, $p->getValue($filters));
     }
 
     public function pluginProvider()

--- a/test/InputFilterPluginManagerFactoryTest.php
+++ b/test/InputFilterPluginManagerFactoryTest.php
@@ -15,9 +15,13 @@ use Laminas\InputFilter\InputFilterPluginManagerFactory;
 use Laminas\InputFilter\InputInterface;
 use Laminas\ServiceManager\ServiceLocatorInterface;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use ReflectionObject;
 
 class InputFilterPluginManagerFactoryTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function testFactoryReturnsPluginManager()
     {
         $container = $this->prophesize(ContainerInterface::class)->reveal();
@@ -28,7 +32,10 @@ class InputFilterPluginManagerFactoryTest extends TestCase
 
         if (method_exists($filters, 'configure')) {
             // laminas-servicemanager v3
-            $this->assertAttributeSame($container, 'creationContext', $filters);
+            $r = new ReflectionObject($filters);
+            $p = $r->getProperty('creationContext');
+            $p->setAccessible(true);
+            $this->assertSame($container, $p->getValue($filters));
         } else {
             // laminas-servicemanager v2
             $this->assertSame($container, $filters->getServiceLocator());

--- a/test/InputFilterPluginManagerTest.php
+++ b/test/InputFilterPluginManagerTest.php
@@ -22,13 +22,17 @@ use Laminas\ServiceManager\ServiceManager;
 use Laminas\Stdlib\InitializableInterface;
 use Laminas\Validator\ValidatorPluginManager;
 use PHPUnit\Framework\TestCase;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject;
+use Prophecy\PhpUnit\ProphecyTrait;
+use ReflectionObject;
 
 /**
  * @covers \Laminas\InputFilter\InputFilterPluginManager
  */
 class InputFilterPluginManagerTest extends TestCase
 {
+    use ProphecyTrait;
+
     /**
      * @var InputFilterPluginManager
      */
@@ -39,7 +43,7 @@ class InputFilterPluginManagerTest extends TestCase
      */
     protected $services;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->services = new ServiceManager();
         $this->manager = new InputFilterPluginManager($this->services);
@@ -56,7 +60,10 @@ class InputFilterPluginManagerTest extends TestCase
             ? 'sharedByDefault' // v3
             : 'shareByDefault'; // v2
 
-        $this->assertAttributeSame(false, $property, $this->manager);
+        $r = new ReflectionObject($this->manager);
+        $p = $r->getProperty($property);
+        $p->setAccessible(true);
+        $this->assertFalse($p->getValue($this->manager));
     }
 
     public function testRegisteringInvalidElementRaisesException()

--- a/test/InputFilterPluginManagerTest.php
+++ b/test/InputFilterPluginManagerTest.php
@@ -56,12 +56,8 @@ class InputFilterPluginManagerTest extends TestCase
 
     public function testIsNotSharedByDefault()
     {
-        $property = method_exists($this->manager, 'configure')
-            ? 'sharedByDefault' // v3
-            : 'shareByDefault'; // v2
-
         $r = new ReflectionObject($this->manager);
-        $p = $r->getProperty($property);
+        $p = $r->getProperty('sharedByDefault');
         $p->setAccessible(true);
         $this->assertFalse($p->getValue($this->manager));
     }

--- a/test/InputFilterTest.php
+++ b/test/InputFilterTest.php
@@ -12,8 +12,7 @@ use ArrayIterator;
 use Laminas\InputFilter\Factory;
 use Laminas\InputFilter\Input;
 use Laminas\InputFilter\InputFilter;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
-use stdClass;
+use PHPUnit\Framework\MockObject\MockObject;
 
 /**
  * @covers \Laminas\InputFilter\InputFilter
@@ -25,7 +24,7 @@ class InputFilterTest extends BaseInputFilterTest
      */
     protected $inputFilter;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->inputFilter = new InputFilter();
     }

--- a/test/InputTest.php
+++ b/test/InputTest.php
@@ -18,7 +18,8 @@ use Laminas\Validator\Translator\TranslatorInterface;
 use Laminas\Validator\ValidatorChain;
 use Laminas\Validator\ValidatorInterface;
 use PHPUnit\Framework\TestCase;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject;
+use Prophecy\PhpUnit\ProphecyTrait;
 use stdClass;
 
 /**
@@ -26,17 +27,19 @@ use stdClass;
  */
 class InputTest extends TestCase
 {
+    use ProphecyTrait;
+
     /**
      * @var Input
      */
     protected $input;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->input = new Input('foo');
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         AbstractValidator::setDefaultTranslator(null);
     }
@@ -47,7 +50,7 @@ class InputTest extends TestCase
         $message .= ';';
 
         $messages = $input->getMessages();
-        $this->assertInternalType('array', $messages, $message . ' non-array messages array');
+        $this->assertIsArray($messages, $message . ' non-array messages array');
 
         $notEmpty         = new NotEmptyValidator();
         $messageTemplates = $notEmpty->getOption('messageTemplates');

--- a/test/ModuleTest.php
+++ b/test/ModuleTest.php
@@ -13,13 +13,16 @@ use Laminas\InputFilter\InputFilterAbstractServiceFactory;
 use Laminas\InputFilter\InputFilterPluginManager;
 use Laminas\InputFilter\Module;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 class ModuleTest extends TestCase
 {
+    use ProphecyTrait;
+
     /** @var Module */
     private $module;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->module = new Module();
     }
@@ -28,7 +31,7 @@ class ModuleTest extends TestCase
     {
         $config = $this->module->getConfig();
 
-        $this->assertInternalType('array', $config);
+        $this->assertIsArray($config);
 
         // Service manager
         $this->assertArrayHasKey('service_manager', $config);


### PR DESCRIPTION
# Feature Request

Q | A
-- | --
New Feature | yes

Summary
To be prepared for the december release of PHP 8.0, this repository has some additional TODOs to be tested against the new major version.

In order to make this repository compatible, one has to follow these steps:

- [x] Modify composer.json to provide support for PHP 8.0 by adding the constraint ~8.0.0
- [x] Modify composer.json to drop support for PHP less than 7.3
- [x] Modify composer.json to implement phpunit 9.3 which supports PHP 7.3+
- [x] Modify .travis.yml to ignore platform requirements when installing composer dependencies (simply add --ignore-platform-reqs to COMPOSER_ARGS env variable)
- [x] Modify .travis.yml to add PHP 8.0 to the matrix (NOTE: Do not allow failures as PHP 8.0 has a feature freeze since 2020-08-04!)
- [x] Modify source code in case there are incompatibilities with PHP 8.0

closes #20