### PR TITLE
Bugfix: removed ArrayAccess from BaseInputFilter::validateInputs() DocBlocks

### DIFF
--- a/src/BaseInputFilter.php
+++ b/src/BaseInputFilter.php
@@ -229,9 +229,9 @@ class BaseInputFilter implements
      * @param  mixed|null $context
      * @return bool
      */
-    protected function validateInputs(array $inputs, array $data = [], $context = null)
+    protected function validateInputs(array $inputs, $data = [], $context = null)
     {
-        $inputContext = $context ?: (array_merge($this->getRawValues(), $data));
+        $inputContext = $context ?: (array_merge($this->getRawValues(), (array) $data));
 
         $this->validInputs   = [];
         $this->invalidInputs = [];

--- a/src/BaseInputFilter.php
+++ b/src/BaseInputFilter.php
@@ -2,7 +2,6 @@
 
 namespace Laminas\InputFilter;
 
-use ArrayAccess;
 use Laminas\Stdlib\ArrayUtils;
 use Laminas\Stdlib\InitializableInterface;
 use Traversable;
@@ -226,13 +225,13 @@ class BaseInputFilter implements
      * Validate a set of inputs against the current data
      *
      * @param  string[] $inputs Array of input names.
-     * @param  array|ArrayAccess $data
+     * @param  array $data
      * @param  mixed|null $context
      * @return bool
      */
-    protected function validateInputs(array $inputs, $data = [], $context = null)
+    protected function validateInputs(array $inputs, array $data = [], $context = null)
     {
-        $inputContext = $context ?: (array_merge($this->getRawValues(), (array) $data));
+        $inputContext = $context ?: (array_merge($this->getRawValues(), $data));
 
         $this->validInputs   = [];
         $this->invalidInputs = [];

--- a/src/BaseInputFilter.php
+++ b/src/BaseInputFilter.php
@@ -229,9 +229,9 @@ class BaseInputFilter implements
      * @param  mixed|null $context
      * @return bool
      */
-    protected function validateInputs(array $inputs, $data = [], $context = null)
+    protected function validateInputs(array $inputs, array $data = [], $context = null)
     {
-        $inputContext = $context ?: (array_merge($this->getRawValues(), (array) $data));
+        $inputContext = $context ?: (array_merge($this->getRawValues(), $data));
 
         $this->validInputs   = [];
         $this->invalidInputs = [];


### PR DESCRIPTION


Signed-off-by: illia <illia.gapak@ffflabel.com>

<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: master branch
  * Bugfix: master branch
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | yes
| New Feature   | no
| RFC           | no
| QA            | no

### Description

I described the problem on [Laminas Forums](https://discourse.laminas.dev/t/arrayaccess-arg-type-in-baseinputfilter-validateinputs/2567) and created a test to show the issue [#40 ](https://github.com/laminas/laminas-inputfilter/pull/40)

This is breaking change for everyone who extends BaseInputFilter::validateInputs() due function signature change - I added 'array' type to $data argument.