### PR TITLE
Hotfix/8 nested input filter config

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -324,6 +324,10 @@ class Factory
             return $inputFilter;
         }
 
+        if (isset($inputFilterSpecification['inputs']) && is_array($inputFilterSpecification['inputs'])) {
+            $inputFilterSpecification = $inputFilterSpecification['inputs'];
+        }
+
         foreach ($inputFilterSpecification as $key => $value) {
             if (null === $value) {
                 continue;

--- a/test/FactoryTest.php
+++ b/test/FactoryTest.php
@@ -503,82 +503,15 @@ class FactoryTest extends TestCase
         $this->assertEquals($input, $inputFilter->get('foo'));
     }
 
-    public function testFactoryWillCreateInputFilterAndAllInputObjectsFromGivenConfiguration()
+    /**
+     * @param array $spec
+     *
+     * @dataProvider getFactoryWillCreateInputFilterAndAllInputObjectsFromGivenConfigurationData
+     */
+    public function testFactoryWillCreateInputFilterAndAllInputObjectsFromGivenConfiguration(array $spec)
     {
         $factory     = $this->createDefaultFactory();
-        $inputFilter = $factory->createInputFilter([
-            'foo' => [
-                'name'       => 'foo',
-                'required'   => false,
-                'validators' => [
-                    [
-                        'name' => Validator\NotEmpty::class,
-                    ],
-                    [
-                        'name' => Validator\StringLength::class,
-                        'options' => [
-                            'min' => 3,
-                            'max' => 5,
-                        ],
-                    ],
-                ],
-            ],
-            'bar' => [
-                'allow_empty' => true,
-                'filters'     => [
-                    [
-                        'name' => Filter\StringTrim::class,
-                    ],
-                    [
-                        'name' => Filter\StringToLower::class,
-                        'options' => [
-                            'encoding' => 'ISO-8859-1',
-                        ],
-                    ],
-                ],
-            ],
-            'baz' => [
-                'type'   => InputFilter::class,
-                'foo' => [
-                    'name'       => 'foo',
-                    'required'   => false,
-                    'validators' => [
-                        [
-                            'name' => Validator\NotEmpty::class,
-                        ],
-                        [
-                            'name' => Validator\StringLength::class,
-                            'options' => [
-                                'min' => 3,
-                                'max' => 5,
-                            ],
-                        ],
-                    ],
-                ],
-                'bar' => [
-                    'allow_empty' => true,
-                    'filters'     => [
-                        [
-                            'name' => Filter\StringTrim::class,
-                        ],
-                        [
-                            'name' => Filter\StringToLower::class,
-                            'options' => [
-                                'encoding' => 'ISO-8859-1',
-                            ],
-                        ],
-                    ],
-                ],
-            ],
-            'bat' => [
-                'type' => 'LaminasTest\InputFilter\TestAsset\CustomInput',
-                'name' => 'bat',
-            ],
-            'zomg' => [
-                'name' => 'zomg',
-                'continue_if_empty' => true,
-            ],
-        ]);
+        $inputFilter = $factory->createInputFilter($spec);
         $this->assertInstanceOf(InputFilter::class, $inputFilter);
         $this->assertEquals(5, count($inputFilter));
 
@@ -617,6 +550,165 @@ class FactoryTest extends TestCase
                     $this->assertTrue($input->continueIfEmpty());
             }
         }
