### PR TITLE
CollectionInputFilter::isValid($context) - pass $context to nested input filter

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -921,7 +921,7 @@
       <code>function () use ($dataRaw, $dataFiltered) {</code>
       <code>function () use ($dataRaw, $dataFiltered, $errorMessage) {</code>
     </MissingClosureReturnType>
-    <MissingParamType occurrences="21">
+    <MissingParamType occurrences="19">
       <code>$count</code>
       <code>$count</code>
       <code>$count</code>
@@ -941,10 +941,8 @@
       <code>$inputFilter</code>
       <code>$required</code>
       <code>$value</code>
-      <code>$customContext</code>
-      <code>$expectedContext</code>
     </MissingParamType>
-    <MissingReturnType occurrences="31">
+    <MissingReturnType occurrences="29">
       <code>countVsDataProvider</code>
       <code>dataNestingCollection</code>
       <code>dataVsValidProvider</code>
@@ -974,8 +972,6 @@
       <code>testSettingDataAsTraversableWithInvalidCollectionsRaisesException</code>
       <code>testSettingDataWithNonArrayNonTraversableRaisesException</code>
       <code>testUsesMessageFromComposedNotEmptyValidatorWhenRequiredButCollectionIsEmpty</code>
-      <code>contextProvider</code>
-      <code>testValidationContext</code>
     </MissingReturnType>
     <MixedArgument occurrences="27">
       <code>$count</code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -921,7 +921,7 @@
       <code>function () use ($dataRaw, $dataFiltered) {</code>
       <code>function () use ($dataRaw, $dataFiltered, $errorMessage) {</code>
     </MissingClosureReturnType>
-    <MissingParamType occurrences="19">
+    <MissingParamType occurrences="21">
       <code>$count</code>
       <code>$count</code>
       <code>$count</code>
@@ -941,8 +941,10 @@
       <code>$inputFilter</code>
       <code>$required</code>
       <code>$value</code>
+      <code>$customContext</code>
+      <code>$expectedContext</code>
     </MissingParamType>
-    <MissingReturnType occurrences="29">
+    <MissingReturnType occurrences="31">
       <code>countVsDataProvider</code>
       <code>dataNestingCollection</code>
       <code>dataVsValidProvider</code>
@@ -972,6 +974,8 @@
       <code>testSettingDataAsTraversableWithInvalidCollectionsRaisesException</code>
       <code>testSettingDataWithNonArrayNonTraversableRaisesException</code>
       <code>testUsesMessageFromComposedNotEmptyValidatorWhenRequiredButCollectionIsEmpty</code>
+      <code>contextProvider</code>
+      <code>testValidationContext</code>
     </MissingReturnType>
     <MixedArgument occurrences="27">
       <code>$count</code>
@@ -1025,7 +1029,7 @@
     <MixedFunctionCall occurrences="1">
       <code>$set[3]()</code>
     </MixedFunctionCall>
-    <MixedMethodCall occurrences="8">
+    <MixedMethodCall occurrences="11">
       <code>method</code>
       <code>method</code>
       <code>method</code>
@@ -1034,17 +1038,22 @@
       <code>willReturn</code>
       <code>willReturn</code>
       <code>with</code>
+      <code>method</code>
+      <code>with</code>
+      <code>willReturn</code>
     </MixedMethodCall>
-    <PossiblyInvalidArgument occurrences="1">
+    <PossiblyInvalidArgument occurrences="2">
+      <code>$baseInputFilter</code>
       <code>$baseInputFilter</code>
     </PossiblyInvalidArgument>
-    <PossiblyUndefinedMethod occurrences="6">
+    <PossiblyUndefinedMethod occurrences="7">
       <code>expects</code>
       <code>expects</code>
       <code>expects</code>
       <code>method</code>
       <code>method</code>
       <code>method</code>
+      <code>expects</code>
     </PossiblyUndefinedMethod>
   </file>
   <file src="test/ConfigProviderTest.php">

--- a/src/CollectionInputFilter.php
+++ b/src/CollectionInputFilter.php
@@ -205,7 +205,7 @@ class CollectionInputFilter extends InputFilter
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function isValid($context = null)
     {

--- a/src/CollectionInputFilter.php
+++ b/src/CollectionInputFilter.php
@@ -206,7 +206,6 @@ class CollectionInputFilter extends InputFilter
 
     /**
      * {@inheritdoc}
-     * @param mixed $context Ignored, but present to retain signature compatibility.
      */
     public function isValid($context = null)
     {
@@ -237,7 +236,7 @@ class CollectionInputFilter extends InputFilter
                 $inputFilter->setValidationGroup($this->validationGroup[$key]);
             }
 
-            if ($inputFilter->isValid()) {
+            if ($inputFilter->isValid($context)) {
                 $this->validInputs[$key] = $inputFilter->getValidInput();
             } else {
                 $valid = false;

--- a/test/CollectionInputFilterTest.php
+++ b/test/CollectionInputFilterTest.php
@@ -799,7 +799,10 @@ class CollectionInputFilterTest extends TestCase
         self::assertSame($unfilteredArray, $collectionInputFilter->getUnfilteredData());
     }
 
-    public function contextProvider()
+    /**
+     * @return iterable<string, array{0: array, 1: null|array, 2: null|array}>
+     */
+    public function contextProvider() : iterable
     {
         $data = ['fooInput' => 'fooValue'];
 
@@ -815,7 +818,7 @@ class CollectionInputFilterTest extends TestCase
     /**
      * @dataProvider contextProvider
      */
-    public function testValidationContext(array $data, $customContext, $expectedContext)
+    public function testValidationContext(array $data, ?array $customContext, ?array $expectedContext) : void
     {
         /** @var MockObject|BaseInputFilter $baseInputFilter */
         $baseInputFilter = $this->createMock(BaseInputFilter::class);


### PR DESCRIPTION
As I mentioned in #42 `CollectionInputFilter::isValid($context)` does not pass given `$context` to nested input filter.

I expect the current behavior is rather bug - php doc - @param mixed $context Ignored, but present to retain signature compatibility.

This PR fixes passing `$context` and thus `$context` is available in nested input filter and its validators.