+    }
+
+    public function getFactoryWillCreateInputFilterAndAllInputObjectsFromGivenConfigurationData()
+    {
+        return [
+            [
+                [
+                    'foo' => [
+                        'name'       => 'foo',
+                        'required'   => false,
+                        'validators' => [
+                            [
+                                'name' => Validator\NotEmpty::class,
+                            ],
+                            [
+                                'name' => Validator\StringLength::class,
+                                'options' => [
+                                    'min' => 3,
+                                    'max' => 5,
+                                ],
+                            ],
+                        ],
+                    ],
+                    'bar' => [
+                        'allow_empty' => true,
+                        'filters'     => [
+                            [
+                                'name' => Filter\StringTrim::class,
+                            ],
+                            [
+                                'name' => Filter\StringToLower::class,
+                                'options' => [
+                                    'encoding' => 'ISO-8859-1',
+                                ],
+                            ],
+                        ],
+                    ],
+                    'baz' => [
+                        'type'   => InputFilter::class,
+                        'foo' => [
+                            'name'       => 'foo',
+                            'required'   => false,
+                            'validators' => [
+                                [
+                                    'name' => Validator\NotEmpty::class,
+                                ],
+                                [
+                                    'name' => Validator\StringLength::class,
+                                    'options' => [
+                                        'min' => 3,
+                                        'max' => 5,
+                                    ],
+                                ],
+                            ],
+                        ],
+                        'bar' => [
+                            'allow_empty' => true,
+                            'filters'     => [
+                                [
+                                    'name' => Filter\StringTrim::class,
+                                ],
+                                [
+                                    'name' => Filter\StringToLower::class,
+                                    'options' => [
+                                        'encoding' => 'ISO-8859-1',
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                    'bat' => [
+                        'type' => 'LaminasTest\InputFilter\TestAsset\CustomInput',
+                        'name' => 'bat',
+                    ],
+                    'zomg' => [
+                        'name' => 'zomg',
+                        'continue_if_empty' => true,
+                    ],
+                ],
+            ],
+
+            [
+                [
+                    'foo' => [
+                        'name'       => 'foo',
+                        'required'   => false,
+                        'validators' => [
+                            [
+                                'name' => Validator\NotEmpty::class,
+                            ],
+                            [
+                                'name' => Validator\StringLength::class,
+                                'options' => [
+                                    'min' => 3,
+                                    'max' => 5,
+                                ],
+                            ],
+                        ],
+                    ],
+                    'bar' => [
+                        'allow_empty' => true,
+                        'filters'     => [
+                            [
+                                'name' => Filter\StringTrim::class,
+                            ],
+                            [
+                                'name' => Filter\StringToLower::class,
+                                'options' => [
+                                    'encoding' => 'ISO-8859-1',
+                                ],
+                            ],
+                        ],
+                    ],
+                    'baz' => [
+                        'type'   => InputFilter::class,
+                        'inputs' => [
+                            'foo' => [
+                                'name'       => 'foo',
+                                'required'   => false,
+                                'validators' => [
+                                    [
+                                        'name' => Validator\NotEmpty::class,
+                                    ],
+                                    [
+                                        'name' => Validator\StringLength::class,
+                                        'options' => [
+                                            'min' => 3,
+                                            'max' => 5,
+                                        ],
+                                    ],
+                                ],
+                            ],
+                            'bar' => [
+                                'allow_empty' => true,
+                                'filters'     => [
+                                    [
+                                        'name' => Filter\StringTrim::class,
+                                    ],
+                                    [
+                                        'name' => Filter\StringToLower::class,
+                                        'options' => [
+                                            'encoding' => 'ISO-8859-1',
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                    'bat' => [
+                        'type' => 'LaminasTest\InputFilter\TestAsset\CustomInput',
+                        'name' => 'bat',
+                    ],
+                    'zomg' => [
+                        'name' => 'zomg',
+                        'continue_if_empty' => true,
+                    ],
+                ],
+            ],
+        ];
     }
 
     public function testFactoryWillCreateInputFilterMatchingInputNameWhenNotSpecified()


### PR DESCRIPTION

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | maybe
| New Feature   | no
| RFC           | no

### Description

This pull request aids to address the problem defined in issue #8 

I have added the ability to nest the input specification of nested input filters, when calling `Factory::createInputFilter()` 

Currently, when nesting input filter configuration, the `type` key sits at the same level as the names of the required inputs. This can cause issue if the input you wish to add also has the name `type`,

    $spec = [
        'baz' => [
            'type' => InputFilter::class,
            'foo' => [
                'name' => 'foo',
                'required' => false,
                'validators' => [
                    [
                       'name' => Validator\NotEmpty::class,
                    ],
                ],
            ],
        ],
    ];

    $factory->createInputFilter($spec);

This PR allows the optional `inputs` key that nests the relevant inputs. If we have an input with the name `type`  if will no longer conflict.

    $spec = [
        'baz' => [
            'type' => InputFilter::class,
            'inputs' => [
                'type' => [
                    'name' => 'foo',
                    'required' => false,
                    'validators' => [
                        [
                            'name' => Validator\NotEmpty::class,
                        ],
                    ],
                ],
            ],
        ],
    ];

    $factory->createInputFilter($spec);

# BC Consideration

There is a possibility that existing code has an input already named `inputs` so we could consider changing this to something more unique


