### PR TITLE
Update to laminas-coding-standard v2 series

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.phpcs-cache
 /.phpunit.result.cache
 /.psalm-cache/
 /clover.xml

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         }
     },
     "require": {
-        "php": "^7.3 || ~8.0.0",
+        "php": "^7.4 || ~8.0.0",
         "laminas/laminas-filter": "^2.9.1",
         "laminas/laminas-servicemanager": "^3.3.1",
         "laminas/laminas-stdlib": "^3.0",

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "laminas/laminas-zendframework-bridge": "^1.0"
     },
     "require-dev": {
-        "laminas/laminas-coding-standard": "~1.0.0",
+        "laminas/laminas-coding-standard": "~2.2.1",
         "laminas/laminas-db": "^2.12",
         "phpspec/prophecy-phpunit": "^2.0",
         "phpunit/phpunit": "^9.4.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6136ee88ef1801d155fae75ce020e24f",
+    "content-hash": "93baa8c57365cf18ab53eb43734820ed",
     "packages": [
         {
             "name": "container-interop/container-interop",
@@ -4730,7 +4730,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.3 || ~8.0.0"
+        "php": "^7.4 || ~8.0.0"
     },
     "platform-dev": [],
     "plugin-api-version": "2.1.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0b3bcb4552291d08de3639586875ba85",
+    "content-hash": "6136ee88ef1801d155fae75ce020e24f",
     "packages": [
         {
             "name": "container-interop/container-interop",
@@ -44,16 +44,16 @@
         },
         {
             "name": "laminas/laminas-filter",
-            "version": "2.10.0",
+            "version": "2.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-filter.git",
-                "reference": "cfb40b104e92a0b52bee696b74f958798ad8faa4"
+                "reference": "0fc5dcd27dc22dba1a2544123684c67768fc5f88"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-filter/zipball/cfb40b104e92a0b52bee696b74f958798ad8faa4",
-                "reference": "cfb40b104e92a0b52bee696b74f958798ad8faa4",
+                "url": "https://api.github.com/repos/laminas/laminas-filter/zipball/0fc5dcd27dc22dba1a2544123684c67768fc5f88",
+                "reference": "0fc5dcd27dc22dba1a2544123684c67768fc5f88",
                 "shasum": ""
             },
             "require": {
@@ -75,7 +75,9 @@
                 "pear/archive_tar": "^1.4.3",
                 "phpspec/prophecy-phpunit": "^2.0",
                 "phpunit/phpunit": "^9.3",
-                "psr/http-factory": "^1.0"
+                "psalm/plugin-phpunit": "^0.15.1",
+                "psr/http-factory": "^1.0",
+                "vimeo/psalm": "^4.6"
             },
             "suggest": {
                 "laminas/laminas-crypt": "Laminas\\Crypt component, for encryption filters",
@@ -120,50 +122,49 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2021-01-01T14:37:45+00:00"
+            "time": "2021-10-24T21:01:15+00:00"
         },
         {
             "name": "laminas/laminas-servicemanager",
-            "version": "3.6.4",
+            "version": "3.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-servicemanager.git",
-                "reference": "b1445e1a7077c21b0fad0974a1b7a11b9dbe0828"
+                "reference": "e52b985909e0940bf22d34f322eb3f48bbef6bd1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-servicemanager/zipball/b1445e1a7077c21b0fad0974a1b7a11b9dbe0828",
-                "reference": "b1445e1a7077c21b0fad0974a1b7a11b9dbe0828",
+                "url": "https://api.github.com/repos/laminas/laminas-servicemanager/zipball/e52b985909e0940bf22d34f322eb3f48bbef6bd1",
+                "reference": "e52b985909e0940bf22d34f322eb3f48bbef6bd1",
                 "shasum": ""
             },
             "require": {
                 "container-interop/container-interop": "^1.2",
                 "laminas/laminas-stdlib": "^3.2.1",
-                "laminas/laminas-zendframework-bridge": "^1.0",
-                "php": "^7.3 || ~8.0.0",
+                "php": "~7.4.0 || ~8.0.0 || ~8.1.0",
                 "psr/container": "^1.0"
             },
             "conflict": {
                 "laminas/laminas-code": "<3.3.1",
-                "zendframework/zend-code": "<3.3.1"
+                "zendframework/zend-code": "<3.3.1",
+                "zendframework/zend-servicemanager": "*"
             },
             "provide": {
                 "container-interop/container-interop-implementation": "^1.2",
                 "psr/container-implementation": "^1.0"
             },
-            "replace": {
-                "zendframework/zend-servicemanager": "^3.4.0"
-            },
             "require-dev": {
                 "composer/package-versions-deprecated": "^1.0",
-                "laminas/laminas-coding-standard": "~1.0.0",
+                "laminas/laminas-coding-standard": "~2.2.1",
                 "laminas/laminas-container-config-test": "^0.3",
-                "laminas/laminas-dependency-plugin": "^2.1",
-                "mikey179/vfsstream": "^1.6.8",
-                "ocramius/proxy-manager": "^2.2.3",
-                "phpbench/phpbench": "^1.0.0-alpha3",
+                "laminas/laminas-dependency-plugin": "^2.1.2",
+                "mikey179/vfsstream": "^1.6.10@alpha",
+                "ocramius/proxy-manager": "^2.11",
+                "phpbench/phpbench": "^1.1",
                 "phpspec/prophecy-phpunit": "^2.0",
-                "phpunit/phpunit": "^9.4"
+                "phpunit/phpunit": "^9.5.5",
+                "psalm/plugin-phpunit": "^0.16.1",
+                "vimeo/psalm": "^4.8"
             },
             "suggest": {
                 "ocramius/proxy-manager": "ProxyManager ^2.1.1 to handle lazy initialization of services"
@@ -207,33 +208,34 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2021-02-03T08:44:41+00:00"
+            "time": "2021-09-18T20:19:36+00:00"
         },
         {
             "name": "laminas/laminas-stdlib",
-            "version": "3.3.1",
+            "version": "3.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-stdlib.git",
-                "reference": "d81c7ffe602ed0e6ecb18691019111c0f4bf1efe"
+                "reference": "db581851a092246ad99e12d4fddf105184924c71"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-stdlib/zipball/d81c7ffe602ed0e6ecb18691019111c0f4bf1efe",
-                "reference": "d81c7ffe602ed0e6ecb18691019111c0f4bf1efe",
+                "url": "https://api.github.com/repos/laminas/laminas-stdlib/zipball/db581851a092246ad99e12d4fddf105184924c71",
+                "reference": "db581851a092246ad99e12d4fddf105184924c71",
                 "shasum": ""
             },
             "require": {
-                "laminas/laminas-zendframework-bridge": "^1.0",
-                "php": "^7.3 || ^8.0"
+                "php": "^7.3 || ~8.0.0 || ~8.1.0"
             },
-            "replace": {
-                "zendframework/zend-stdlib": "^3.2.1"
+            "conflict": {
+                "zendframework/zend-stdlib": "*"
             },
             "require-dev": {
-                "laminas/laminas-coding-standard": "~1.0.0",
+                "laminas/laminas-coding-standard": "~2.3.0",
                 "phpbench/phpbench": "^0.17.1",
-                "phpunit/phpunit": "~9.3.7"
+                "phpunit/phpunit": "~9.3.7",
+                "psalm/plugin-phpunit": "^0.16.0",
+                "vimeo/psalm": "^4.7"
             },
             "type": "library",
             "autoload": {
@@ -265,35 +267,33 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2020-11-19T20:18:59+00:00"
+            "time": "2021-11-10T11:33:52+00:00"
         },
         {
             "name": "laminas/laminas-validator",
-            "version": "2.14.4",
+            "version": "2.15.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-validator.git",
-                "reference": "e370c4695db1c81e6dfad38d8c4dbdb37b23d776"
+                "reference": "270380e87904f5a1a1fba3059989d4ca157e16a9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-validator/zipball/e370c4695db1c81e6dfad38d8c4dbdb37b23d776",
-                "reference": "e370c4695db1c81e6dfad38d8c4dbdb37b23d776",
+                "url": "https://api.github.com/repos/laminas/laminas-validator/zipball/270380e87904f5a1a1fba3059989d4ca157e16a9",
+                "reference": "270380e87904f5a1a1fba3059989d4ca157e16a9",
                 "shasum": ""
             },
             "require": {
                 "container-interop/container-interop": "^1.1",
-                "laminas/laminas-stdlib": "^3.3",
-                "laminas/laminas-zendframework-bridge": "^1.0",
-                "php": "^7.3 || ~8.0.0"
+                "laminas/laminas-stdlib": "^3.6",
+                "php": "^7.3 || ~8.0.0 || ~8.1.0"
             },
-            "replace": {
-                "zendframework/zend-validator": "^2.13.0"
+            "conflict": {
+                "zendframework/zend-validator": "*"
             },
             "require-dev": {
                 "laminas/laminas-cache": "^2.6.1",
-                "laminas/laminas-coding-standard": "~1.0.0",
-                "laminas/laminas-config": "^2.6",
+                "laminas/laminas-coding-standard": "~2.2.1",
                 "laminas/laminas-db": "^2.7",
                 "laminas/laminas-filter": "^2.6",
                 "laminas/laminas-http": "^2.14.2",
@@ -303,7 +303,7 @@
                 "laminas/laminas-session": "^2.8",
                 "laminas/laminas-uri": "^2.7",
                 "phpspec/prophecy-phpunit": "^2.0",
-                "phpunit/phpunit": "^9.3",
+                "phpunit/phpunit": "^9.5.5",
                 "psalm/plugin-phpunit": "^0.15.0",
                 "psr/http-client": "^1.0",
                 "psr/http-factory": "^1.0",
@@ -357,27 +357,27 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2021-01-24T20:45:49+00:00"
+            "time": "2021-09-08T23:16:56+00:00"
         },
         {
             "name": "laminas/laminas-zendframework-bridge",
-            "version": "1.2.0",
+            "version": "1.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-zendframework-bridge.git",
-                "reference": "6cccbddfcfc742eb02158d6137ca5687d92cee32"
+                "reference": "bf180a382393e7db5c1e8d0f2ec0c4af9c724baf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-zendframework-bridge/zipball/6cccbddfcfc742eb02158d6137ca5687d92cee32",
-                "reference": "6cccbddfcfc742eb02158d6137ca5687d92cee32",
+                "url": "https://api.github.com/repos/laminas/laminas-zendframework-bridge/zipball/bf180a382393e7db5c1e8d0f2ec0c4af9c724baf",
+                "reference": "bf180a382393e7db5c1e8d0f2ec0c4af9c724baf",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.3 || ^8.0"
+                "php": "^7.3 || ~8.0.0 || ~8.1.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5 || ^8.1 || ^9.3",
+                "phpunit/phpunit": "^9.3",
                 "psalm/plugin-phpunit": "^0.15.1",
                 "squizlabs/php_codesniffer": "^3.5",
                 "vimeo/psalm": "^4.6"
@@ -419,24 +419,24 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2021-02-25T21:54:58+00:00"
+            "time": "2021-09-03T17:53:30+00:00"
         },
         {
             "name": "psr/container",
-            "version": "1.1.1",
+            "version": "1.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/container.git",
-                "reference": "8622567409010282b7aeebe4bb841fe98b58dcaf"
+                "reference": "513e0666f7216c7459170d56df27dfcefe1689ea"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/container/zipball/8622567409010282b7aeebe4bb841fe98b58dcaf",
-                "reference": "8622567409010282b7aeebe4bb841fe98b58dcaf",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/513e0666f7216c7459170d56df27dfcefe1689ea",
+                "reference": "513e0666f7216c7459170d56df27dfcefe1689ea",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.0"
+                "php": ">=7.4.0"
             },
             "type": "library",
             "autoload": {
@@ -465,35 +465,35 @@
             ],
             "support": {
                 "issues": "https://github.com/php-fig/container/issues",
-                "source": "https://github.com/php-fig/container/tree/1.1.1"
+                "source": "https://github.com/php-fig/container/tree/1.1.2"
             },
-            "time": "2021-03-05T17:36:06+00:00"
+            "time": "2021-11-05T16:50:12+00:00"
         }
     ],
     "packages-dev": [
         {
             "name": "amphp/amp",
-            "version": "v2.5.2",
+            "version": "v2.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/amphp/amp.git",
-                "reference": "efca2b32a7580087adb8aabbff6be1dc1bb924a9"
+                "reference": "c5fc66a78ee38d7ac9195a37bacaf940eb3f65ae"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/amphp/amp/zipball/efca2b32a7580087adb8aabbff6be1dc1bb924a9",
-                "reference": "efca2b32a7580087adb8aabbff6be1dc1bb924a9",
+                "url": "https://api.github.com/repos/amphp/amp/zipball/c5fc66a78ee38d7ac9195a37bacaf940eb3f65ae",
+                "reference": "c5fc66a78ee38d7ac9195a37bacaf940eb3f65ae",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7"
+                "php": ">=7.1"
             },
             "require-dev": {
                 "amphp/php-cs-fixer-config": "dev-master",
                 "amphp/phpunit-util": "^1",
                 "ext-json": "*",
                 "jetbrains/phpstorm-stubs": "^2019.3",
-                "phpunit/phpunit": "^6.0.9 | ^7",
+                "phpunit/phpunit": "^7 | ^8 | ^9",
                 "psalm/phar": "^3.11@dev",
                 "react/promise": "^2"
             },
@@ -550,7 +550,7 @@
             "support": {
                 "irc": "irc://irc.freenode.org/amphp",
                 "issues": "https://github.com/amphp/amp/issues",
-                "source": "https://github.com/amphp/amp/tree/v2.5.2"
+                "source": "https://github.com/amphp/amp/tree/v2.6.1"
             },
             "funding": [
                 {
@@ -558,20 +558,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-01-10T17:06:37+00:00"
+            "time": "2021-09-23T18:43:08+00:00"
         },
         {
             "name": "amphp/byte-stream",
-            "version": "v1.8.0",
+            "version": "v1.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/amphp/byte-stream.git",
-                "reference": "f0c20cf598a958ba2aa8c6e5a71c697d652c7088"
+                "reference": "acbd8002b3536485c997c4e019206b3f10ca15bd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/amphp/byte-stream/zipball/f0c20cf598a958ba2aa8c6e5a71c697d652c7088",
-                "reference": "f0c20cf598a958ba2aa8c6e5a71c697d652c7088",
+                "url": "https://api.github.com/repos/amphp/byte-stream/zipball/acbd8002b3536485c997c4e019206b3f10ca15bd",
+                "reference": "acbd8002b3536485c997c4e019206b3f10ca15bd",
                 "shasum": ""
             },
             "require": {
@@ -627,22 +627,28 @@
             "support": {
                 "irc": "irc://irc.freenode.org/amphp",
                 "issues": "https://github.com/amphp/byte-stream/issues",
-                "source": "https://github.com/amphp/byte-stream/tree/master"
+                "source": "https://github.com/amphp/byte-stream/tree/v1.8.1"
             },
-            "time": "2020-06-29T18:35:05+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-03-30T17:13:30+00:00"
         },
         {
             "name": "composer/package-versions-deprecated",
-            "version": "1.11.99.1",
+            "version": "1.11.99.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/package-versions-deprecated.git",
-                "reference": "7413f0b55a051e89485c5cb9f765fe24bb02a7b6"
+                "reference": "b174585d1fe49ceed21928a945138948cb394600"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/package-versions-deprecated/zipball/7413f0b55a051e89485c5cb9f765fe24bb02a7b6",
-                "reference": "7413f0b55a051e89485c5cb9f765fe24bb02a7b6",
+                "url": "https://api.github.com/repos/composer/package-versions-deprecated/zipball/b174585d1fe49ceed21928a945138948cb394600",
+                "reference": "b174585d1fe49ceed21928a945138948cb394600",
                 "shasum": ""
             },
             "require": {
@@ -686,7 +692,7 @@
             "description": "Composer plugin that provides efficient querying for installed package versions (no runtime IO)",
             "support": {
                 "issues": "https://github.com/composer/package-versions-deprecated/issues",
-                "source": "https://github.com/composer/package-versions-deprecated/tree/1.11.99.1"
+                "source": "https://github.com/composer/package-versions-deprecated/tree/1.11.99.4"
             },
             "funding": [
                 {
@@ -702,20 +708,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-11-11T10:22:58+00:00"
+            "time": "2021-09-13T08:41:34+00:00"
         },
         {
             "name": "composer/semver",
-            "version": "3.2.4",
+            "version": "3.2.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/semver.git",
-                "reference": "a02fdf930a3c1c3ed3a49b5f63859c0c20e10464"
+                "reference": "83e511e247de329283478496f7a1e114c9517506"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/semver/zipball/a02fdf930a3c1c3ed3a49b5f63859c0c20e10464",
-                "reference": "a02fdf930a3c1c3ed3a49b5f63859c0c20e10464",
+                "url": "https://api.github.com/repos/composer/semver/zipball/83e511e247de329283478496f7a1e114c9517506",
+                "reference": "83e511e247de329283478496f7a1e114c9517506",
                 "shasum": ""
             },
             "require": {
@@ -767,7 +773,7 @@
             "support": {
                 "irc": "irc://irc.freenode.org/composer",
                 "issues": "https://github.com/composer/semver/issues",
-                "source": "https://github.com/composer/semver/tree/3.2.4"
+                "source": "https://github.com/composer/semver/tree/3.2.6"
             },
             "funding": [
                 {
@@ -783,28 +789,29 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-11-13T08:59:24+00:00"
+            "time": "2021-10-25T11:34:17+00:00"
         },
         {
             "name": "composer/xdebug-handler",
-            "version": "1.4.5",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/xdebug-handler.git",
-                "reference": "f28d44c286812c714741478d968104c5e604a1d4"
+                "reference": "84674dd3a7575ba617f5a76d7e9e29a7d3891339"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/f28d44c286812c714741478d968104c5e604a1d4",
-                "reference": "f28d44c286812c714741478d968104c5e604a1d4",
+                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/84674dd3a7575ba617f5a76d7e9e29a7d3891339",
+                "reference": "84674dd3a7575ba617f5a76d7e9e29a7d3891339",
                 "shasum": ""
             },
             "require": {
                 "php": "^5.3.2 || ^7.0 || ^8.0",
-                "psr/log": "^1.0"
+                "psr/log": "^1 || ^2 || ^3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.8.35 || ^5.7 || 6.5 - 8"
+                "phpstan/phpstan": "^0.12.55",
+                "symfony/phpunit-bridge": "^4.2 || ^5"
             },
             "type": "library",
             "autoload": {
@@ -830,7 +837,7 @@
             "support": {
                 "irc": "irc://irc.freenode.org/composer",
                 "issues": "https://github.com/composer/xdebug-handler/issues",
-                "source": "https://github.com/composer/xdebug-handler/tree/1.4.5"
+                "source": "https://github.com/composer/xdebug-handler/tree/2.0.2"
             },
             "funding": [
                 {
@@ -846,7 +853,77 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-11-13T08:04:11+00:00"
+            "time": "2021-07-31T17:03:58+00:00"
+        },
+        {
+            "name": "dealerdirect/phpcodesniffer-composer-installer",
+            "version": "v0.7.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer.git",
+                "reference": "fe390591e0241955f22eb9ba327d137e501c771c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/fe390591e0241955f22eb9ba327d137e501c771c",
+                "reference": "fe390591e0241955f22eb9ba327d137e501c771c",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0 || ^2.0",
+                "php": ">=5.3",
+                "squizlabs/php_codesniffer": "^2.0 || ^3.0 || ^4.0"
+            },
+            "require-dev": {
+                "composer/composer": "*",
+                "phpcompatibility/php-compatibility": "^9.0",
+                "sensiolabs/security-checker": "^4.1.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Franck Nijhof",
+                    "email": "franck.nijhof@dealerdirect.com",
+                    "homepage": "http://www.frenck.nl",
+                    "role": "Developer / IT Manager"
+                }
+            ],
+            "description": "PHP_CodeSniffer Standards Composer Installer Plugin",
+            "homepage": "http://www.dealerdirect.com",
+            "keywords": [
+                "PHPCodeSniffer",
+                "PHP_CodeSniffer",
+                "code quality",
+                "codesniffer",
+                "composer",
+                "installer",
+                "phpcs",
+                "plugin",
+                "qa",
+                "quality",
+                "standard",
+                "standards",
+                "style guide",
+                "stylecheck",
+                "tests"
+            ],
+            "support": {
+                "issues": "https://github.com/dealerdirect/phpcodesniffer-composer-installer/issues",
+                "source": "https://github.com/dealerdirect/phpcodesniffer-composer-installer"
+            },
+            "time": "2020-12-07T18:04:37+00:00"
         },
         {
             "name": "dnoegel/php-xdg-base-dir",
@@ -956,20 +1033,20 @@
         },
         {
             "name": "felixfbecker/advanced-json-rpc",
-            "version": "v3.2.0",
+            "version": "v3.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/felixfbecker/php-advanced-json-rpc.git",
-                "reference": "06f0b06043c7438959dbdeed8bb3f699a19be22e"
+                "reference": "b5f37dbff9a8ad360ca341f3240dc1c168b45447"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/felixfbecker/php-advanced-json-rpc/zipball/06f0b06043c7438959dbdeed8bb3f699a19be22e",
-                "reference": "06f0b06043c7438959dbdeed8bb3f699a19be22e",
+                "url": "https://api.github.com/repos/felixfbecker/php-advanced-json-rpc/zipball/b5f37dbff9a8ad360ca341f3240dc1c168b45447",
+                "reference": "b5f37dbff9a8ad360ca341f3240dc1c168b45447",
                 "shasum": ""
             },
             "require": {
-                "netresearch/jsonmapper": "^1.0 || ^2.0",
+                "netresearch/jsonmapper": "^1.0 || ^2.0 || ^3.0 || ^4.0",
                 "php": "^7.1 || ^8.0",
                 "phpdocumentor/reflection-docblock": "^4.3.4 || ^5.0.0"
             },
@@ -995,9 +1072,9 @@
             "description": "A more advanced JSONRPC implementation",
             "support": {
                 "issues": "https://github.com/felixfbecker/php-advanced-json-rpc/issues",
-                "source": "https://github.com/felixfbecker/php-advanced-json-rpc/tree/v3.2.0"
+                "source": "https://github.com/felixfbecker/php-advanced-json-rpc/tree/v3.2.1"
             },
-            "time": "2021-01-10T17:48:47+00:00"
+            "time": "2021-06-11T22:34:44+00:00"
         },
         {
             "name": "felixfbecker/language-server-protocol",
@@ -1057,31 +1134,36 @@
         },
         {
             "name": "laminas/laminas-coding-standard",
-            "version": "1.0.0",
+            "version": "2.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-coding-standard.git",
-                "reference": "08880ce2fbfe62d471cd3cb766a91da630b32539"
+                "reference": "c953ecb1d37034f4aa326046e2c24a10fe0a2845"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-coding-standard/zipball/08880ce2fbfe62d471cd3cb766a91da630b32539",
-                "reference": "08880ce2fbfe62d471cd3cb766a91da630b32539",
+                "url": "https://api.github.com/repos/laminas/laminas-coding-standard/zipball/c953ecb1d37034f4aa326046e2c24a10fe0a2845",
+                "reference": "c953ecb1d37034f4aa326046e2c24a10fe0a2845",
                 "shasum": ""
             },
             "require": {
-                "laminas/laminas-zendframework-bridge": "^1.0",
-                "squizlabs/php_codesniffer": "^2.7"
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7",
+                "php": "^7.3 || ~8.0.0",
+                "slevomat/coding-standard": "^6.4.1",
+                "squizlabs/php_codesniffer": "^3.5.8",
+                "webimpress/coding-standard": "^1.1.6"
             },
-            "replace": {
-                "zendframework/zend-coding-standard": "self.version"
+            "type": "phpcodesniffer-standard",
+            "autoload": {
+                "psr-4": {
+                    "LaminasCodingStandard\\": "src/LaminasCodingStandard/"
+                }
             },
-            "type": "library",
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "BSD-3-Clause"
             ],
-            "description": "Laminas coding standard",
+            "description": "Laminas Coding Standard",
             "homepage": "https://laminas.dev",
             "keywords": [
                 "Coding Standard",
@@ -1095,41 +1177,45 @@
                 "rss": "https://github.com/laminas/laminas-coding-standard/releases.atom",
                 "source": "https://github.com/laminas/laminas-coding-standard"
             },
-            "time": "2019-12-31T16:28:26+00:00"
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2021-05-17T17:39:41+00:00"
         },
         {
             "name": "laminas/laminas-db",
-            "version": "2.12.0",
+            "version": "2.13.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-db.git",
-                "reference": "80cbba4e749f9eb7d8036172acb9ad41e8b6923f"
+                "reference": "cdabb4bfa669c2c0edb0cb4e014c15b41afd3fb1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-db/zipball/80cbba4e749f9eb7d8036172acb9ad41e8b6923f",
-                "reference": "80cbba4e749f9eb7d8036172acb9ad41e8b6923f",
+                "url": "https://api.github.com/repos/laminas/laminas-db/zipball/cdabb4bfa669c2c0edb0cb4e014c15b41afd3fb1",
+                "reference": "cdabb4bfa669c2c0edb0cb4e014c15b41afd3fb1",
                 "shasum": ""
             },
             "require": {
-                "laminas/laminas-stdlib": "^3.3",
-                "laminas/laminas-zendframework-bridge": "^1.0",
-                "php": "^7.3 || ~8.0.0"
+                "laminas/laminas-stdlib": "^3.6",
+                "php": "^7.3 || ~8.0.0 || ~8.1.0"
             },
-            "replace": {
-                "zendframework/zend-db": "^2.11.0"
+            "conflict": {
+                "zendframework/zend-db": "*"
             },
             "require-dev": {
-                "laminas/laminas-coding-standard": "~1.0.0",
-                "laminas/laminas-eventmanager": "^3.3",
-                "laminas/laminas-hydrator": "^3.2 || ^4.0",
-                "laminas/laminas-servicemanager": "^3.3",
-                "phpspec/prophecy-phpunit": "^2.0",
-                "phpunit/phpunit": "^9.3"
+                "laminas/laminas-coding-standard": "~2.2.1",
+                "laminas/laminas-eventmanager": "^3.4",
+                "laminas/laminas-hydrator": "^3.2 || ^4.3",
+                "laminas/laminas-servicemanager": "^3.7",
+                "phpunit/phpunit": "^9.5.5"
             },
             "suggest": {
                 "laminas/laminas-eventmanager": "Laminas\\EventManager component",
-                "laminas/laminas-hydrator": "(^3.2 || ^4.0) Laminas\\Hydrator component for using HydratingResultSets",
+                "laminas/laminas-hydrator": "(^3.2 || ^4.3) Laminas\\Hydrator component for using HydratingResultSets",
                 "laminas/laminas-servicemanager": "Laminas\\ServiceManager component"
             },
             "type": "library",
@@ -1168,7 +1254,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2021-02-22T22:27:56+00:00"
+            "time": "2021-09-21T18:59:44+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -1230,16 +1316,16 @@
         },
         {
             "name": "netresearch/jsonmapper",
-            "version": "v2.1.0",
+            "version": "v4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cweiske/jsonmapper.git",
-                "reference": "e0f1e33a71587aca81be5cffbb9746510e1fe04e"
+                "reference": "8bbc021a8edb2e4a7ea2f8ad4fa9ec9dce2fcb8d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cweiske/jsonmapper/zipball/e0f1e33a71587aca81be5cffbb9746510e1fe04e",
-                "reference": "e0f1e33a71587aca81be5cffbb9746510e1fe04e",
+                "url": "https://api.github.com/repos/cweiske/jsonmapper/zipball/8bbc021a8edb2e4a7ea2f8ad4fa9ec9dce2fcb8d",
+                "reference": "8bbc021a8edb2e4a7ea2f8ad4fa9ec9dce2fcb8d",
                 "shasum": ""
             },
             "require": {
@@ -1247,10 +1333,10 @@
                 "ext-pcre": "*",
                 "ext-reflection": "*",
                 "ext-spl": "*",
-                "php": ">=5.6"
+                "php": ">=7.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.8.35 || ~5.7 || ~6.4 || ~7.0",
+                "phpunit/phpunit": "~7.5 || ~8.0 || ~9.0",
                 "squizlabs/php_codesniffer": "~3.5"
             },
             "type": "library",
@@ -1275,22 +1361,22 @@
             "support": {
                 "email": "cweiske@cweiske.de",
                 "issues": "https://github.com/cweiske/jsonmapper/issues",
-                "source": "https://github.com/cweiske/jsonmapper/tree/master"
+                "source": "https://github.com/cweiske/jsonmapper/tree/v4.0.0"
             },
-            "time": "2020-04-16T18:48:43+00:00"
+            "time": "2020-12-01T19:48:11+00:00"
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.10.4",
+            "version": "v4.13.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "c6d052fc58cb876152f89f532b95a8d7907e7f0e"
+                "reference": "210577fe3cf7badcc5814d99455df46564f3c077"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/c6d052fc58cb876152f89f532b95a8d7907e7f0e",
-                "reference": "c6d052fc58cb876152f89f532b95a8d7907e7f0e",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/210577fe3cf7badcc5814d99455df46564f3c077",
+                "reference": "210577fe3cf7badcc5814d99455df46564f3c077",
                 "shasum": ""
             },
             "require": {
@@ -1331,9 +1417,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.10.4"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v4.13.2"
             },
-            "time": "2020-12-20T10:01:03+00:00"
+            "time": "2021-11-30T19:35:32+00:00"
         },
         {
             "name": "openlss/lib-array2xml",
@@ -1390,16 +1476,16 @@
         },
         {
             "name": "phar-io/manifest",
-            "version": "2.0.1",
+            "version": "2.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phar-io/manifest.git",
-                "reference": "85265efd3af7ba3ca4b2a2c34dbfc5788dd29133"
+                "reference": "97803eca37d319dfa7826cc2437fc020857acb53"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/manifest/zipball/85265efd3af7ba3ca4b2a2c34dbfc5788dd29133",
-                "reference": "85265efd3af7ba3ca4b2a2c34dbfc5788dd29133",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/97803eca37d319dfa7826cc2437fc020857acb53",
+                "reference": "97803eca37d319dfa7826cc2437fc020857acb53",
                 "shasum": ""
             },
             "require": {
@@ -1444,9 +1530,9 @@
             "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
             "support": {
                 "issues": "https://github.com/phar-io/manifest/issues",
-                "source": "https://github.com/phar-io/manifest/tree/master"
+                "source": "https://github.com/phar-io/manifest/tree/2.0.3"
             },
-            "time": "2020-06-27T14:33:11+00:00"
+            "time": "2021-07-20T11:28:43+00:00"
         },
         {
             "name": "phar-io/version",
@@ -1554,16 +1640,16 @@
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "5.2.2",
+            "version": "5.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "069a785b2141f5bcf49f3e353548dc1cce6df556"
+                "reference": "622548b623e81ca6d78b721c5e029f4ce664f170"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/069a785b2141f5bcf49f3e353548dc1cce6df556",
-                "reference": "069a785b2141f5bcf49f3e353548dc1cce6df556",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/622548b623e81ca6d78b721c5e029f4ce664f170",
+                "reference": "622548b623e81ca6d78b721c5e029f4ce664f170",
                 "shasum": ""
             },
             "require": {
@@ -1574,7 +1660,8 @@
                 "webmozart/assert": "^1.9.1"
             },
             "require-dev": {
-                "mockery/mockery": "~1.3.2"
+                "mockery/mockery": "~1.3.2",
+                "psalm/phar": "^4.8"
             },
             "type": "library",
             "extra": {
@@ -1604,22 +1691,22 @@
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
             "support": {
                 "issues": "https://github.com/phpDocumentor/ReflectionDocBlock/issues",
-                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/master"
+                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/5.3.0"
             },
-            "time": "2020-09-03T19:13:55+00:00"
+            "time": "2021-10-19T17:43:47+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
-            "version": "1.4.0",
+            "version": "1.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "6a467b8989322d92aa1c8bf2bebcc6e5c2ba55c0"
+                "reference": "a12f7e301eb7258bb68acd89d4aefa05c2906cae"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/6a467b8989322d92aa1c8bf2bebcc6e5c2ba55c0",
-                "reference": "6a467b8989322d92aa1c8bf2bebcc6e5c2ba55c0",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/a12f7e301eb7258bb68acd89d4aefa05c2906cae",
+                "reference": "a12f7e301eb7258bb68acd89d4aefa05c2906cae",
                 "shasum": ""
             },
             "require": {
@@ -1627,7 +1714,8 @@
                 "phpdocumentor/reflection-common": "^2.0"
             },
             "require-dev": {
-                "ext-tokenizer": "*"
+                "ext-tokenizer": "*",
+                "psalm/phar": "^4.8"
             },
             "type": "library",
             "extra": {
@@ -1653,39 +1741,39 @@
             "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
             "support": {
                 "issues": "https://github.com/phpDocumentor/TypeResolver/issues",
-                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.4.0"
+                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.5.1"
             },
-            "time": "2020-09-17T18:55:26+00:00"
+            "time": "2021-10-02T14:08:47+00:00"
         },
         {
             "name": "phpspec/prophecy",
-            "version": "1.12.2",
+            "version": "1.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "245710e971a030f42e08f4912863805570f23d39"
+                "reference": "d86dfc2e2a3cd366cee475e52c6bb3bbc371aa0e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/245710e971a030f42e08f4912863805570f23d39",
-                "reference": "245710e971a030f42e08f4912863805570f23d39",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/d86dfc2e2a3cd366cee475e52c6bb3bbc371aa0e",
+                "reference": "d86dfc2e2a3cd366cee475e52c6bb3bbc371aa0e",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.2",
-                "php": "^7.2 || ~8.0, <8.1",
+                "php": "^7.2 || ~8.0, <8.2",
                 "phpdocumentor/reflection-docblock": "^5.2",
                 "sebastian/comparator": "^3.0 || ^4.0",
                 "sebastian/recursion-context": "^3.0 || ^4.0"
             },
             "require-dev": {
-                "phpspec/phpspec": "^6.0",
+                "phpspec/phpspec": "^6.0 || ^7.0",
                 "phpunit/phpunit": "^8.0 || ^9.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.11.x-dev"
+                    "dev-master": "1.x-dev"
                 }
             },
             "autoload": {
@@ -1720,9 +1808,9 @@
             ],
             "support": {
                 "issues": "https://github.com/phpspec/prophecy/issues",
-                "source": "https://github.com/phpspec/prophecy/tree/1.12.2"
+                "source": "https://github.com/phpspec/prophecy/tree/1.14.0"
             },
-            "time": "2020-12-19T10:15:11+00:00"
+            "time": "2021-09-10T09:02:12+00:00"
         },
         {
             "name": "phpspec/prophecy-phpunit",
@@ -1777,24 +1865,77 @@
             "time": "2020-07-09T08:33:42+00:00"
         },
         {
-            "name": "phpunit/php-code-coverage",
-            "version": "9.2.5",
+            "name": "phpstan/phpdoc-parser",
+            "version": "0.4.9",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "f3e026641cc91909d421802dd3ac7827ebfd97e1"
+                "url": "https://github.com/phpstan/phpdoc-parser.git",
+                "reference": "98a088b17966bdf6ee25c8a4b634df313d8aa531"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/f3e026641cc91909d421802dd3ac7827ebfd97e1",
-                "reference": "f3e026641cc91909d421802dd3ac7827ebfd97e1",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/98a088b17966bdf6ee25c8a4b634df313d8aa531",
+                "reference": "98a088b17966bdf6ee25c8a4b634df313d8aa531",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "consistence/coding-standard": "^3.5",
+                "ergebnis/composer-normalize": "^2.0.2",
+                "jakub-onderka/php-parallel-lint": "^0.9.2",
+                "phing/phing": "^2.16.0",
+                "phpstan/extension-installer": "^1.0",
+                "phpstan/phpstan": "^0.12.26",
+                "phpstan/phpstan-strict-rules": "^0.12",
+                "phpunit/phpunit": "^6.3",
+                "slevomat/coding-standard": "^4.7.2",
+                "symfony/process": "^4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "0.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\PhpDocParser\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPDoc parser with support for nullable, intersection and generic types",
+            "support": {
+                "issues": "https://github.com/phpstan/phpdoc-parser/issues",
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/master"
+            },
+            "time": "2020-08-03T20:32:43+00:00"
+        },
+        {
+            "name": "phpunit/php-code-coverage",
+            "version": "9.2.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
+                "reference": "f301eb1453c9e7a1bc912ee8b0ea9db22c60223b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/f301eb1453c9e7a1bc912ee8b0ea9db22c60223b",
+                "reference": "f301eb1453c9e7a1bc912ee8b0ea9db22c60223b",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-libxml": "*",
                 "ext-xmlwriter": "*",
-                "nikic/php-parser": "^4.10.2",
+                "nikic/php-parser": "^4.13.0",
                 "php": ">=7.3",
                 "phpunit/php-file-iterator": "^3.0.3",
                 "phpunit/php-text-template": "^2.0.2",
@@ -1843,7 +1984,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.5"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.9"
             },
             "funding": [
                 {
@@ -1851,7 +1992,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-11-28T06:44:49+00:00"
+            "time": "2021-11-19T15:21:02+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -2096,16 +2237,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.5.2",
+            "version": "9.5.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "f661659747f2f87f9e72095bb207bceb0f151cb4"
+                "reference": "c814a05837f2edb0d1471d6e3f4ab3501ca3899a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/f661659747f2f87f9e72095bb207bceb0f151cb4",
-                "reference": "f661659747f2f87f9e72095bb207bceb0f151cb4",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/c814a05837f2edb0d1471d6e3f4ab3501ca3899a",
+                "reference": "c814a05837f2edb0d1471d6e3f4ab3501ca3899a",
                 "shasum": ""
             },
             "require": {
@@ -2117,11 +2258,11 @@
                 "ext-xml": "*",
                 "ext-xmlwriter": "*",
                 "myclabs/deep-copy": "^1.10.1",
-                "phar-io/manifest": "^2.0.1",
+                "phar-io/manifest": "^2.0.3",
                 "phar-io/version": "^3.0.2",
                 "php": ">=7.3",
                 "phpspec/prophecy": "^1.12.1",
-                "phpunit/php-code-coverage": "^9.2.3",
+                "phpunit/php-code-coverage": "^9.2.7",
                 "phpunit/php-file-iterator": "^3.0.5",
                 "phpunit/php-invoker": "^3.1.1",
                 "phpunit/php-text-template": "^2.0.3",
@@ -2135,7 +2276,7 @@
                 "sebastian/global-state": "^5.0.1",
                 "sebastian/object-enumerator": "^4.0.3",
                 "sebastian/resource-operations": "^3.0.3",
-                "sebastian/type": "^2.3",
+                "sebastian/type": "^2.3.4",
                 "sebastian/version": "^3.0.2"
             },
             "require-dev": {
@@ -2183,7 +2324,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.2"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.10"
             },
             "funding": [
                 {
@@ -2195,20 +2336,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-02-02T14:45:58+00:00"
+            "time": "2021-09-25T07:38:51+00:00"
         },
         {
             "name": "psalm/plugin-phpunit",
-            "version": "0.15.1",
+            "version": "0.15.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/psalm/psalm-plugin-phpunit.git",
-                "reference": "30ca25ce069bf4943c36e59b7df6954f6af05e64"
+                "reference": "31d15bbc0169a3c454e495e03fd8a6ccb663661b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/psalm/psalm-plugin-phpunit/zipball/30ca25ce069bf4943c36e59b7df6954f6af05e64",
-                "reference": "30ca25ce069bf4943c36e59b7df6954f6af05e64",
+                "url": "https://api.github.com/repos/psalm/psalm-plugin-phpunit/zipball/31d15bbc0169a3c454e495e03fd8a6ccb663661b",
+                "reference": "31d15bbc0169a3c454e495e03fd8a6ccb663661b",
                 "shasum": ""
             },
             "require": {
@@ -2253,9 +2394,9 @@
             "description": "Psalm plugin for PHPUnit",
             "support": {
                 "issues": "https://github.com/psalm/psalm-plugin-phpunit/issues",
-                "source": "https://github.com/psalm/psalm-plugin-phpunit/tree/0.15.1"
+                "source": "https://github.com/psalm/psalm-plugin-phpunit/tree/0.15.2"
             },
-            "time": "2021-01-23T00:19:07+00:00"
+            "time": "2021-05-29T19:11:38+00:00"
         },
         {
             "name": "psr/http-message",
@@ -2312,16 +2453,16 @@
         },
         {
             "name": "psr/log",
-            "version": "1.1.3",
+            "version": "1.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/log.git",
-                "reference": "0f73288fd15629204f9d42b7055f72dacbe811fc"
+                "reference": "d49695b909c3b7628b6289db5479a1c204601f11"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/0f73288fd15629204f9d42b7055f72dacbe811fc",
-                "reference": "0f73288fd15629204f9d42b7055f72dacbe811fc",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/d49695b909c3b7628b6289db5479a1c204601f11",
+                "reference": "d49695b909c3b7628b6289db5479a1c204601f11",
                 "shasum": ""
             },
             "require": {
@@ -2345,7 +2486,7 @@
             "authors": [
                 {
                     "name": "PHP-FIG",
-                    "homepage": "http://www.php-fig.org/"
+                    "homepage": "https://www.php-fig.org/"
                 }
             ],
             "description": "Common interface for logging libraries",
@@ -2356,9 +2497,9 @@
                 "psr-3"
             ],
             "support": {
-                "source": "https://github.com/php-fig/log/tree/1.1.3"
+                "source": "https://github.com/php-fig/log/tree/1.1.4"
             },
-            "time": "2020-03-23T09:12:05+00:00"
+            "time": "2021-05-03T11:20:27+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -2789,16 +2930,16 @@
         },
         {
             "name": "sebastian/exporter",
-            "version": "4.0.3",
+            "version": "4.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "d89cc98761b8cb5a1a235a6b703ae50d34080e65"
+                "reference": "65e8b7db476c5dd267e65eea9cab77584d3cfff9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/d89cc98761b8cb5a1a235a6b703ae50d34080e65",
-                "reference": "d89cc98761b8cb5a1a235a6b703ae50d34080e65",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/65e8b7db476c5dd267e65eea9cab77584d3cfff9",
+                "reference": "65e8b7db476c5dd267e65eea9cab77584d3cfff9",
                 "shasum": ""
             },
             "require": {
@@ -2847,14 +2988,14 @@
                 }
             ],
             "description": "Provides the functionality to export PHP variables for visualization",
-            "homepage": "http://www.github.com/sebastianbergmann/exporter",
+            "homepage": "https://www.github.com/sebastianbergmann/exporter",
             "keywords": [
                 "export",
                 "exporter"
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/exporter/issues",
-                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.3"
+                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.4"
             },
             "funding": [
                 {
@@ -2862,20 +3003,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T05:24:23+00:00"
+            "time": "2021-11-11T14:18:36+00:00"
         },
         {
             "name": "sebastian/global-state",
-            "version": "5.0.2",
+            "version": "5.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "a90ccbddffa067b51f574dea6eb25d5680839455"
+                "reference": "23bd5951f7ff26f12d4e3242864df3e08dec4e49"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/a90ccbddffa067b51f574dea6eb25d5680839455",
-                "reference": "a90ccbddffa067b51f574dea6eb25d5680839455",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/23bd5951f7ff26f12d4e3242864df3e08dec4e49",
+                "reference": "23bd5951f7ff26f12d4e3242864df3e08dec4e49",
                 "shasum": ""
             },
             "require": {
@@ -2918,7 +3059,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/global-state/issues",
-                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.2"
+                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.3"
             },
             "funding": [
                 {
@@ -2926,7 +3067,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T15:55:19+00:00"
+            "time": "2021-06-11T13:31:12+00:00"
         },
         {
             "name": "sebastian/lines-of-code",
@@ -3217,16 +3358,16 @@
         },
         {
             "name": "sebastian/type",
-            "version": "2.3.1",
+            "version": "2.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/type.git",
-                "reference": "81cd61ab7bbf2de744aba0ea61fae32f721df3d2"
+                "reference": "b8cd8a1c753c90bc1a0f5372170e3e489136f914"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/81cd61ab7bbf2de744aba0ea61fae32f721df3d2",
-                "reference": "81cd61ab7bbf2de744aba0ea61fae32f721df3d2",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/b8cd8a1c753c90bc1a0f5372170e3e489136f914",
+                "reference": "b8cd8a1c753c90bc1a0f5372170e3e489136f914",
                 "shasum": ""
             },
             "require": {
@@ -3261,7 +3402,7 @@
             "homepage": "https://github.com/sebastianbergmann/type",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/type/issues",
-                "source": "https://github.com/sebastianbergmann/type/tree/2.3.1"
+                "source": "https://github.com/sebastianbergmann/type/tree/2.3.4"
             },
             "funding": [
                 {
@@ -3269,7 +3410,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:18:59+00:00"
+            "time": "2021-06-15T12:49:02+00:00"
         },
         {
             "name": "sebastian/version",
@@ -3325,64 +3466,98 @@
             "time": "2020-09-28T06:39:44+00:00"
         },
         {
-            "name": "squizlabs/php_codesniffer",
-            "version": "2.9.2",
+            "name": "slevomat/coding-standard",
+            "version": "6.4.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "2acf168de78487db620ab4bc524135a13cfe6745"
+                "url": "https://github.com/slevomat/coding-standard.git",
+                "reference": "696dcca217d0c9da2c40d02731526c1e25b65346"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/2acf168de78487db620ab4bc524135a13cfe6745",
-                "reference": "2acf168de78487db620ab4bc524135a13cfe6745",
+                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/696dcca217d0c9da2c40d02731526c1e25b65346",
+                "reference": "696dcca217d0c9da2c40d02731526c1e25b65346",
+                "shasum": ""
+            },
+            "require": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7",
+                "php": "^7.1 || ^8.0",
+                "phpstan/phpdoc-parser": "0.4.5 - 0.4.9",
+                "squizlabs/php_codesniffer": "^3.5.6"
+            },
+            "require-dev": {
+                "phing/phing": "2.16.3",
+                "php-parallel-lint/php-parallel-lint": "1.2.0",
+                "phpstan/phpstan": "0.12.48",
+                "phpstan/phpstan-deprecation-rules": "0.12.5",
+                "phpstan/phpstan-phpunit": "0.12.16",
+                "phpstan/phpstan-strict-rules": "0.12.5",
+                "phpunit/phpunit": "7.5.20|8.5.5|9.4.0"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "6.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "SlevomatCodingStandard\\": "SlevomatCodingStandard"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Slevomat Coding Standard for PHP_CodeSniffer complements Consistence Coding Standard by providing sniffs with additional checks.",
+            "support": {
+                "issues": "https://github.com/slevomat/coding-standard/issues",
+                "source": "https://github.com/slevomat/coding-standard/tree/6.4.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/kukulich",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/slevomat/coding-standard",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-10-05T12:39:37+00:00"
+        },
+        {
+            "name": "squizlabs/php_codesniffer",
+            "version": "3.6.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
+                "reference": "f268ca40d54617c6e06757f83f699775c9b3ff2e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/f268ca40d54617c6e06757f83f699775c9b3ff2e",
+                "reference": "f268ca40d54617c6e06757f83f699775c9b3ff2e",
                 "shasum": ""
             },
             "require": {
                 "ext-simplexml": "*",
                 "ext-tokenizer": "*",
                 "ext-xmlwriter": "*",
-                "php": ">=5.1.2"
+                "php": ">=5.4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.0"
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
             },
             "bin": [
-                "scripts/phpcs",
-                "scripts/phpcbf"
+                "bin/phpcs",
+                "bin/phpcbf"
             ],
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.x-dev"
+                    "dev-master": "3.x-dev"
                 }
-            },
-            "autoload": {
-                "classmap": [
-                    "CodeSniffer.php",
-                    "CodeSniffer/CLI.php",
-                    "CodeSniffer/Exception.php",
-                    "CodeSniffer/File.php",
-                    "CodeSniffer/Fixer.php",
-                    "CodeSniffer/Report.php",
-                    "CodeSniffer/Reporting.php",
-                    "CodeSniffer/Sniff.php",
-                    "CodeSniffer/Tokens.php",
-                    "CodeSniffer/Reports/",
-                    "CodeSniffer/Tokenizers/",
-                    "CodeSniffer/DocGenerators/",
-                    "CodeSniffer/Standards/AbstractPatternSniff.php",
-                    "CodeSniffer/Standards/AbstractScopeSniff.php",
-                    "CodeSniffer/Standards/AbstractVariableSniff.php",
-                    "CodeSniffer/Standards/IncorrectPatternException.php",
-                    "CodeSniffer/Standards/Generic/Sniffs/",
-                    "CodeSniffer/Standards/MySource/Sniffs/",
-                    "CodeSniffer/Standards/PEAR/Sniffs/",
-                    "CodeSniffer/Standards/PSR1/Sniffs/",
-                    "CodeSniffer/Standards/PSR2/Sniffs/",
-                    "CodeSniffer/Standards/Squiz/Sniffs/",
-                    "CodeSniffer/Standards/Zend/Sniffs/"
-                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -3395,7 +3570,7 @@
                 }
             ],
             "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
-            "homepage": "http://www.squizlabs.com/php-codesniffer",
+            "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
             "keywords": [
                 "phpcs",
                 "standards"
@@ -3405,31 +3580,33 @@
                 "source": "https://github.com/squizlabs/PHP_CodeSniffer",
                 "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
             },
-            "time": "2018-11-07T22:31:41+00:00"
+            "time": "2021-10-11T04:00:11+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v5.2.5",
+            "version": "v5.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "938ebbadae1b0a9c9d1ec313f87f9708609f1b79"
+                "reference": "ec3661faca1d110d6c307e124b44f99ac54179e3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/938ebbadae1b0a9c9d1ec313f87f9708609f1b79",
-                "reference": "938ebbadae1b0a9c9d1ec313f87f9708609f1b79",
+                "url": "https://api.github.com/repos/symfony/console/zipball/ec3661faca1d110d6c307e124b44f99ac54179e3",
+                "reference": "ec3661faca1d110d6c307e124b44f99ac54179e3",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2.5",
+                "symfony/deprecation-contracts": "^2.1|^3",
                 "symfony/polyfill-mbstring": "~1.0",
                 "symfony/polyfill-php73": "^1.8",
-                "symfony/polyfill-php80": "^1.15",
-                "symfony/service-contracts": "^1.1|^2",
-                "symfony/string": "^5.1"
+                "symfony/polyfill-php80": "^1.16",
+                "symfony/service-contracts": "^1.1|^2|^3",
+                "symfony/string": "^5.1|^6.0"
             },
             "conflict": {
+                "psr/log": ">=3",
                 "symfony/dependency-injection": "<4.4",
                 "symfony/dotenv": "<5.1",
                 "symfony/event-dispatcher": "<4.4",
@@ -3437,16 +3614,16 @@
                 "symfony/process": "<4.4"
             },
             "provide": {
-                "psr/log-implementation": "1.0"
+                "psr/log-implementation": "1.0|2.0"
             },
             "require-dev": {
-                "psr/log": "~1.0",
-                "symfony/config": "^4.4|^5.0",
-                "symfony/dependency-injection": "^4.4|^5.0",
-                "symfony/event-dispatcher": "^4.4|^5.0",
-                "symfony/lock": "^4.4|^5.0",
-                "symfony/process": "^4.4|^5.0",
-                "symfony/var-dumper": "^4.4|^5.0"
+                "psr/log": "^1|^2",
+                "symfony/config": "^4.4|^5.0|^6.0",
+                "symfony/dependency-injection": "^4.4|^5.0|^6.0",
+                "symfony/event-dispatcher": "^4.4|^5.0|^6.0",
+                "symfony/lock": "^4.4|^5.0|^6.0",
+                "symfony/process": "^4.4|^5.0|^6.0",
+                "symfony/var-dumper": "^4.4|^5.0|^6.0"
             },
             "suggest": {
                 "psr/log": "For using the console logger",
@@ -3486,7 +3663,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v5.2.5"
+                "source": "https://github.com/symfony/console/tree/v5.4.0"
             },
             "funding": [
                 {
@@ -3502,20 +3679,87 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-03-06T13:42:15+00:00"
+            "time": "2021-11-29T15:30:56+00:00"
         },
         {
-            "name": "symfony/polyfill-ctype",
-            "version": "v1.22.1",
+            "name": "symfony/deprecation-contracts",
+            "version": "v2.5.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "c6c942b1ac76c82448322025e084cadc56048b4e"
+                "url": "https://github.com/symfony/deprecation-contracts.git",
+                "reference": "6f981ee24cf69ee7ce9736146d1c57c2780598a8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/c6c942b1ac76c82448322025e084cadc56048b4e",
-                "reference": "c6c942b1ac76c82448322025e084cadc56048b4e",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/6f981ee24cf69ee7ce9736146d1c57c2780598a8",
+                "reference": "6f981ee24cf69ee7ce9736146d1c57c2780598a8",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "2.5-dev"
+                },
+                "thanks": {
+                    "name": "symfony/contracts",
+                    "url": "https://github.com/symfony/contracts"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "function.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "A generic function and convention to trigger deprecation notices",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v2.5.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-07-12T14:48:14+00:00"
+        },
+        {
+            "name": "symfony/polyfill-ctype",
+            "version": "v1.23.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-ctype.git",
+                "reference": "46cd95797e9df938fdd2b03693b5fca5e64b01ce"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/46cd95797e9df938fdd2b03693b5fca5e64b01ce",
+                "reference": "46cd95797e9df938fdd2b03693b5fca5e64b01ce",
                 "shasum": ""
             },
             "require": {
@@ -3527,7 +3771,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.22-dev"
+                    "dev-main": "1.23-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -3565,7 +3809,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.22.1"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.23.0"
             },
             "funding": [
                 {
@@ -3581,20 +3825,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-07T16:49:33+00:00"
+            "time": "2021-02-19T12:13:01+00:00"
         },
         {
             "name": "symfony/polyfill-intl-grapheme",
-            "version": "v1.22.1",
+            "version": "v1.23.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
-                "reference": "5601e09b69f26c1828b13b6bb87cb07cddba3170"
+                "reference": "16880ba9c5ebe3642d1995ab866db29270b36535"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/5601e09b69f26c1828b13b6bb87cb07cddba3170",
-                "reference": "5601e09b69f26c1828b13b6bb87cb07cddba3170",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/16880ba9c5ebe3642d1995ab866db29270b36535",
+                "reference": "16880ba9c5ebe3642d1995ab866db29270b36535",
                 "shasum": ""
             },
             "require": {
@@ -3606,7 +3850,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.22-dev"
+                    "dev-main": "1.23-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -3646,7 +3890,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.22.1"
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.23.1"
             },
             "funding": [
                 {
@@ -3662,20 +3906,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-22T09:19:47+00:00"
+            "time": "2021-05-27T12:26:48+00:00"
         },
         {
             "name": "symfony/polyfill-intl-normalizer",
-            "version": "v1.22.1",
+            "version": "v1.23.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
-                "reference": "43a0283138253ed1d48d352ab6d0bdb3f809f248"
+                "reference": "8590a5f561694770bdcd3f9b5c69dde6945028e8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/43a0283138253ed1d48d352ab6d0bdb3f809f248",
-                "reference": "43a0283138253ed1d48d352ab6d0bdb3f809f248",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/8590a5f561694770bdcd3f9b5c69dde6945028e8",
+                "reference": "8590a5f561694770bdcd3f9b5c69dde6945028e8",
                 "shasum": ""
             },
             "require": {
@@ -3687,7 +3931,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.22-dev"
+                    "dev-main": "1.23-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -3730,7 +3974,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.22.1"
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.23.0"
             },
             "funding": [
                 {
@@ -3746,20 +3990,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-22T09:19:47+00:00"
+            "time": "2021-02-19T12:13:01+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.22.1",
+            "version": "v1.23.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "5232de97ee3b75b0360528dae24e73db49566ab1"
+                "reference": "9174a3d80210dca8daa7f31fec659150bbeabfc6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/5232de97ee3b75b0360528dae24e73db49566ab1",
-                "reference": "5232de97ee3b75b0360528dae24e73db49566ab1",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/9174a3d80210dca8daa7f31fec659150bbeabfc6",
+                "reference": "9174a3d80210dca8daa7f31fec659150bbeabfc6",
                 "shasum": ""
             },
             "require": {
@@ -3771,7 +4015,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.22-dev"
+                    "dev-main": "1.23-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -3810,7 +4054,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.22.1"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.23.1"
             },
             "funding": [
                 {
@@ -3826,20 +4070,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-22T09:19:47+00:00"
+            "time": "2021-05-27T12:26:48+00:00"
         },
         {
             "name": "symfony/polyfill-php73",
-            "version": "v1.22.1",
+            "version": "v1.23.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php73.git",
-                "reference": "a678b42e92f86eca04b7fa4c0f6f19d097fb69e2"
+                "reference": "fba8933c384d6476ab14fb7b8526e5287ca7e010"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/a678b42e92f86eca04b7fa4c0f6f19d097fb69e2",
-                "reference": "a678b42e92f86eca04b7fa4c0f6f19d097fb69e2",
+                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/fba8933c384d6476ab14fb7b8526e5287ca7e010",
+                "reference": "fba8933c384d6476ab14fb7b8526e5287ca7e010",
                 "shasum": ""
             },
             "require": {
@@ -3848,7 +4092,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.22-dev"
+                    "dev-main": "1.23-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -3889,7 +4133,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php73/tree/v1.22.1"
+                "source": "https://github.com/symfony/polyfill-php73/tree/v1.23.0"
             },
             "funding": [
                 {
@@ -3905,20 +4149,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-07T16:49:33+00:00"
+            "time": "2021-02-19T12:13:01+00:00"
         },
         {
             "name": "symfony/polyfill-php80",
-            "version": "v1.22.1",
+            "version": "v1.23.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "dc3063ba22c2a1fd2f45ed856374d79114998f91"
+                "reference": "1100343ed1a92e3a38f9ae122fc0eb21602547be"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/dc3063ba22c2a1fd2f45ed856374d79114998f91",
-                "reference": "dc3063ba22c2a1fd2f45ed856374d79114998f91",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/1100343ed1a92e3a38f9ae122fc0eb21602547be",
+                "reference": "1100343ed1a92e3a38f9ae122fc0eb21602547be",
                 "shasum": ""
             },
             "require": {
@@ -3927,7 +4171,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.22-dev"
+                    "dev-main": "1.23-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -3972,7 +4216,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.22.1"
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.23.1"
             },
             "funding": [
                 {
@@ -3988,25 +4232,29 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-07T16:49:33+00:00"
+            "time": "2021-07-28T13:41:28+00:00"
         },
         {
             "name": "symfony/service-contracts",
-            "version": "v2.2.0",
+            "version": "v2.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "d15da7ba4957ffb8f1747218be9e1a121fd298a1"
+                "reference": "1ab11b933cd6bc5464b08e81e2c5b07dec58b0fc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/d15da7ba4957ffb8f1747218be9e1a121fd298a1",
-                "reference": "d15da7ba4957ffb8f1747218be9e1a121fd298a1",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/1ab11b933cd6bc5464b08e81e2c5b07dec58b0fc",
+                "reference": "1ab11b933cd6bc5464b08e81e2c5b07dec58b0fc",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2.5",
-                "psr/container": "^1.0"
+                "psr/container": "^1.1",
+                "symfony/deprecation-contracts": "^2.1"
+            },
+            "conflict": {
+                "ext-psr": "<1.1|>=2"
             },
             "suggest": {
                 "symfony/service-implementation": ""
@@ -4014,7 +4262,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.2-dev"
+                    "dev-main": "2.5-dev"
                 },
                 "thanks": {
                     "name": "symfony/contracts",
@@ -4051,7 +4299,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/service-contracts/tree/master"
+                "source": "https://github.com/symfony/service-contracts/tree/v2.5.0"
             },
             "funding": [
                 {
@@ -4067,20 +4315,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-09-07T11:33:47+00:00"
+            "time": "2021-11-04T16:48:04+00:00"
         },
         {
             "name": "symfony/string",
-            "version": "v5.2.4",
+            "version": "v5.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "4e78d7d47061fa183639927ec40d607973699609"
+                "reference": "9ffaaba53c61ba75a3c7a3a779051d1e9ec4fd2d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/4e78d7d47061fa183639927ec40d607973699609",
-                "reference": "4e78d7d47061fa183639927ec40d607973699609",
+                "url": "https://api.github.com/repos/symfony/string/zipball/9ffaaba53c61ba75a3c7a3a779051d1e9ec4fd2d",
+                "reference": "9ffaaba53c61ba75a3c7a3a779051d1e9ec4fd2d",
                 "shasum": ""
             },
             "require": {
@@ -4091,11 +4339,14 @@
                 "symfony/polyfill-mbstring": "~1.0",
                 "symfony/polyfill-php80": "~1.15"
             },
+            "conflict": {
+                "symfony/translation-contracts": ">=3.0"
+            },
             "require-dev": {
-                "symfony/error-handler": "^4.4|^5.0",
-                "symfony/http-client": "^4.4|^5.0",
+                "symfony/error-handler": "^4.4|^5.0|^6.0",
+                "symfony/http-client": "^4.4|^5.0|^6.0",
                 "symfony/translation-contracts": "^1.1|^2",
-                "symfony/var-exporter": "^4.4|^5.0"
+                "symfony/var-exporter": "^4.4|^5.0|^6.0"
             },
             "type": "library",
             "autoload": {
@@ -4134,7 +4385,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v5.2.4"
+                "source": "https://github.com/symfony/string/tree/v5.4.0"
             },
             "funding": [
                 {
@@ -4150,20 +4401,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-02-16T10:20:28+00:00"
+            "time": "2021-11-24T10:02:00+00:00"
         },
         {
             "name": "theseer/tokenizer",
-            "version": "1.2.0",
+            "version": "1.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/theseer/tokenizer.git",
-                "reference": "75a63c33a8577608444246075ea0af0d052e452a"
+                "reference": "34a41e998c2183e22995f158c581e7b5e755ab9e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/75a63c33a8577608444246075ea0af0d052e452a",
-                "reference": "75a63c33a8577608444246075ea0af0d052e452a",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/34a41e998c2183e22995f158c581e7b5e755ab9e",
+                "reference": "34a41e998c2183e22995f158c581e7b5e755ab9e",
                 "shasum": ""
             },
             "require": {
@@ -4192,7 +4443,7 @@
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
             "support": {
                 "issues": "https://github.com/theseer/tokenizer/issues",
-                "source": "https://github.com/theseer/tokenizer/tree/master"
+                "source": "https://github.com/theseer/tokenizer/tree/1.2.1"
             },
             "funding": [
                 {
@@ -4200,20 +4451,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-07-12T23:59:07+00:00"
+            "time": "2021-07-28T10:34:58+00:00"
         },
         {
             "name": "vimeo/psalm",
-            "version": "4.6.3",
+            "version": "4.13.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vimeo/psalm.git",
-                "reference": "f1a840727dd756899eee2f1f9ea443e265a4763f"
+                "reference": "5cf660f63b548ccd4a56f62d916ee4d6028e01a3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vimeo/psalm/zipball/f1a840727dd756899eee2f1f9ea443e265a4763f",
-                "reference": "f1a840727dd756899eee2f1f9ea443e265a4763f",
+                "url": "https://api.github.com/repos/vimeo/psalm/zipball/5cf660f63b548ccd4a56f62d916ee4d6028e01a3",
+                "reference": "5cf660f63b548ccd4a56f62d916ee4d6028e01a3",
                 "shasum": ""
             },
             "require": {
@@ -4221,8 +4472,9 @@
                 "amphp/byte-stream": "^1.5",
                 "composer/package-versions-deprecated": "^1.8.0",
                 "composer/semver": "^1.4 || ^2.0 || ^3.0",
-                "composer/xdebug-handler": "^1.1",
+                "composer/xdebug-handler": "^1.1 || ^2.0",
                 "dnoegel/php-xdg-base-dir": "^0.1.1",
+                "ext-ctype": "*",
                 "ext-dom": "*",
                 "ext-json": "*",
                 "ext-libxml": "*",
@@ -4232,11 +4484,11 @@
                 "felixfbecker/advanced-json-rpc": "^3.0.3",
                 "felixfbecker/language-server-protocol": "^1.5",
                 "netresearch/jsonmapper": "^1.0 || ^2.0 || ^3.0 || ^4.0",
-                "nikic/php-parser": "^4.10.1",
+                "nikic/php-parser": "^4.13",
                 "openlss/lib-array2xml": "^1.0",
                 "php": "^7.1|^8",
                 "sebastian/diff": "^3.0 || ^4.0",
-                "symfony/console": "^3.4.17 || ^4.1.6 || ^5.0",
+                "symfony/console": "^3.4.17 || ^4.1.6 || ^5.0 || ^6.0",
                 "webmozart/path-util": "^2.3"
             },
             "provide": {
@@ -4251,14 +4503,15 @@
                 "phpmyadmin/sql-parser": "5.1.0||dev-master",
                 "phpspec/prophecy": ">=1.9.0",
                 "phpunit/phpunit": "^9.0",
-                "psalm/plugin-phpunit": "^0.13",
-                "slevomat/coding-standard": "^6.3.11",
+                "psalm/plugin-phpunit": "^0.16",
+                "slevomat/coding-standard": "^7.0",
                 "squizlabs/php_codesniffer": "^3.5",
-                "symfony/process": "^4.3",
+                "symfony/process": "^4.3 || ^5.0 || ^6.0",
                 "weirdan/prophecy-shim": "^1.0 || ^2.0"
             },
             "suggest": {
-                "ext-igbinary": "^2.0.5"
+                "ext-curl": "In order to send data to shepherd",
+                "ext-igbinary": "^2.0.5 is required, used to serialize caching data"
             },
             "bin": [
                 "psalm",
@@ -4302,9 +4555,64 @@
             ],
             "support": {
                 "issues": "https://github.com/vimeo/psalm/issues",
-                "source": "https://github.com/vimeo/psalm/tree/4.6.3"
+                "source": "https://github.com/vimeo/psalm/tree/4.13.1"
             },
-            "time": "2021-03-14T00:28:24+00:00"
+            "time": "2021-11-23T23:52:49+00:00"
+        },
+        {
+            "name": "webimpress/coding-standard",
+            "version": "1.2.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webimpress/coding-standard.git",
+                "reference": "7a71421c7fc85827488f10c4c510fe80f94d1a74"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webimpress/coding-standard/zipball/7a71421c7fc85827488f10c4c510fe80f94d1a74",
+                "reference": "7a71421c7fc85827488f10c4c510fe80f94d1a74",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.3 || ^8.0",
+                "squizlabs/php_codesniffer": "^3.6.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.5.10"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "dev-master": "1.2.x-dev",
+                "dev-develop": "1.3.x-dev"
+            },
+            "autoload": {
+                "psr-4": {
+                    "WebimpressCodingStandard\\": "src/WebimpressCodingStandard/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "description": "Webimpress Coding Standard",
+            "keywords": [
+                "Coding Standard",
+                "PSR-2",
+                "phpcs",
+                "psr-12",
+                "webimpress"
+            ],
+            "support": {
+                "issues": "https://github.com/webimpress/coding-standard/issues",
+                "source": "https://github.com/webimpress/coding-standard/tree/1.2.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/michalbundyra",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-10-28T21:18:17+00:00"
         },
         {
             "name": "webmozart/assert",
@@ -4412,6 +4720,7 @@
                 "issues": "https://github.com/webmozart/path-util/issues",
                 "source": "https://github.com/webmozart/path-util/tree/2.3.0"
             },
+            "abandoned": "symfony/filesystem",
             "time": "2015-12-17T08:42:14+00:00"
         }
     ],
@@ -4424,5 +4733,5 @@
         "php": "^7.3 || ~8.0.0"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0"?>
-<ruleset name="Laminas coding standard">
-    <rule ref="./vendor/laminas/laminas-coding-standard/ruleset.xml"/>
-
-    <!-- Paths to check -->
-    <file>src</file>
-    <file>test</file>
-</ruleset>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<ruleset
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="./vendor/squizlabs/php_codesniffer/phpcs.xsd">
+
+    <arg name="basepath" value="."/>
+    <arg name="cache" value=".phpcs-cache"/>
+    <arg name="colors"/>
+    <arg name="extensions" value="php"/>
+    <arg name="parallel" value="80"/>
+
+    <!-- Show progress -->
+    <arg value="p"/>
+
+    <!-- Paths to check -->
+    <file>src</file>
+    <file>test</file>
+
+    <!-- Include all rules from Laminas Coding Standard -->
+    <rule ref="LaminasCodingStandard"/>
+</ruleset>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="4.6.1@e93e532e4eaad6d68c4d7b606853800eaceccc72">
+<files psalm-version="4.13.1@5cf660f63b548ccd4a56f62d916ee4d6028e01a3">
   <file src="src/ArrayInput.php">
     <DeprecatedInterface occurrences="1">
       <code>ArrayInput</code>
@@ -34,24 +34,16 @@
     <NonInvariantDocblockPropertyType occurrences="1">
       <code>$value</code>
     </NonInvariantDocblockPropertyType>
-    <PropertyNotSetInConstructor occurrences="2">
-      <code>ArrayInput</code>
-      <code>ArrayInput</code>
-    </PropertyNotSetInConstructor>
   </file>
   <file src="src/BaseInputFilter.php">
-    <DocblockTypeContradiction occurrences="7">
-      <code>! $input instanceof InputInterface &amp;&amp; ! $input instanceof InputFilterInterface</code>
-      <code>$input instanceof InputInterface</code>
+    <DocblockTypeContradiction occurrences="6">
       <code>$input instanceof InputInterface &amp;&amp; (empty($name) || is_int($name))</code>
       <code>[]</code>
       <code>[]</code>
+      <code>gettype($input)</code>
       <code>is_array($data)</code>
       <code>is_int($name)</code>
     </DocblockTypeContradiction>
-    <InvalidArgument occurrences="1">
-      <code>$value</code>
-    </InvalidArgument>
     <InvalidReturnStatement occurrences="2">
       <code>is_array($this-&gt;invalidInputs) ? $this-&gt;invalidInputs : []</code>
       <code>is_array($this-&gt;validInputs) ? $this-&gt;validInputs : []</code>
@@ -99,8 +91,7 @@
     <MoreSpecificImplementedParamType occurrences="1">
       <code>$input</code>
     </MoreSpecificImplementedParamType>
-    <PossiblyInvalidArgument occurrences="2">
-      <code>$data</code>
+    <PossiblyInvalidArgument occurrences="1">
       <code>$input</code>
     </PossiblyInvalidArgument>
     <PossiblyNullArgument occurrences="1">
@@ -109,9 +100,10 @@
     <PossiblyNullArrayOffset occurrences="1">
       <code>$this-&gt;inputs</code>
     </PossiblyNullArrayOffset>
-    <RedundantConditionGivenDocblockType occurrences="2">
+    <RedundantConditionGivenDocblockType occurrences="3">
       <code>is_array($this-&gt;invalidInputs)</code>
       <code>is_array($this-&gt;validInputs)</code>
+      <code>is_object($input)</code>
     </RedundantConditionGivenDocblockType>
     <TooManyArguments occurrences="2">
       <code>isValid</code>
@@ -119,11 +111,10 @@
     </TooManyArguments>
   </file>
   <file src="src/CollectionInputFilter.php">
-    <DocblockTypeContradiction occurrences="5">
+    <DocblockTypeContradiction occurrences="4">
       <code>$this-&gt;notEmptyValidator === null</code>
       <code>gettype($inputFilter)</code>
       <code>is_object($data)</code>
-      <code>null === $this-&gt;count</code>
       <code>null === $this-&gt;inputFilter</code>
     </DocblockTypeContradiction>
     <InvalidArgument occurrences="1">
@@ -162,9 +153,6 @@
       <code>$this-&gt;data</code>
       <code>$this-&gt;data</code>
     </PossiblyNullArgument>
-    <PossiblyNullPropertyAssignmentValue occurrences="1">
-      <code>null</code>
-    </PossiblyNullPropertyAssignmentValue>
     <RedundantConditionGivenDocblockType occurrences="2">
       <code>gettype($data)</code>
       <code>is_object($inputFilter)</code>
@@ -181,10 +169,6 @@
       <code>is_array($validator)</code>
       <code>null === $this-&gt;inputFilterManager</code>
     </DocblockTypeContradiction>
-    <InvalidArgument occurrences="2">
-      <code>$value</code>
-      <code>$value</code>
-    </InvalidArgument>
     <InvalidReturnStatement occurrences="1">
       <code>$inputFilter</code>
     </InvalidReturnStatement>
@@ -217,8 +201,9 @@
       <code>$value</code>
       <code>$value['type']</code>
     </MixedArgument>
-    <MixedArgumentTypeCoercion occurrences="1">
+    <MixedArgumentTypeCoercion occurrences="2">
       <code>$key</code>
+      <code>$value</code>
     </MixedArgumentTypeCoercion>
     <MixedArrayAccess occurrences="4">
       <code>$validator['break_chain_on_failure']</code>
@@ -253,9 +238,15 @@
     <PropertyNotSetInConstructor occurrences="1">
       <code>$inputFilterManager</code>
     </PropertyNotSetInConstructor>
-    <RedundantConditionGivenDocblockType occurrences="4">
+    <RedundantConditionGivenDocblockType occurrences="10">
+      <code>$input-&gt;getFilterChain()</code>
+      <code>$input-&gt;getValidatorChain()</code>
       <code>$this-&gt;defaultFilterChain</code>
       <code>$this-&gt;defaultFilterChain</code>
+      <code>$this-&gt;defaultFilterChain</code>
+      <code>$this-&gt;defaultFilterChain</code>
+      <code>$this-&gt;defaultValidatorChain</code>
+      <code>$this-&gt;defaultValidatorChain</code>
       <code>$this-&gt;defaultValidatorChain</code>
       <code>$this-&gt;defaultValidatorChain</code>
     </RedundantConditionGivenDocblockType>
@@ -277,9 +268,9 @@
     <InvalidPropertyAssignmentValue occurrences="1">
       <code>$this-&gt;prepareRequiredValidationFailureMessage()</code>
     </InvalidPropertyAssignmentValue>
-    <MissingParamType occurrences="1">
-      <code>$rawValue</code>
-    </MissingParamType>
+    <LessSpecificReturnStatement occurrences="1">
+      <code>parent::resetValue()</code>
+    </LessSpecificReturnStatement>
     <MixedAssignment occurrences="1">
       <code>$rawValue</code>
     </MixedAssignment>
@@ -289,30 +280,23 @@
     <MoreSpecificImplementedParamType occurrences="1">
       <code>$value</code>
     </MoreSpecificImplementedParamType>
+    <MoreSpecificReturnType occurrences="1">
+      <code>self</code>
+    </MoreSpecificReturnType>
     <PossiblyNullPropertyAssignmentValue occurrences="1">
       <code>null</code>
     </PossiblyNullPropertyAssignmentValue>
-    <PropertyNotSetInConstructor occurrences="3">
+    <PropertyNotSetInConstructor occurrences="1">
       <code>$implementation</code>
-      <code>FileInput</code>
-      <code>FileInput</code>
     </PropertyNotSetInConstructor>
     <UndefinedDocblockClass occurrences="1">
       <code>array|UploadedFile</code>
     </UndefinedDocblockClass>
   </file>
-  <file src="src/FileInput/FileInputDecoratorInterface.php">
-    <MissingParamType occurrences="1">
-      <code>$rawValue</code>
-    </MissingParamType>
-  </file>
   <file src="src/FileInput/HttpServerFileInputDecorator.php">
     <DeprecatedInterface occurrences="1">
       <code>HttpServerFileInputDecorator</code>
     </DeprecatedInterface>
-    <MissingParamType occurrences="1">
-      <code>$rawValue</code>
-    </MissingParamType>
     <MixedAssignment occurrences="5">
       <code>$fileData</code>
       <code>$newValue[]</code>
@@ -320,11 +304,6 @@
       <code>$value</code>
       <code>$value</code>
     </MixedAssignment>
-    <PropertyNotSetInConstructor occurrences="3">
-      <code>HttpServerFileInputDecorator</code>
-      <code>HttpServerFileInputDecorator</code>
-      <code>HttpServerFileInputDecorator</code>
-    </PropertyNotSetInConstructor>
     <RedundantCondition occurrences="2">
       <code>is_array($rawValue)</code>
       <code>is_array($rawValue)</code>
@@ -354,11 +333,9 @@
     <MixedReturnTypeCoercion occurrences="1">
       <code>$newValue</code>
     </MixedReturnTypeCoercion>
-    <PropertyNotSetInConstructor occurrences="3">
-      <code>PsrFileInputDecorator</code>
-      <code>PsrFileInputDecorator</code>
-      <code>PsrFileInputDecorator</code>
-    </PropertyNotSetInConstructor>
+    <MoreSpecificImplementedParamType occurrences="1">
+      <code>$rawValue</code>
+    </MoreSpecificImplementedParamType>
   </file>
   <file src="src/Input.php">
     <DeprecatedInterface occurrences="1">
@@ -374,23 +351,28 @@
       <code>setAllowEmpty</code>
       <code>setContinueIfEmpty</code>
     </DeprecatedMethod>
-    <DeprecatedProperty occurrences="4">
+    <DeprecatedProperty occurrences="7">
       <code>$this-&gt;allowEmpty</code>
+      <code>$this-&gt;allowEmpty</code>
+      <code>$this-&gt;continueIfEmpty</code>
       <code>$this-&gt;continueIfEmpty</code>
       <code>$this-&gt;notEmptyValidator</code>
       <code>$this-&gt;notEmptyValidator</code>
+      <code>$this-&gt;notEmptyValidator</code>
     </DeprecatedProperty>
-    <DocblockTypeContradiction occurrences="3">
-      <code>$this-&gt;filterChain</code>
-      <code>$this-&gt;validatorChain</code>
+    <DocblockTypeContradiction occurrences="1">
       <code>is_array($this-&gt;errorMessage)</code>
     </DocblockTypeContradiction>
+    <ImplementedReturnTypeMismatch occurrences="1">
+      <code>null|string</code>
+    </ImplementedReturnTypeMismatch>
+    <InvalidNullableReturnType occurrences="2">
+      <code>FilterChain</code>
+      <code>ValidatorChain</code>
+    </InvalidNullableReturnType>
     <InvalidPropertyAssignmentValue occurrences="1">
       <code>$this-&gt;prepareRequiredValidationFailureMessage()</code>
     </InvalidPropertyAssignmentValue>
-    <MissingParamType occurrences="1">
-      <code>$name</code>
-    </MissingParamType>
     <MissingReturnType occurrences="1">
       <code>clearFallbackValue</code>
     </MissingReturnType>
@@ -400,12 +382,11 @@
       <code>$validator['instance']</code>
       <code>$validator['instance']</code>
     </MixedArrayAccess>
-    <MixedAssignment occurrences="9">
+    <MixedAssignment occurrences="8">
       <code>$message</code>
       <code>$message</code>
       <code>$notEmpty</code>
       <code>$templates</code>
-      <code>$this-&gt;name</code>
       <code>$translator</code>
       <code>$validator</code>
       <code>$validator</code>
@@ -422,15 +403,15 @@
       <code>string[]</code>
       <code>string[]</code>
     </MixedReturnTypeCoercion>
+    <NullableReturnStatement occurrences="2">
+      <code>$this-&gt;filterChain</code>
+      <code>$this-&gt;validatorChain</code>
+    </NullableReturnStatement>
     <PossiblyUndefinedMethod occurrences="3">
       <code>getOption</code>
       <code>getTranslator</code>
       <code>getTranslatorTextDomain</code>
     </PossiblyUndefinedMethod>
-    <PropertyNotSetInConstructor occurrences="2">
-      <code>$filterChain</code>
-      <code>$validatorChain</code>
-    </PropertyNotSetInConstructor>
     <RedundantCastGivenDocblockType occurrences="6">
       <code>(bool) $allowEmpty</code>
       <code>(bool) $breakOnFailure</code>
@@ -470,14 +451,9 @@
     <MissingConstructor occurrences="1">
       <code>$factory</code>
     </MissingConstructor>
-    <MissingParamType occurrences="2">
-      <code>$name</code>
-      <code>$requestedName</code>
-    </MissingParamType>
-    <MixedArgument occurrences="3">
+    <MixedArgument occurrences="2">
       <code>$config</code>
       <code>$container-&gt;get('InputFilterManager')</code>
-      <code>$requestedName</code>
     </MixedArgument>
     <MixedArrayAccess occurrences="1">
       <code>$allConfig['input_filter_specs']</code>
@@ -506,14 +482,13 @@
       <code>setPluginManager</code>
       <code>setPluginManager</code>
     </PossiblyNullReference>
-    <RedundantConditionGivenDocblockType occurrences="1">
+    <RedundantConditionGivenDocblockType occurrences="3">
+      <code>$container-&gt;getServiceLocator()</code>
+      <code>$container-&gt;getServiceLocator()</code>
       <code>$this-&gt;factory instanceof Factory</code>
     </RedundantConditionGivenDocblockType>
   </file>
   <file src="src/InputFilterPluginManager.php">
-    <DocblockTypeContradiction occurrences="1">
-      <code>gettype($plugin)</code>
-    </DocblockTypeContradiction>
     <InvalidScalarArgument occurrences="1">
       <code>$e-&gt;getCode()</code>
     </InvalidScalarArgument>
@@ -523,11 +498,13 @@
     <MissingReturnType occurrences="1">
       <code>populateFactory</code>
     </MissingReturnType>
-    <MixedArgument occurrences="3">
+    <MixedArgument occurrences="2">
       <code>$container-&gt;get('FilterManager')</code>
       <code>$container-&gt;get('ValidatorManager')</code>
-      <code>$plugin</code>
     </MixedArgument>
+    <MixedArgumentTypeCoercion occurrences="1">
+      <code>$v3config</code>
+    </MixedArgumentTypeCoercion>
     <MixedAssignment occurrences="1">
       <code>$container</code>
     </MixedAssignment>
@@ -544,9 +521,9 @@
       <code>setPluginManager</code>
       <code>setPluginManager</code>
     </PossiblyNullReference>
-    <RedundantConditionGivenDocblockType occurrences="1">
-      <code>is_object($plugin)</code>
-    </RedundantConditionGivenDocblockType>
+    <PropertyTypeCoercion occurrences="1">
+      <code>$this-&gt;initializers</code>
+    </PropertyTypeCoercion>
     <UndefinedThisPropertyFetch occurrences="1">
       <code>$this-&gt;serviceLocator</code>
     </UndefinedThisPropertyFetch>
@@ -560,23 +537,16 @@
       <code>$name</code>
       <code>$requestedName</code>
     </MissingParamType>
-    <MissingPropertyType occurrences="1">
-      <code>$creationOptions</code>
-    </MissingPropertyType>
-    <MixedArgument occurrences="2">
+    <MixedArgument occurrences="1">
       <code>$config['input_filters']</code>
-      <code>$this-&gt;creationOptions</code>
     </MixedArgument>
     <ParamNameMismatch occurrences="1">
       <code>$container</code>
     </ParamNameMismatch>
   </file>
   <file src="src/Module.php">
-    <MissingReturnType occurrences="1">
-      <code>getConfig</code>
-    </MissingReturnType>
     <UndefinedDocblockClass occurrences="1">
-      <code>\Laminas\ModuleManager\ModuleManager</code>
+      <code>ModuleManager</code>
     </UndefinedDocblockClass>
   </file>
   <file src="src/OptionalInputFilter.php">
@@ -590,13 +560,24 @@
       <code>$data ?: []</code>
     </PossiblyInvalidArgument>
   </file>
-  <file src="src/ReplaceableInputInterface.php">
-    <MissingParamType occurrences="2">
-      <code>$input</code>
-      <code>$name</code>
-    </MissingParamType>
-  </file>
   <file src="test/ArrayInputTest.php">
+    <ImplementedReturnTypeMismatch occurrences="6">
+      <code>FilterChain&amp;MockObject</code>
+      <code>NotEmptyValidator&amp;MockObject</code>
+      <code>ValidatorChain&amp;MockObject</code>
+      <code>string[]</code>
+    </ImplementedReturnTypeMismatch>
+    <InvalidReturnStatement occurrences="4">
+      <code>$dataSets</code>
+      <code>parent::createFilterChainMock($valueMap)</code>
+      <code>parent::createNonEmptyValidatorMock($isValid, $value, $context)</code>
+      <code>parent::createValidatorChainMock($valueMap, $messages)</code>
+    </InvalidReturnStatement>
+    <InvalidReturnType occurrences="4">
+      <code>FilterChain&amp;MockObject</code>
+      <code>NotEmptyValidator&amp;MockObject</code>
+      <code>ValidatorChain&amp;MockObject</code>
+    </InvalidReturnType>
     <MissingClosureParamType occurrences="3">
       <code>$set</code>
       <code>$set</code>
@@ -606,23 +587,13 @@
       <code>function ($values) {</code>
       <code>function ($values) {</code>
     </MissingClosureReturnType>
-    <MissingParamType occurrences="1">
-      <code>$raw</code>
-    </MissingParamType>
-    <MissingReturnType occurrences="8">
-      <code>emptyValueProvider</code>
-      <code>fallbackValueVsIsValidProvider</code>
-      <code>getDummyValue</code>
-      <code>mixedValueProvider</code>
+    <MissingReturnType occurrences="4">
       <code>testArrayInputMarkedRequiredWithoutAFallbackFailsValidationForEmptyArrays</code>
       <code>testArrayInputMarkedRequiredWithoutAFallbackUsesProvidedErrorMessageOnFailureDueToEmptyArray</code>
       <code>testDefaultGetValue</code>
       <code>testSetValueWithInvalidInputTypeThrowsInvalidArgumentException</code>
     </MissingReturnType>
-    <MixedArgument occurrences="7">
-      <code>$dataSets</code>
-      <code>$dataSets</code>
-      <code>$dataSets</code>
+    <MixedArgument occurrences="4">
       <code>$this-&gt;input-&gt;getValue()</code>
       <code>$values[0]</code>
       <code>$values[0]</code>
@@ -651,84 +622,53 @@
       <code>$values[0]</code>
       <code>$values[1]</code>
     </MixedArrayAssignment>
-    <MixedAssignment occurrences="7">
-      <code>$dataSets</code>
-      <code>$dataSets</code>
-      <code>$dataSets</code>
+    <MixedAssignment occurrences="4">
       <code>$value</code>
       <code>$values[0]</code>
       <code>$values[0]</code>
       <code>$values[1]</code>
     </MixedAssignment>
+    <MixedReturnTypeCoercion occurrences="4">
+      <code>$dataSets</code>
+      <code>$dataSets</code>
+    </MixedReturnTypeCoercion>
+    <RedundantCondition occurrences="2">
+      <code>isArray</code>
+      <code>isArray</code>
+    </RedundantCondition>
+    <UndefinedDocblockClass occurrences="3">
+      <code>FilterChain&amp;MockObject</code>
+      <code>NotEmptyValidator&amp;MockObject</code>
+      <code>ValidatorChain&amp;MockObject</code>
+    </UndefinedDocblockClass>
   </file>
   <file src="test/BaseInputFilterTest.php">
-    <InvalidArgument occurrences="2">
+    <InvalidArgument occurrences="5">
+      <code>$data</code>
+      <code>$input</code>
+      <code>$input</code>
       <code>new stdClass()</code>
       <code>new stdClass()</code>
     </InvalidArgument>
-    <MissingClosureParamType occurrences="14">
-      <code>$bOnFail</code>
+    <InvalidDocblock occurrences="1">
+      <code>public function addMethodArgumentsProvider(): array</code>
+    </InvalidDocblock>
+    <LessSpecificReturnStatement occurrences="1"/>
+    <MissingClosureParamType occurrences="7">
       <code>$context</code>
       <code>$context</code>
       <code>$data</code>
       <code>$data</code>
-      <code>$iName</code>
       <code>$inputTypeData</code>
       <code>$inputTypeData</code>
-      <code>$isValid</code>
-      <code>$isValid</code>
-      <code>$msg</code>
-      <code>$msg</code>
-      <code>$required</code>
       <code>$set</code>
     </MissingClosureParamType>
-    <MissingClosureReturnType occurrences="5">
+    <MissingClosureReturnType occurrences="3">
       <code>function ($data) {</code>
-      <code>function ($iName, $required, $bOnFail, $isValid, $msg = []) use ($vRaw, $vFiltered) {</code>
       <code>function ($inputTypeData) {</code>
       <code>function ($inputTypeData) {</code>
-      <code>function ($isValid, $msg = []) use ($vRaw, $vFiltered) {</code>
     </MissingClosureReturnType>
-    <MissingParamType occurrences="33">
-      <code>$customContext</code>
-      <code>$data</code>
-      <code>$data</code>
-      <code>$data</code>
-      <code>$data</code>
-      <code>$expectedContext</code>
-      <code>$expectedInput</code>
-      <code>$expectedInput</code>
-      <code>$expectedInputName</code>
-      <code>$expectedInputName</code>
-      <code>$expectedInvalidInputs</code>
-      <code>$expectedInvalidInputs</code>
-      <code>$expectedIsValid</code>
-      <code>$expectedIsValid</code>
-      <code>$expectedMessages</code>
-      <code>$expectedMessages</code>
-      <code>$expectedRawValues</code>
-      <code>$expectedRawValues</code>
-      <code>$expectedValidInputs</code>
-      <code>$expectedValidInputs</code>
-      <code>$expectedValues</code>
-      <code>$expectedValues</code>
-      <code>$getUnknown</code>
-      <code>$hasUnknown</code>
-      <code>$input</code>
-      <code>$input</code>
-      <code>$input</code>
-      <code>$inputName</code>
-      <code>$inputs</code>
-      <code>$inputs</code>
-      <code>$inputs</code>
-      <code>$name</code>
-      <code>$name</code>
-    </MissingParamType>
-    <MissingReturnType occurrences="42">
-      <code>addMethodArgumentsProvider</code>
-      <code>contextProvider</code>
-      <code>inputProvider</code>
-      <code>setDataArgumentsProvider</code>
+    <MissingReturnType occurrences="36">
       <code>testAddHasGet</code>
       <code>testAddRemove</code>
       <code>testAddWithInvalidInputTypeThrowsInvalidArgumentException</code>
@@ -763,46 +703,29 @@
       <code>testSetValidationGroupThrowExceptionIfInputFilterNotExists</code>
       <code>testSettingAndReturnDataArrayUsingSetDataForUnfilteredDataInterface</code>
       <code>testSettingAndReturningDataArrayUnfilteredDataInterface</code>
-      <code>testUnknown</code>
       <code>testValidationContext</code>
       <code>testValidationSkipsFieldsMarkedNotRequiredWhenNoDataPresent</code>
-      <code>unknownScenariosProvider</code>
     </MissingReturnType>
-    <MixedArgument occurrences="28">
-      <code>$bOnFail</code>
+    <MixedArgument occurrences="6">
       <code>$data</code>
-      <code>$data</code>
-      <code>$data</code>
-      <code>$data</code>
-      <code>$expectedInputName</code>
-      <code>$expectedInputName</code>
-      <code>$expectedInputName</code>
-      <code>$expectedInputName</code>
-      <code>$expectedInputName</code>
-      <code>$iName</code>
+      <code>$dataTypes['Traversable']($data)</code>
       <code>$input</code>
       <code>$input</code>
-      <code>$input</code>
-      <code>$input</code>
-      <code>$inputName</code>
-      <code>$inputName</code>
-      <code>$inputName</code>
-      <code>$isValid</code>
-      <code>$isValid</code>
-      <code>$msg</code>
-      <code>$msg</code>
-      <code>$name</code>
-      <code>$name</code>
-      <code>$name</code>
-      <code>$required</code>
       <code>$set[5]</code>
       <code>$set[6]</code>
     </MixedArgument>
-    <MixedArrayAccess occurrences="13">
+    <MixedArgumentTypeCoercion occurrences="6">
+      <code>$inputName</code>
+      <code>$inputName</code>
+      <code>$inputName</code>
+      <code>$msg</code>
+      <code>$msg</code>
+      <code>$name</code>
+    </MixedArgumentTypeCoercion>
+    <MixedArrayAccess occurrences="12">
       <code>$filter1-&gt;getValues()['nested']['nestedField1']</code>
       <code>$filter1-&gt;getValues()['nested']['nestedField1']</code>
       <code>$filter1-&gt;getValues()['nested']['nestedField1']</code>
-      <code>$inputTypeData[0]</code>
       <code>$inputTypeData[1]</code>
       <code>$inputTypeData[2]</code>
       <code>$set[0]</code>
@@ -823,96 +746,56 @@
       <code>$set[5][$name]</code>
       <code>$set[6][$name]</code>
     </MixedArrayOffset>
-    <MixedAssignment occurrences="20">
+    <MixedAssignment occurrences="12">
       <code>$createMock</code>
       <code>$expectedRawValue</code>
       <code>$expectedValue</code>
       <code>$input</code>
       <code>$input</code>
       <code>$input</code>
-      <code>$inputName</code>
-      <code>$inputName</code>
-      <code>$inputName</code>
-      <code>$inputTypeData</code>
-      <code>$inputTypeDescription</code>
-      <code>$inputTypes</code>
-      <code>$name</code>
       <code>$name</code>
       <code>$set[0][$name]</code>
       <code>$set[5][$name]</code>
       <code>$set[6][$name]</code>
-      <code>$tmpTemplate[0]</code>
       <code>$tmpTemplate[2]</code>
       <code>$tmpTemplate[3]</code>
     </MixedAssignment>
     <MixedFunctionCall occurrences="1">
       <code>$createMock($set[2])</code>
     </MixedFunctionCall>
-    <MixedMethodCall occurrences="19">
-      <code>method</code>
-      <code>method</code>
-      <code>method</code>
-      <code>method</code>
-      <code>method</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>with</code>
-      <code>with</code>
-    </MixedMethodCall>
-    <MixedOperand occurrences="3">
-      <code>$inputName</code>
-      <code>$inputName</code>
-      <code>$inputTypeDescription</code>
-    </MixedOperand>
+    <MixedInferredReturnType occurrences="1"/>
+    <MixedReturnTypeCoercion occurrences="2">
+      <code>$dataSets</code>
+    </MixedReturnTypeCoercion>
+    <MoreSpecificReturnType occurrences="1">
+      <code>array&lt;string, array{0: InputInterface, 1: null|string, 2: MockObject&amp;InputInterface}&gt;</code>
+    </MoreSpecificReturnType>
     <NullArgument occurrences="1">
       <code>null</code>
     </NullArgument>
-    <PossiblyInvalidArgument occurrences="9">
-      <code>$flatInput</code>
-      <code>$input</code>
-      <code>$input</code>
-      <code>$inputOptional</code>
-      <code>$inputRequired</code>
-      <code>$nestedInput</code>
-      <code>$nestedInput1</code>
-      <code>$nestedInput2</code>
-      <code>$optionalInput</code>
-    </PossiblyInvalidArgument>
-    <PossiblyUndefinedMethod occurrences="18">
-      <code>expects</code>
-      <code>expects</code>
-      <code>expects</code>
-      <code>expects</code>
-      <code>expects</code>
+    <PossiblyNullArgument occurrences="2">
+      <code>$expectedInputName</code>
+      <code>$expectedInputName</code>
+    </PossiblyNullArgument>
+    <PossiblyUndefinedMethod occurrences="3">
       <code>getName</code>
       <code>getName</code>
       <code>isRequired</code>
-      <code>method</code>
-      <code>method</code>
-      <code>method</code>
-      <code>method</code>
-      <code>method</code>
-      <code>method</code>
-      <code>method</code>
-      <code>method</code>
-      <code>method</code>
-      <code>method</code>
     </PossiblyUndefinedMethod>
   </file>
   <file src="test/CollectionInputFilterTest.php">
-    <InvalidArgument occurrences="1">
+    <ArgumentTypeCoercion occurrences="2">
+      <code>$expectedType</code>
+      <code>$inputFilter</code>
+    </ArgumentTypeCoercion>
+    <InvalidArgument occurrences="2">
       <code>new stdClass()</code>
+      <code>testDataVsValid</code>
     </InvalidArgument>
+    <InvalidReturnStatement occurrences="2"/>
+    <InvalidReturnType occurrences="2">
+      <code>array&lt;string, array{0: null|int, 1: bool}&gt;</code>
+    </InvalidReturnType>
     <MissingClosureParamType occurrences="1">
       <code>$set</code>
     </MissingClosureParamType>
@@ -921,35 +804,7 @@
       <code>function () use ($dataRaw, $dataFiltered) {</code>
       <code>function () use ($dataRaw, $dataFiltered, $errorMessage) {</code>
     </MissingClosureReturnType>
-    <MissingParamType occurrences="19">
-      <code>$count</code>
-      <code>$count</code>
-      <code>$count</code>
-      <code>$data</code>
-      <code>$data</code>
-      <code>$data</code>
-      <code>$data</code>
-      <code>$data</code>
-      <code>$expectedCount</code>
-      <code>$expectedIsValid</code>
-      <code>$expectedMessages</code>
-      <code>$expectedRaw</code>
-      <code>$expectedType</code>
-      <code>$expectedValid</code>
-      <code>$expectedValues</code>
-      <code>$inputFilter</code>
-      <code>$inputFilter</code>
-      <code>$required</code>
-      <code>$value</code>
-    </MissingParamType>
-    <MissingReturnType occurrences="29">
-      <code>countVsDataProvider</code>
-      <code>dataNestingCollection</code>
-      <code>dataVsValidProvider</code>
-      <code>inputFilterProvider</code>
-      <code>invalidCollections</code>
-      <code>invalidDataType</code>
-      <code>isRequiredProvider</code>
+    <MissingReturnType occurrences="22">
       <code>testAllowsComposingANotEmptyValidator</code>
       <code>testCollectionValidationDoesNotReuseMessagesBetweenInputs</code>
       <code>testCollectionValidationUsesCustomInputErrorMessages</code>
@@ -973,18 +828,8 @@
       <code>testSettingDataWithNonArrayNonTraversableRaisesException</code>
       <code>testUsesMessageFromComposedNotEmptyValidatorWhenRequiredButCollectionIsEmpty</code>
     </MissingReturnType>
-    <MixedArgument occurrences="27">
-      <code>$count</code>
-      <code>$count</code>
-      <code>$count</code>
+    <MixedArgument occurrences="15">
       <code>$data</code>
-      <code>$data</code>
-      <code>$data</code>
-      <code>$data</code>
-      <code>$data</code>
-      <code>$expectedType</code>
-      <code>$inputFilter</code>
-      <code>$inputFilter</code>
       <code>$messages[0]</code>
       <code>$messages[0]</code>
       <code>$messages[0]['phone']</code>
@@ -999,8 +844,6 @@
       <code>$messages[1]['phone']</code>
       <code>$messages[1]['phone']</code>
       <code>$messages[1]['phone']</code>
-      <code>$required</code>
-      <code>$value</code>
     </MixedArgument>
     <MixedArrayAccess occurrences="11">
       <code>$messages[0]['phone']</code>
@@ -1029,15 +872,18 @@
       <code>method</code>
       <code>method</code>
       <code>method</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>with</code>
       <code>method</code>
-      <code>with</code>
       <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>with</code>
+      <code>with</code>
     </MixedMethodCall>
+    <MixedReturnTypeCoercion occurrences="2">
+      <code>$dataSets</code>
+    </MixedReturnTypeCoercion>
     <PossiblyInvalidArgument occurrences="2">
       <code>$baseInputFilter</code>
       <code>$baseInputFilter</code>
@@ -1046,10 +892,10 @@
       <code>expects</code>
       <code>expects</code>
       <code>expects</code>
-      <code>method</code>
-      <code>method</code>
-      <code>method</code>
       <code>expects</code>
+      <code>method</code>
+      <code>method</code>
+      <code>method</code>
     </PossiblyUndefinedMethod>
   </file>
   <file src="test/ConfigProviderTest.php">
@@ -1060,9 +906,6 @@
     </MissingReturnType>
   </file>
   <file src="test/FactoryTest.php">
-    <ArgumentTypeCoercion occurrences="1">
-      <code>'LaminasTest\InputFilter\TestAsset\CustomInput'</code>
-    </ArgumentTypeCoercion>
     <DeprecatedMethod occurrences="7">
       <code>allowEmpty</code>
       <code>allowEmpty</code>
@@ -1076,16 +919,7 @@
       <code>'invalid_value'</code>
       <code>'invalid_value'</code>
     </InvalidArgument>
-    <MissingClosureParamType occurrences="3">
-      <code>$value</code>
-      <code>$value</code>
-      <code>$value</code>
-    </MissingClosureParamType>
-    <MissingParamType occurrences="1">
-      <code>$specificationKey</code>
-    </MissingParamType>
-    <MissingReturnType occurrences="57">
-      <code>inputTypeSpecificationProvider</code>
+    <MissingReturnType occurrences="56">
       <code>testCanCreateInputFilterFromProvider</code>
       <code>testCanCreateInputFilterWithNullInputs</code>
       <code>testCanCreateInputFromProvider</code>
@@ -1143,13 +977,9 @@
       <code>testSuggestedTypeMayBePluginNameInInputFilterPluginManager</code>
       <code>testWhenCreateInputPullsInputFromThePluginManagerItMustNotOverwriteFilterAndValidatorChains</code>
     </MissingReturnType>
-    <MixedArgument occurrences="1">
-      <code>$specificationKey</code>
-    </MixedArgument>
     <MixedArrayAccess occurrences="1">
       <code>$validator['instance']</code>
     </MixedArrayAccess>
-    <MixedArrayOffset occurrences="1"/>
     <MixedAssignment occurrences="3">
       <code>$defaultFilterChain</code>
       <code>$defaultValidatorChain</code>
@@ -1186,7 +1016,7 @@
       <code>getPluginManager</code>
       <code>getPluginManager</code>
     </PossiblyNullReference>
-    <PossiblyUndefinedMethod occurrences="17">
+    <PossiblyUndefinedMethod occurrences="16">
       <code>breakOnFailure</code>
       <code>breakOnFailure</code>
       <code>expects</code>
@@ -1198,7 +1028,6 @@
       <code>getErrorMessage</code>
       <code>getFilterChain</code>
       <code>getFilterChain</code>
-      <code>getName</code>
       <code>getName</code>
       <code>getName</code>
       <code>getValidatorChain</code>
@@ -1216,27 +1045,21 @@
     <DeprecatedMethod occurrences="1">
       <code>setMethods</code>
     </DeprecatedMethod>
+    <ImplementedReturnTypeMismatch occurrences="1">
+      <code>array&lt;string, string&gt;</code>
+    </ImplementedReturnTypeMismatch>
     <InvalidArgument occurrences="2">
       <code>''</code>
       <code>''</code>
     </InvalidArgument>
-    <MissingParamType occurrences="10">
-      <code>$expectedValue</code>
-      <code>$fallbackValue</code>
-      <code>$fallbackValue</code>
-      <code>$isValid</code>
-      <code>$originalValue</code>
-      <code>$raw</code>
-      <code>$required</code>
-      <code>$required</code>
-      <code>$value</code>
-      <code>$value</code>
-    </MissingParamType>
-    <MissingReturnType occurrences="27">
-      <code>emptyValueProvider</code>
-      <code>getDummyValue</code>
-      <code>isRequiredVsAllowEmptyVsContinueIfEmptyVsIsValidProvider</code>
-      <code>mixedValueProvider</code>
+    <InvalidReturnStatement occurrences="1">
+      <code>$dataSets</code>
+    </InvalidReturnStatement>
+    <InvalidReturnType occurrences="1">
+      <code>iterable</code>
+    </InvalidReturnType>
+    <LessSpecificReturnStatement occurrences="1"/>
+    <MissingReturnType occurrences="23">
       <code>testAutoPrependUploadValidatorIsOnByDefault</code>
       <code>testCanFilterArrayOfMultiFileData</code>
       <code>testCanRetrieveRawValue</code>
@@ -1261,16 +1084,13 @@
       <code>testValidationsRunWithoutFileArrayDueToAjaxPost</code>
       <code>testValidationsRunWithoutFileArrayIsSend</code>
     </MissingReturnType>
-    <MixedArrayAccess occurrences="5">
-      <code>$dataSets['Required: T; AEmpty: F; CIEmpty: F; Validator: X, Value: Empty / multi']</code>
-      <code>$dataSets['Required: T; AEmpty: F; CIEmpty: F; Validator: X, Value: Empty / single']</code>
-      <code>$dataSets['Required: T; AEmpty: F; CIEmpty: F; Validator: X, Value: Empty / tmp_name']</code>
+    <MixedArrayAccess occurrences="2">
       <code>$validators[0]['instance']</code>
       <code>$validators[0]['instance']</code>
     </MixedArrayAccess>
-    <MixedAssignment occurrences="1">
-      <code>$dataSets</code>
-    </MixedAssignment>
+    <MoreSpecificReturnType occurrences="1">
+      <code>array</code>
+    </MoreSpecificReturnType>
     <NonInvariantDocblockPropertyType occurrences="1">
       <code>$input</code>
     </NonInvariantDocblockPropertyType>
@@ -1287,6 +1107,9 @@
     </PropertyTypeCoercion>
   </file>
   <file src="test/FileInput/PsrFileInputDecoratorTest.php">
+    <ImplementedReturnTypeMismatch occurrences="4">
+      <code>UploadedFileInterface</code>
+    </ImplementedReturnTypeMismatch>
     <InvalidArgument occurrences="6">
       <code>$badValue-&gt;reveal()</code>
       <code>$upload-&gt;reveal()</code>
@@ -1295,23 +1118,8 @@
       <code>$uploadedFile-&gt;reveal()</code>
       <code>$value-&gt;reveal()</code>
     </InvalidArgument>
-    <MissingParamType occurrences="10">
-      <code>$expectedValue</code>
-      <code>$fallbackValue</code>
-      <code>$fallbackValue</code>
-      <code>$isValid</code>
-      <code>$originalValue</code>
-      <code>$raw</code>
-      <code>$required</code>
-      <code>$required</code>
-      <code>$value</code>
-      <code>$value</code>
-    </MissingParamType>
-    <MissingReturnType occurrences="23">
-      <code>emptyValueProvider</code>
-      <code>getDummyValue</code>
-      <code>isRequiredVsAllowEmptyVsContinueIfEmptyVsIsValidProvider</code>
-      <code>mixedValueProvider</code>
+    <InvalidReturnType occurrences="1"/>
+    <MissingReturnType occurrences="19">
       <code>testAutoPrependUploadValidatorIsOnByDefault</code>
       <code>testCanFilterArrayOfMultiFileData</code>
       <code>testCanRetrieveRawValue</code>
@@ -1339,18 +1147,6 @@
       <code>$validators[0]['instance']</code>
       <code>$validators[0]['instance']</code>
     </MixedArrayAccess>
-    <MixedAssignment occurrences="4">
-      <code>$data</code>
-      <code>$generator</code>
-      <code>$generator</code>
-      <code>$name</code>
-    </MixedAssignment>
-    <MixedClone occurrences="1">
-      <code>clone $generator</code>
-    </MixedClone>
-    <MixedMethodCall occurrences="1">
-      <code>rewind</code>
-    </MixedMethodCall>
     <NonInvariantDocblockPropertyType occurrences="1">
       <code>$input</code>
     </NonInvariantDocblockPropertyType>
@@ -1362,22 +1158,16 @@
     <PropertyTypeCoercion occurrences="1">
       <code>new FileInput('foo')</code>
     </PropertyTypeCoercion>
+    <TypeDoesNotContainType occurrences="1">
+      <code>$generator instanceof Generator</code>
+    </TypeDoesNotContainType>
   </file>
   <file src="test/InputFilterAbstractServiceFactoryTest.php">
-    <ArgumentTypeCoercion occurrences="2">
-      <code>'LaminasTest\InputFilter\TestAsset\Foo'</code>
-      <code>'Laminas\InputFilter\InputFilterPluginManager'</code>
-    </ArgumentTypeCoercion>
-    <MissingClosureParamType occurrences="2">
-      <code>$value</code>
-      <code>$value</code>
-    </MissingClosureParamType>
     <MissingClosureReturnType occurrences="2">
-      <code>function ($value) {</code>
-      <code>function ($value) {</code>
+      <code>function () {</code>
+      <code>function () {</code>
     </MissingClosureReturnType>
-    <MissingReturnType occurrences="11">
-      <code>getCompatContainer</code>
+    <MissingReturnType occurrences="10">
       <code>testAllowsPassingNonPluginManagerContainerToFactoryWithServiceManagerV2</code>
       <code>testCanCreateServiceIfConfigInputFiltersContainsMatchingServiceName</code>
       <code>testCannotCreateServiceIfConfigInputFiltersDoesNotContainMatchingServiceName</code>
@@ -1395,17 +1185,15 @@
       <code>$validatorChain</code>
       <code>$validatorChain</code>
     </MixedArgument>
-    <MixedAssignment occurrences="5">
+    <MixedAssignment occurrences="4">
       <code>$filterChain</code>
       <code>$input</code>
       <code>$inputFilter</code>
-      <code>$inputFilterManager</code>
       <code>$validatorChain</code>
     </MixedAssignment>
-    <MixedMethodCall occurrences="14">
+    <MixedMethodCall occurrences="13">
       <code>addAbstractFactory</code>
       <code>addAbstractFactory</code>
-      <code>get</code>
       <code>get</code>
       <code>get</code>
       <code>get</code>
@@ -1442,25 +1230,13 @@
     <InvalidReturnType occurrences="1">
       <code>getInstanceOf</code>
     </InvalidReturnType>
-    <MissingReturnType occurrences="1">
-      <code>testInstanceOfMatches</code>
-    </MissingReturnType>
   </file>
   <file src="test/InputFilterPluginManagerFactoryTest.php">
-    <MissingClosureParamType occurrences="2">
-      <code>$container</code>
-      <code>$container</code>
-    </MissingClosureParamType>
-    <MissingClosureReturnType occurrences="2">
-      <code>function ($container) use ($inputFilter) {</code>
-      <code>function ($container) use ($inputFilter) {</code>
+    <LessSpecificReturnStatement occurrences="1"/>
+    <MissingClosureReturnType occurrences="1">
+      <code>function () use ($inputFilter) {</code>
     </MissingClosureReturnType>
-    <MissingParamType occurrences="2">
-      <code>$pluginType</code>
-      <code>$pluginType</code>
-    </MissingParamType>
-    <MissingReturnType occurrences="8">
-      <code>pluginProvider</code>
+    <MissingReturnType occurrences="7">
       <code>testConfiguresInputFilterServicesWhenFound</code>
       <code>testDoesNotConfigureInputFilterServicesWhenConfigServiceDoesNotContainInputFiltersConfig</code>
       <code>testDoesNotConfigureInputFilterServicesWhenConfigServiceNotPresent</code>
@@ -1469,25 +1245,17 @@
       <code>testFactoryConfiguresPluginManagerUnderServiceManagerV2</code>
       <code>testFactoryReturnsPluginManager</code>
     </MissingReturnType>
-    <MixedArgument occurrences="2">
-      <code>$pluginType</code>
-      <code>$pluginType</code>
-    </MixedArgument>
+    <MoreSpecificReturnType occurrences="1">
+      <code>array&lt;string, array{0: class-string&lt;InputInterface&gt;}&gt;</code>
+    </MoreSpecificReturnType>
   </file>
   <file src="test/InputFilterPluginManagerTest.php">
-    <MissingParamType occurrences="7">
-      <code>$alias</code>
-      <code>$expectedInstance</code>
-      <code>$instanceOf</code>
-      <code>$service</code>
-      <code>$service</code>
-      <code>$serviceName</code>
-      <code>$serviceName</code>
-    </MissingParamType>
-    <MissingReturnType occurrences="13">
-      <code>defaultInvokableClassesProvider</code>
-      <code>getServiceNotFoundException</code>
-      <code>serviceProvider</code>
+    <ArgumentTypeCoercion occurrences="2">
+      <code>$this-&gt;getServiceNotFoundException()</code>
+      <code>$this-&gt;getServiceNotFoundException()</code>
+    </ArgumentTypeCoercion>
+    <LessSpecificReturnStatement occurrences="1"/>
+    <MissingReturnType occurrences="10">
       <code>testDefaultInvokableClasses</code>
       <code>testGet</code>
       <code>testInputFilterInvokableClassSMDependenciesArePopulatedWithServiceLocator</code>
@@ -1499,18 +1267,7 @@
       <code>testRegisteringInvalidElementRaisesException</code>
       <code>testServicesAreInitiatedIfImplementsInitializableInterface</code>
     </MissingReturnType>
-    <MixedArgument occurrences="10">
-      <code>$alias</code>
-      <code>$expectedInstance</code>
-      <code>$instanceOf</code>
-      <code>$service</code>
-      <code>$serviceName</code>
-      <code>$serviceName</code>
-      <code>$serviceName</code>
-      <code>$serviceName</code>
-      <code>$this-&gt;getServiceNotFoundException()</code>
-      <code>$this-&gt;getServiceNotFoundException()</code>
-    </MixedArgument>
+    <MoreSpecificReturnType occurrences="1"/>
     <PossiblyNullReference occurrences="2">
       <code>getPluginManager</code>
       <code>getPluginManager</code>
@@ -1520,22 +1277,20 @@
     </RedundantConditionGivenDocblockType>
   </file>
   <file src="test/InputFilterTest.php">
-    <MissingReturnType occurrences="4">
-      <code>inputProvider</code>
+    <ImplementedReturnTypeMismatch occurrences="1"/>
+    <LessSpecificReturnStatement occurrences="1">
+      <code>$dataSets</code>
+    </LessSpecificReturnStatement>
+    <MissingReturnType occurrences="3">
       <code>testCanComposeAFactory</code>
       <code>testLazilyComposesAFactoryByDefault</code>
       <code>testNestedInputFilterShouldAllowNullValueForData</code>
     </MissingReturnType>
-    <MixedArgument occurrences="1">
-      <code>$dataSets</code>
-    </MixedArgument>
     <MixedArrayAccess occurrences="2">
       <code>$filter1-&gt;getValues()['nested']['nestedField1']</code>
       <code>$filter1-&gt;getValues()['nested']['nestedField1']</code>
     </MixedArrayAccess>
-    <MixedAssignment occurrences="1">
-      <code>$dataSets</code>
-    </MixedAssignment>
+    <MoreSpecificReturnType occurrences="1"/>
     <NonInvariantDocblockPropertyType occurrences="1">
       <code>$inputFilter</code>
     </NonInvariantDocblockPropertyType>
@@ -1571,6 +1326,13 @@
       <code>setMethods</code>
       <code>setMethods</code>
     </DeprecatedMethod>
+    <InvalidReturnStatement occurrences="2">
+      <code>$dataSets</code>
+    </InvalidReturnStatement>
+    <InvalidReturnType occurrences="2"/>
+    <LessSpecificReturnStatement occurrences="1">
+      <code>array_merge($emptyValues, $mixedValues)</code>
+    </LessSpecificReturnStatement>
     <MissingClosureParamType occurrences="6">
       <code>$context</code>
       <code>$context</code>
@@ -1584,41 +1346,7 @@
       <code>function ($value, $context = null) {</code>
       <code>function ($value, $context = null) {</code>
     </MissingClosureReturnType>
-    <MissingParamType occurrences="25">
-      <code>$allowEmpty</code>
-      <code>$continueIfEmpty</code>
-      <code>$expectedIsValid</code>
-      <code>$expectedMessages</code>
-      <code>$expectedValue</code>
-      <code>$fallbackValue</code>
-      <code>$fallbackValue</code>
-      <code>$fallbackValue</code>
-      <code>$fallbackValue</code>
-      <code>$isValid</code>
-      <code>$message</code>
-      <code>$originalValue</code>
-      <code>$raw</code>
-      <code>$required</code>
-      <code>$required</code>
-      <code>$required</code>
-      <code>$validator</code>
-      <code>$value</code>
-      <code>$value</code>
-      <code>$value</code>
-      <code>$value</code>
-      <code>$value</code>
-      <code>$value</code>
-      <code>$valueFiltered</code>
-      <code>$valueRaw</code>
-    </MissingParamType>
-    <MissingReturnType occurrences="47">
-      <code>assertRequiredValidationErrorMessage</code>
-      <code>emptyValueProvider</code>
-      <code>fallbackValueVsIsValidProvider</code>
-      <code>getDummyValue</code>
-      <code>isRequiredVsAllowEmptyVsContinueIfEmptyVsIsValidProvider</code>
-      <code>mixedValueProvider</code>
-      <code>setValueProvider</code>
+    <MissingReturnType occurrences="40">
       <code>testAllowEmptyFlagIsMutable</code>
       <code>testBreakOnFailureFlagIsMutable</code>
       <code>testBreakOnFailureFlagIsOffByDefault</code>
@@ -1660,18 +1388,6 @@
       <code>testValidationOperatesOnFilteredValue</code>
       <code>testValueMayBeInjected</code>
     </MissingReturnType>
-    <MixedArgument occurrences="10">
-      <code>$allValues</code>
-      <code>$allowEmpty</code>
-      <code>$continueIfEmpty</code>
-      <code>$emptyValues</code>
-      <code>$emptyValues</code>
-      <code>$mixedValues</code>
-      <code>$required</code>
-      <code>$required</code>
-      <code>$required</code>
-      <code>$validator</code>
-    </MixedArgument>
     <MixedArrayAccess occurrences="5">
       <code>$messageTemplates[NotEmptyValidator::IS_EMPTY]</code>
       <code>$validators[0]['instance']</code>
@@ -1679,28 +1395,12 @@
       <code>$value['filtered']</code>
       <code>$value['raw']</code>
     </MixedArrayAccess>
-    <MixedAssignment occurrences="21">
-      <code>$allValues</code>
-      <code>$emptyValues</code>
-      <code>$emptyValues</code>
-      <code>$emptyValues</code>
-      <code>$emptyValues</code>
-      <code>$expectedValue</code>
+    <MixedAssignment occurrences="5">
       <code>$isValidMethod</code>
       <code>$isValidMethod</code>
-      <code>$message</code>
       <code>$messageTemplates</code>
-      <code>$mixedValues</code>
-      <code>$mixedValues</code>
-      <code>$sourceRawValue</code>
       <code>$tmpTemplate[4]</code>
       <code>$value</code>
-      <code>$valueFiltered</code>
-      <code>$valueFiltered</code>
-      <code>$valueRaw</code>
-      <code>$valueRaw</code>
-      <code>$valueRaw</code>
-      <code>$valueRaw</code>
     </MixedAssignment>
     <MixedMethodCall occurrences="27">
       <code>method</code>
@@ -1731,9 +1431,7 @@
       <code>with</code>
       <code>with</code>
     </MixedMethodCall>
-    <MixedOperand occurrences="1">
-      <code>$message</code>
-    </MixedOperand>
+    <MoreSpecificReturnType occurrences="1"/>
     <PossiblyInvalidArgument occurrences="17">
       <code>$chain</code>
       <code>$chain</code>
@@ -1775,6 +1473,9 @@
       <code>method</code>
       <code>method</code>
     </PossiblyUndefinedMethod>
+    <RedundantCondition occurrences="1">
+      <code>isArray</code>
+    </RedundantCondition>
     <RedundantConditionGivenDocblockType occurrences="1">
       <code>assertIsArray</code>
     </RedundantConditionGivenDocblockType>
@@ -1796,23 +1497,14 @@
       <code>$config['service_manager']['factories']</code>
     </MixedArgument>
     <MixedArrayAccess occurrences="3">
-      <code>$config['input_filters']</code>
-      <code>$config['service_manager']</code>
-      <code>$config['service_manager']</code>
+      <code>$config['input_filters']['abstract_factories']</code>
+      <code>$config['service_manager']['aliases']</code>
+      <code>$config['service_manager']['factories']</code>
     </MixedArrayAccess>
-    <MixedAssignment occurrences="3">
-      <code>$config</code>
-      <code>$config</code>
-      <code>$config</code>
-    </MixedAssignment>
   </file>
   <file src="test/OptionalInputFilterTest.php">
-    <MissingPropertyType occurrences="1">
-      <code>$nestedCarInputFilter</code>
-    </MissingPropertyType>
-    <MissingReturnType occurrences="9">
+    <MissingReturnType occurrences="8">
       <code>assertGetValuesThrows</code>
-      <code>getNestedCarInputFilter</code>
       <code>testIteratorBehavesTheSameAsArray</code>
       <code>testStateIsClearedBetweenValidationAttempts</code>
       <code>testValidatesSuccessfullyWhenEmptyDataSetProvided</code>
@@ -1821,34 +1513,6 @@
       <code>testValidatesSuccessfullyWhenValidNonEmptyDataSetProvided</code>
       <code>testValidationFailureWhenInvalidDataSetIsProvided</code>
     </MissingReturnType>
-    <MixedArgument occurrences="1">
-      <code>$inputFilter</code>
-    </MixedArgument>
-    <MixedAssignment occurrences="5">
-      <code>$inputFilter</code>
-      <code>$inputFilter</code>
-      <code>$inputFilter</code>
-      <code>$inputFilter</code>
-      <code>$inputFilter</code>
-    </MixedAssignment>
-    <MixedMethodCall occurrences="16">
-      <code>get</code>
-      <code>getValues</code>
-      <code>getValues</code>
-      <code>getValues</code>
-      <code>getValues</code>
-      <code>isValid</code>
-      <code>isValid</code>
-      <code>isValid</code>
-      <code>isValid</code>
-      <code>isValid</code>
-      <code>isValid</code>
-      <code>setData</code>
-      <code>setData</code>
-      <code>setData</code>
-      <code>setData</code>
-      <code>setData</code>
-    </MixedMethodCall>
   </file>
   <file src="test/TestAsset/CustomFactory.php">
     <PropertyNotSetInConstructor occurrences="1">
@@ -1859,10 +1523,6 @@
     <DeprecatedInterface occurrences="1">
       <code>CustomInput</code>
     </DeprecatedInterface>
-    <PropertyNotSetInConstructor occurrences="2">
-      <code>CustomInput</code>
-      <code>CustomInput</code>
-    </PropertyNotSetInConstructor>
   </file>
   <file src="test/TestAsset/FooAbstractFactory.php">
     <DeprecatedInterface occurrences="1">
@@ -1871,30 +1531,11 @@
     <InvalidNullableReturnType occurrences="1">
       <code>canCreate</code>
     </InvalidNullableReturnType>
-    <MissingParamType occurrences="4">
-      <code>$name</code>
-      <code>$name</code>
-      <code>$requestedName</code>
-      <code>$requestedName</code>
-    </MissingParamType>
-    <MixedArgument occurrences="2">
-      <code>$requestedName ?: $name</code>
-      <code>$requestedName ?: $name</code>
-    </MixedArgument>
     <ParamNameMismatch occurrences="3">
       <code>$container</code>
       <code>$container</code>
       <code>$name</code>
     </ParamNameMismatch>
-  </file>
-  <file src="test/TestAsset/ModuleEventInterface.php">
-    <MissingParamType occurrences="2">
-      <code>$default</code>
-      <code>$name</code>
-    </MissingParamType>
-    <MissingReturnType occurrences="1">
-      <code>getParam</code>
-    </MissingReturnType>
   </file>
   <file src="test/TestAsset/ModuleManagerInterface.php">
     <MissingReturnType occurrences="1">
@@ -1905,5 +1546,11 @@
     <MissingReturnType occurrences="1">
       <code>addServiceManager</code>
     </MissingReturnType>
+  </file>
+  <file src="vendor/laminas/laminas-servicemanager/src/ServiceManager.php">
+    <ParseError occurrences="2">
+      <code>=&gt;</code>
+      <code>fn</code>
+    </ParseError>
   </file>
 </files>

--- a/src/ArrayInput.php
+++ b/src/ArrayInput.php
@@ -2,11 +2,13 @@
 
 namespace Laminas\InputFilter;
 
+use function gettype;
+use function is_array;
+use function sprintf;
+
 class ArrayInput extends Input
 {
-    /**
-     * @var array
-     */
+    /** @var array */
     protected $value = [];
 
     /**
@@ -30,7 +32,7 @@ class ArrayInput extends Input
      */
     public function resetValue()
     {
-        $this->value = [];
+        $this->value    = [];
         $this->hasValue = false;
         return $this;
     }
@@ -54,8 +56,8 @@ class ArrayInput extends Input
      */
     public function isValid($context = null)
     {
-        $hasValue = $this->hasValue();
-        $required = $this->isRequired();
+        $hasValue    = $this->hasValue();
+        $required    = $this->isRequired();
         $hasFallback = $this->hasFallback();
 
         if (! $hasValue && $hasFallback) {
@@ -85,7 +87,7 @@ class ArrayInput extends Input
         }
 
         foreach ($values as $value) {
-            $empty = ($value === null || $value === '' || $value === []);
+            $empty = $value === null || $value === '' || $value === [];
             if ($empty && ! $this->isRequired() && ! $this->continueIfEmpty()) {
                 $result = true;
                 continue;

--- a/src/BaseInputFilter.php
+++ b/src/BaseInputFilter.php
@@ -6,6 +6,20 @@ use Laminas\Stdlib\ArrayUtils;
 use Laminas\Stdlib\InitializableInterface;
 use Traversable;
 
+use function array_diff;
+use function array_intersect;
+use function array_key_exists;
+use function array_keys;
+use function array_merge;
+use function count;
+use function func_get_args;
+use function get_class;
+use function gettype;
+use function is_array;
+use function is_int;
+use function is_object;
+use function sprintf;
+
 class BaseInputFilter implements
     InputFilterInterface,
     UnknownInputsCapableInterface,
@@ -13,34 +27,22 @@ class BaseInputFilter implements
     ReplaceableInputInterface,
     UnfilteredDataInterface
 {
-    /**
-     * @var null|array
-     */
+    /** @var null|array */
     protected $data;
 
-    /**
-     * @var array|object
-     */
+    /** @var array|object */
     protected $unfilteredData = [];
 
-    /**
-     * @var InputInterface[]|InputFilterInterface[]
-     */
+    /** @var InputInterface[]|InputFilterInterface[] */
     protected $inputs = [];
 
-    /**
-     * @var InputInterface[]|InputFilterInterface[]
-     */
+    /** @var InputInterface[]|InputFilterInterface[] */
     protected $invalidInputs;
 
-    /**
-     * @var null|string[] Input names
-     */
+    /** @var null|string[] Input names */
     protected $validationGroup;
 
-    /**
-     * @var InputInterface[]|InputFilterInterface[]
-     */
+    /** @var InputInterface[]|InputFilterInterface[] */
     protected $validInputs;
 
     /**
@@ -81,7 +83,7 @@ class BaseInputFilter implements
                 __METHOD__,
                 InputInterface::class,
                 InputFilterInterface::class,
-                (is_object($input) ? get_class($input) : gettype($input))
+                is_object($input) ? get_class($input) : gettype($input)
             ));
         }
 
@@ -189,7 +191,7 @@ class BaseInputFilter implements
             throw new Exception\InvalidArgumentException(sprintf(
                 '%s expects an array or Traversable argument; received %s',
                 __METHOD__,
-                (is_object($data) ? get_class($data) : gettype($data))
+                is_object($data) ? get_class($data) : gettype($data)
             ));
         }
 
@@ -231,20 +233,20 @@ class BaseInputFilter implements
      */
     protected function validateInputs(array $inputs, array $data = [], $context = null)
     {
-        $inputContext = $context ?: (array_merge($this->getRawValues(), $data));
+        $inputContext = $context ?: array_merge($this->getRawValues(), $data);
 
         $this->validInputs   = [];
         $this->invalidInputs = [];
         $valid               = true;
 
         foreach ($inputs as $name) {
-            $input       = $this->inputs[$name];
+            $input = $this->inputs[$name];
 
             // Validate an input filter
             if ($input instanceof InputFilterInterface) {
                 if (! $input->isValid($context)) {
                     $this->invalidInputs[$name] = $input;
-                    $valid = false;
+                    $valid                      = false;
                     continue;
                 }
                 $this->validInputs[$name] = $input;
@@ -257,7 +259,8 @@ class BaseInputFilter implements
             }
 
             // If input is optional (not required), and value is not set, then ignore.
-            if (! array_key_exists($name, $data)
+            if (
+                ! array_key_exists($name, $data)
                 && ! $input->isRequired()
             ) {
                 continue;
@@ -267,7 +270,7 @@ class BaseInputFilter implements
             if (! $input->isValid($inputContext)) {
                 // Validation failure
                 $this->invalidInputs[$name] = $input;
-                $valid = false;
+                $valid                      = false;
 
                 if ($input->breakOnFailure()) {
                     return false;
@@ -591,8 +594,6 @@ class BaseInputFilter implements
 
     /**
      * Merges the inputs from an InputFilter into the current one
-     *
-     * @param BaseInputFilter $inputFilter
      *
      * @return self
      */

--- a/src/CollectionInputFilter.php
+++ b/src/CollectionInputFilter.php
@@ -5,41 +5,34 @@ namespace Laminas\InputFilter;
 use Laminas\Validator\NotEmpty;
 use Traversable;
 
+use function count;
+use function get_class;
+use function gettype;
+use function is_array;
+use function is_object;
+use function sprintf;
+
 class CollectionInputFilter extends InputFilter
 {
-    /**
-     * @var bool
-     */
+    /** @var bool */
     protected $isRequired = false;
 
-    /**
-     * @var int
-     */
-    protected $count = null;
+    /** @var int */
+    protected $count;
 
-    /**
-     * @var array[]
-     */
+    /** @var array[] */
     protected $collectionValues = [];
 
-    /**
-     * @var array[]
-     */
+    /** @var array[] */
     protected $collectionRawValues = [];
 
-    /**
-     * @var array
-     */
+    /** @var array */
     protected $collectionMessages = [];
 
-    /**
-     * @var BaseInputFilter
-     */
+    /** @var BaseInputFilter */
     protected $inputFilter;
 
-    /**
-     * @var NotEmpty
-     */
+    /** @var NotEmpty */
     protected $notEmptyValidator;
 
     /**
@@ -60,7 +53,7 @@ class CollectionInputFilter extends InputFilter
                 '%s expects an instance of %s; received "%s"',
                 __METHOD__,
                 BaseInputFilter::class,
-                (is_object($inputFilter) ? get_class($inputFilter) : gettype($inputFilter))
+                is_object($inputFilter) ? get_class($inputFilter) : gettype($inputFilter)
             ));
         }
 
@@ -188,7 +181,6 @@ class CollectionInputFilter extends InputFilter
      * This validator will be used to produce a validation failure message in
      * cases where the collection is empty but required.
      *
-     * @param NotEmpty $notEmptyValidator
      * @return $this
      */
     public function setNotEmptyValidator(NotEmpty $notEmptyValidator)
@@ -199,17 +191,17 @@ class CollectionInputFilter extends InputFilter
     }
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
     public function isValid($context = null)
     {
         $this->collectionMessages = [];
-        $inputFilter = $this->getInputFilter();
-        $valid = true;
+        $inputFilter              = $this->getInputFilter();
+        $valid                    = true;
 
         if ($this->getCount() < 1 && $this->isRequired) {
             $this->collectionMessages[] = $this->prepareRequiredValidationFailureMessage();
-            $valid = false;
+            $valid                      = false;
         }
 
         if (count($this->data) < $this->getCount()) {
@@ -233,12 +225,12 @@ class CollectionInputFilter extends InputFilter
             if ($inputFilter->isValid($context)) {
                 $this->validInputs[$key] = $inputFilter->getValidInput();
             } else {
-                $valid = false;
+                $valid                          = false;
                 $this->collectionMessages[$key] = $inputFilter->getMessages();
-                $this->invalidInputs[$key] = $inputFilter->getInvalidInput();
+                $this->invalidInputs[$key]      = $inputFilter->getInvalidInput();
             }
 
-            $this->collectionValues[$key] = $inputFilter->getValues();
+            $this->collectionValues[$key]    = $inputFilter->getValues();
             $this->collectionRawValues[$key] = $inputFilter->getRawValues();
         }
 

--- a/src/CollectionInputFilter.php
+++ b/src/CollectionInputFilter.php
@@ -17,7 +17,7 @@ class CollectionInputFilter extends InputFilter
     /** @var bool */
     protected $isRequired = false;
 
-    /** @var int */
+    /** @var null|int */
     protected $count;
 
     /** @var array[] */

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -12,7 +12,7 @@ class ConfigProvider
     public function __invoke()
     {
         return [
-            'dependencies' => $this->getDependencyConfig(),
+            'dependencies'  => $this->getDependencyConfig(),
             'input_filters' => $this->getInputFilterConfig(),
         ];
     }
@@ -25,7 +25,7 @@ class ConfigProvider
     public function getDependencyConfig()
     {
         return [
-            'aliases' => [
+            'aliases'   => [
                 'InputFilterManager' => InputFilterPluginManager::class,
 
                 // Legacy Zend Framework aliases

--- a/src/FileInput.php
+++ b/src/FileInput.php
@@ -23,14 +23,10 @@ use function is_array;
  */
 class FileInput extends Input
 {
-    /**
-     * @var bool
-     */
+    /** @var bool */
     protected $isValid = false;
 
-    /**
-     * @var bool
-     */
+    /** @var bool */
     protected $autoPrependUploadValidator = true;
 
     /** @var FileInput\FileInputDecoratorInterface */
@@ -38,7 +34,6 @@ class FileInput extends Input
 
     /**
      * @param array|UploadedFile $value
-     *
      * @return Input
      */
     public function setValue($value)
@@ -48,6 +43,7 @@ class FileInput extends Input
         return $this;
     }
 
+    /** @return self */
     public function resetValue()
     {
         $this->implementation = null;
@@ -56,7 +52,6 @@ class FileInput extends Input
 
     /**
      * @param  bool $value Enable/Disable automatically prepending an Upload validator
-     *
      * @return FileInput
      */
     public function setAutoPrependUploadValidator($value)
@@ -87,7 +82,7 @@ class FileInput extends Input
     /**
      * Checks if the raw input value is an empty file input eg: no file was uploaded
      *
-     * @param $rawValue
+     * @param mixed $rawValue
      * @return bool
      */
     public function isEmptyFile($rawValue)
@@ -143,8 +138,6 @@ class FileInput extends Input
     }
 
     /**
-     * @param  InputInterface $input
-     *
      * @return FileInput
      */
     public function merge(InputInterface $input)

--- a/src/FileInput.php
+++ b/src/FileInput.php
@@ -119,7 +119,7 @@ class FileInput extends Input
             return true;
         }
 
-        if (! $hasValue && $required && ! $this->hasFallback()) {
+        if (! $hasValue && ! $this->hasFallback()) { // required, no value, and no fallback
             if ($this->errorMessage === null) {
                 $this->errorMessage = $this->prepareRequiredValidationFailureMessage();
             }

--- a/src/FileInput/FileInputDecoratorInterface.php
+++ b/src/FileInput/FileInputDecoratorInterface.php
@@ -14,7 +14,7 @@ interface FileInputDecoratorInterface
     /**
      * Checks if the raw input value is an empty file input eg: no file was uploaded
      *
-     * @param $rawValue
+     * @param mixed $rawValue
      * @return bool
      */
     public static function isEmptyFileDecorator($rawValue);

--- a/src/FileInput/HttpServerFileInputDecorator.php
+++ b/src/FileInput/HttpServerFileInputDecorator.php
@@ -9,6 +9,8 @@ use Laminas\Validator\ValidatorChain;
 use function count;
 use function is_array;
 
+use const UPLOAD_ERR_NO_FILE;
+
 /**
  * Decorator for filtering standard SAPI file uploads.
  *
@@ -31,7 +33,7 @@ class HttpServerFileInputDecorator extends FileInput implements FileInputDecorat
     /**
      * Checks if the raw input value is an empty file input eg: no file was uploaded
      *
-     * @param $rawValue
+     * @param mixed $rawValue
      * @return bool
      */
     public static function isEmptyFileDecorator($rawValue)
@@ -150,7 +152,8 @@ class HttpServerFileInputDecorator extends FileInput implements FileInputDecorat
 
         // Check if Upload validator is already first in chain
         $validators = $chain->getValidators();
-        if (isset($validators[0]['instance'])
+        if (
+            isset($validators[0]['instance'])
             && $validators[0]['instance'] instanceof UploadValidator
         ) {
             $this->subject->autoPrependUploadValidator = false;

--- a/src/FileInput/PsrFileInputDecorator.php
+++ b/src/FileInput/PsrFileInputDecorator.php
@@ -9,6 +9,8 @@ use Psr\Http\Message\UploadedFileInterface;
 
 use function is_array;
 
+use const UPLOAD_ERR_NO_FILE;
+
 /**
  * PsrFileInput is a special Input type for handling uploaded files through  PSR-7 middlware.
  *
@@ -113,7 +115,8 @@ class PsrFileInputDecorator extends FileInput implements FileInputDecoratorInter
 
         // Check if Upload validator is already first in chain
         $validators = $chain->getValidators();
-        if (isset($validators[0]['instance'])
+        if (
+            isset($validators[0]['instance'])
             && $validators[0]['instance'] instanceof UploadValidator
         ) {
             $this->subject->autoPrependUploadValidator = false;

--- a/src/Input.php
+++ b/src/Input.php
@@ -7,6 +7,9 @@ use Laminas\ServiceManager\AbstractPluginManager;
 use Laminas\Validator\NotEmpty;
 use Laminas\Validator\ValidatorChain;
 
+use function class_exists;
+use function is_array;
+
 class Input implements
     InputInterface,
     EmptyContextInterface
@@ -25,24 +28,16 @@ class Input implements
      */
     protected $continueIfEmpty = false;
 
-    /**
-     * @var bool
-     */
+    /** @var bool */
     protected $breakOnFailure = false;
 
-    /**
-     * @var string|null
-     */
+    /** @var string|null */
     protected $errorMessage;
 
-    /**
-     * @var FilterChain
-     */
+    /** @var FilterChain */
     protected $filterChain;
 
-    /**
-     * @var string
-     */
+    /** @var null|string */
     protected $name;
 
     /**
@@ -52,19 +47,13 @@ class Input implements
      */
     protected $notEmptyValidator = false;
 
-    /**
-     * @var bool
-     */
+    /** @var bool */
     protected $required = true;
 
-    /**
-     * @var ValidatorChain
-     */
+    /** @var ValidatorChain */
     protected $validatorChain;
 
-    /**
-     * @var mixed
-     */
+    /** @var mixed */
     protected $value;
 
     /**
@@ -74,16 +63,13 @@ class Input implements
      */
     protected $hasValue = false;
 
-    /**
-     * @var mixed
-     */
+    /** @var mixed */
     protected $fallbackValue;
 
-    /**
-     * @var bool
-     */
+    /** @var bool */
     protected $hasFallback = false;
 
+    /** @param null|string $name */
     public function __construct($name = null)
     {
         $this->name = $name;
@@ -129,12 +115,11 @@ class Input implements
      */
     public function setErrorMessage($errorMessage)
     {
-        $this->errorMessage = (null === $errorMessage) ? null : (string) $errorMessage;
+        $this->errorMessage = null === $errorMessage ? null : (string) $errorMessage;
         return $this;
     }
 
     /**
-     * @param  FilterChain $filterChain
      * @return Input
      */
     public function setFilterChain(FilterChain $filterChain)
@@ -164,7 +149,6 @@ class Input implements
     }
 
     /**
-     * @param  ValidatorChain $validatorChain
      * @return Input
      */
     public function setValidatorChain(ValidatorChain $validatorChain)
@@ -187,7 +171,7 @@ class Input implements
      */
     public function setValue($value)
     {
-        $this->value = $value;
+        $this->value    = $value;
         $this->hasValue = true;
         return $this;
     }
@@ -202,7 +186,7 @@ class Input implements
      */
     public function resetValue()
     {
-        $this->value = null;
+        $this->value    = null;
         $this->hasValue = false;
         return $this;
     }
@@ -214,7 +198,7 @@ class Input implements
     public function setFallbackValue($value)
     {
         $this->fallbackValue = $value;
-        $this->hasFallback = true;
+        $this->hasFallback   = true;
         return $this;
     }
 
@@ -344,12 +328,11 @@ class Input implements
 
     public function clearFallbackValue()
     {
-        $this->hasFallback = false;
+        $this->hasFallback   = false;
         $this->fallbackValue = null;
     }
 
     /**
-     * @param  InputInterface $input
      * @return Input
      */
     public function merge(InputInterface $input)
@@ -386,7 +369,7 @@ class Input implements
 
         $value           = $this->getValue();
         $hasValue        = $this->hasValue();
-        $empty           = ($value === null || $value === '' || $value === []);
+        $empty           = $value === null || $value === '' || $value === [];
         $required        = $this->isRequired();
         $allowEmpty      = $this->allowEmpty();
         $continueIfEmpty = $this->continueIfEmpty();
@@ -489,8 +472,8 @@ class Input implements
      */
     protected function prepareRequiredValidationFailureMessage()
     {
-        $chain      = $this->getValidatorChain();
-        $notEmpty   = $chain->plugin(NotEmpty::class);
+        $chain    = $this->getValidatorChain();
+        $notEmpty = $chain->plugin(NotEmpty::class);
 
         foreach ($chain->getValidators() as $validator) {
             if ($validator['instance'] instanceof NotEmpty) {

--- a/src/Input.php
+++ b/src/Input.php
@@ -34,7 +34,7 @@ class Input implements
     /** @var string|null */
     protected $errorMessage;
 
-    /** @var FilterChain */
+    /** @var null|FilterChain */
     protected $filterChain;
 
     /** @var null|string */
@@ -50,7 +50,7 @@ class Input implements
     /** @var bool */
     protected $required = true;
 
-    /** @var ValidatorChain */
+    /** @var null|ValidatorChain */
     protected $validatorChain;
 
     /** @var mixed */
@@ -250,7 +250,7 @@ class Input implements
     }
 
     /**
-     * @return string
+     * @return null|string
      */
     public function getName()
     {
@@ -383,7 +383,7 @@ class Input implements
             return true;
         }
 
-        if (! $hasValue && $required) {
+        if (! $hasValue) { // required, but no value
             if ($this->errorMessage === null) {
                 $this->errorMessage = $this->prepareRequiredValidationFailureMessage();
             }

--- a/src/InputFilter.php
+++ b/src/InputFilter.php
@@ -4,17 +4,16 @@ namespace Laminas\InputFilter;
 
 use Traversable;
 
+use function is_array;
+
 class InputFilter extends BaseInputFilter
 {
-    /**
-     * @var Factory
-     */
+    /** @var Factory */
     protected $factory;
 
     /**
      * Set factory to use when adding inputs and filters by spec
      *
-     * @param  Factory $factory
      * @return InputFilter
      */
     public function setFactory(Factory $factory)
@@ -47,11 +46,12 @@ class InputFilter extends BaseInputFilter
      */
     public function add($input, $name = null)
     {
-        if (is_array($input)
+        if (
+            is_array($input)
             || ($input instanceof Traversable && ! $input instanceof InputFilterInterface)
         ) {
             $factory = $this->getFactory();
-            $input = $factory->createInput($input);
+            $input   = $factory->createInput($input);
         }
         return parent::add($input, $name);
     }

--- a/src/InputFilterAbstractServiceFactory.php
+++ b/src/InputFilterAbstractServiceFactory.php
@@ -9,20 +9,19 @@ use Laminas\ServiceManager\AbstractPluginManager;
 use Laminas\ServiceManager\ServiceLocatorInterface;
 use Laminas\Validator\ValidatorPluginManager;
 
+use function is_array;
+
 class InputFilterAbstractServiceFactory implements AbstractFactoryInterface
 {
-    /**
-     * @var Factory
-     */
+    /** @var Factory */
     protected $factory;
 
     /**
-     * @param ContainerInterface      $services
      * @param string                  $rName
      * @param array                   $options
      * @return InputFilterInterface
      */
-    public function __invoke(ContainerInterface $services, $rName, array  $options = null)
+    public function __invoke(ContainerInterface $services, $rName, ?array $options = null)
     {
         $allConfig = $services->get('config');
         $config    = $allConfig['input_filter_specs'][$rName];
@@ -32,8 +31,6 @@ class InputFilterAbstractServiceFactory implements AbstractFactoryInterface
     }
 
     /**
-     *
-     * @param ContainerInterface $services
      * @param string $rName
      * @return bool
      */
@@ -44,7 +41,8 @@ class InputFilterAbstractServiceFactory implements AbstractFactoryInterface
         }
 
         $config = $services->get('config');
-        if (! isset($config['input_filter_specs'][$rName])
+        if (
+            ! isset($config['input_filter_specs'][$rName])
             || ! is_array($config['input_filter_specs'][$rName])
         ) {
             return false;
@@ -56,9 +54,8 @@ class InputFilterAbstractServiceFactory implements AbstractFactoryInterface
     /**
      * Determine if we can create a service with name (v2)
      *
-     * @param ServiceLocatorInterface $container
-     * @param $name
-     * @param $requestedName
+     * @param string $name
+     * @param string $requestedName
      * @return bool
      */
     public function canCreateServiceWithName(ServiceLocatorInterface $container, $name, $requestedName)
@@ -74,7 +71,6 @@ class InputFilterAbstractServiceFactory implements AbstractFactoryInterface
     /**
      * Create the requested service (v2)
      *
-     * @param ServiceLocatorInterface $container
      * @param string                  $cName
      * @param string                  $rName
      * @return InputFilterInterface
@@ -90,7 +86,6 @@ class InputFilterAbstractServiceFactory implements AbstractFactoryInterface
     }
 
     /**
-     * @param ContainerInterface $container
      * @return Factory
      */
     protected function getInputFilterFactory(ContainerInterface $container)
@@ -113,7 +108,6 @@ class InputFilterAbstractServiceFactory implements AbstractFactoryInterface
     }
 
     /**
-     * @param ContainerInterface $container
      * @return FilterPluginManager
      */
     protected function getFilterPluginManager(ContainerInterface $container)
@@ -126,7 +120,6 @@ class InputFilterAbstractServiceFactory implements AbstractFactoryInterface
     }
 
     /**
-     * @param ContainerInterface $container
      * @return ValidatorPluginManager
      */
     protected function getValidatorPluginManager(ContainerInterface $container)

--- a/src/InputFilterAwareInterface.php
+++ b/src/InputFilterAwareInterface.php
@@ -7,7 +7,6 @@ interface InputFilterAwareInterface
     /**
      * Set input filter
      *
-     * @param  InputFilterInterface $inputFilter
      * @return InputFilterAwareInterface
      */
     public function setInputFilter(InputFilterInterface $inputFilter);

--- a/src/InputFilterAwareTrait.php
+++ b/src/InputFilterAwareTrait.php
@@ -4,15 +4,12 @@ namespace Laminas\InputFilter;
 
 trait InputFilterAwareTrait
 {
-    /**
-     * @var InputFilterInterface
-     */
-    protected $inputFilter = null;
+    /** @var InputFilterInterface */
+    protected $inputFilter;
 
     /**
      * Set input filter
      *
-     * @param InputFilterInterface $inputFilter
      * @return mixed
      */
     public function setInputFilter(InputFilterInterface $inputFilter)

--- a/src/InputFilterInterface.php
+++ b/src/InputFilterInterface.php
@@ -7,7 +7,7 @@ use Traversable;
 
 interface InputFilterInterface extends Countable
 {
-    const VALIDATE_ALL = 'INPUT_FILTER_ALL';
+    public const VALIDATE_ALL = 'INPUT_FILTER_ALL';
 
     /**
      * Add an input to the input filter
@@ -17,7 +17,7 @@ interface InputFilterInterface extends Countable
      *     raise an exception for any they cannot process.
      * @param  null|string $name Name used to retrieve this input
      * @return InputFilterInterface
-     * @throws Exception\InvalidArgumentException if unable to handle the input type.
+     * @throws Exception\InvalidArgumentException If unable to handle the input type.
      */
     public function add($input, $name = null);
 

--- a/src/InputFilterPluginManager.php
+++ b/src/InputFilterPluginManager.php
@@ -131,12 +131,12 @@ class InputFilterPluginManager extends AbstractPluginManager
     /**
      * {@inheritDoc} (v3)
      */
-    public function validate($plugin)
+    public function validate($instance)
     {
-        if ($plugin instanceof InputFilterInterface || $plugin instanceof InputInterface) {
+        if ($instance instanceof InputFilterInterface || $instance instanceof InputInterface) {
             // Hook to perform various initialization, when the inputFilter is not created through the factory
-            if ($plugin instanceof InitializableInterface) {
-                $plugin->init();
+            if ($instance instanceof InitializableInterface) {
+                $instance->init();
             }
 
             // we're okay
@@ -145,7 +145,7 @@ class InputFilterPluginManager extends AbstractPluginManager
 
         throw new InvalidServiceException(sprintf(
             'Plugin of type %s is invalid; must implement %s or %s',
-            is_object($plugin) ? get_class($plugin) : gettype($plugin),
+            is_object($instance) ? get_class($instance) : gettype($instance),
             InputFilterInterface::class,
             InputInterface::class
         ));

--- a/src/InputFilterPluginManager.php
+++ b/src/InputFilterPluginManager.php
@@ -4,9 +4,16 @@ namespace Laminas\InputFilter;
 
 use Interop\Container\ContainerInterface;
 use Laminas\ServiceManager\AbstractPluginManager;
+use Laminas\ServiceManager\ConfigInterface;
 use Laminas\ServiceManager\Exception\InvalidServiceException;
 use Laminas\ServiceManager\Factory\InvokableFactory;
 use Laminas\Stdlib\InitializableInterface;
+
+use function get_class;
+use function gettype;
+use function is_object;
+use function property_exists;
+use function sprintf;
 
 /**
  * Plugin manager implementation for input filters.
@@ -31,14 +38,14 @@ class InputFilterPluginManager extends AbstractPluginManager
         'OptionalInputFilter' => OptionalInputFilter::class,
 
         // Legacy Zend Framework aliases
-        \Zend\InputFilter\InputFilter::class => InputFilter::class,
+        \Zend\InputFilter\InputFilter::class           => InputFilter::class,
         \Zend\InputFilter\CollectionInputFilter::class => CollectionInputFilter::class,
-        \Zend\InputFilter\OptionalInputFilter::class => OptionalInputFilter::class,
+        \Zend\InputFilter\OptionalInputFilter::class   => OptionalInputFilter::class,
 
         // v2 normalized FQCNs
-        'zendinputfilterinputfilter' => InputFilter::class,
+        'zendinputfilterinputfilter'           => InputFilter::class,
         'zendinputfiltercollectioninputfilter' => CollectionInputFilter::class,
-        'zendinputfilteroptionalinputfilter' => OptionalInputFilter::class,
+        'zendinputfilteroptionalinputfilter'   => OptionalInputFilter::class,
     ];
 
     /**
@@ -47,13 +54,13 @@ class InputFilterPluginManager extends AbstractPluginManager
      * @var string[]
      */
     protected $factories = [
-        InputFilter::class                      => InvokableFactory::class,
-        CollectionInputFilter::class            => InvokableFactory::class,
-        OptionalInputFilter::class              => InvokableFactory::class,
+        InputFilter::class           => InvokableFactory::class,
+        CollectionInputFilter::class => InvokableFactory::class,
+        OptionalInputFilter::class   => InvokableFactory::class,
         // v2 canonical FQCN
-        'laminasinputfilterinputfilter'            => InvokableFactory::class,
-        'laminasinputfiltercollectioninputfilter'  => InvokableFactory::class,
-        'laminasinputfilteroptionalinputfilter'    => InvokableFactory::class,
+        'laminasinputfilterinputfilter'           => InvokableFactory::class,
+        'laminasinputfiltercollectioninputfilter' => InvokableFactory::class,
+        'laminasinputfilteroptionalinputfilter'   => InvokableFactory::class,
     ];
 
     /**
@@ -71,9 +78,9 @@ class InputFilterPluginManager extends AbstractPluginManager
     protected $shareByDefault = false;
 
     /**
-     * @param null|\Laminas\ServiceManager\ConfigInterface|ContainerInterface $configOrContainer
-     *     For laminas-servicemanager v2, null or a ConfigInterface instance are
-     *     allowed; for v3, a ContainerInterface is expected.
+     * @param null|ConfigInterface|ContainerInterface $configOrContainer For laminas-servicemanager v2,
+     *     null or a ConfigInterface instance are allowed; for v3, a
+     *     ContainerInterface is expected.
      * @param array $v3config Optional configuration array (laminas-servicemanager v3 only)
      */
     public function __construct($configOrContainer = null, array $v3config = [])
@@ -104,7 +111,6 @@ class InputFilterPluginManager extends AbstractPluginManager
     /**
      * Populate the filter and validator managers for the default filter/validator chains.
      *
-     * @param Factory $factory
      * @return void
      */
     public function populateFactoryPluginManagers(Factory $factory)
@@ -139,7 +145,7 @@ class InputFilterPluginManager extends AbstractPluginManager
 
         throw new InvalidServiceException(sprintf(
             'Plugin of type %s is invalid; must implement %s or %s',
-            (is_object($plugin) ? get_class($plugin) : gettype($plugin)),
+            is_object($plugin) ? get_class($plugin) : gettype($plugin),
             InputFilterInterface::class,
             InputInterface::class
         ));
@@ -153,7 +159,7 @@ class InputFilterPluginManager extends AbstractPluginManager
      *
      * @param  mixed                      $plugin
      * @return void
-     * @throws Exception\RuntimeException if invalid
+     * @throws Exception\RuntimeException If invalid.
      */
     public function validatePlugin($plugin)
     {

--- a/src/InputFilterPluginManagerFactory.php
+++ b/src/InputFilterPluginManagerFactory.php
@@ -7,12 +7,14 @@ use Laminas\ServiceManager\Config;
 use Laminas\ServiceManager\FactoryInterface;
 use Laminas\ServiceManager\ServiceLocatorInterface;
 
+use function is_array;
+
 class InputFilterPluginManagerFactory implements FactoryInterface
 {
     /**
      * laminas-servicemanager v2 support for invocation options.
      *
-     * @param array
+     * @var array
      */
     protected $creationOptions;
 
@@ -21,7 +23,7 @@ class InputFilterPluginManagerFactory implements FactoryInterface
      *
      * @return InputFilterPluginManager
      */
-    public function __invoke(ContainerInterface $container, $name, array $options = null)
+    public function __invoke(ContainerInterface $container, $name, ?array $options = null)
     {
         $pluginManager = new InputFilterPluginManager($container, $options ?: []);
 

--- a/src/InputFilterPluginManagerFactory.php
+++ b/src/InputFilterPluginManagerFactory.php
@@ -14,7 +14,7 @@ class InputFilterPluginManagerFactory implements FactoryInterface
     /**
      * laminas-servicemanager v2 support for invocation options.
      *
-     * @var array
+     * @var null|array
      */
     protected $creationOptions;
 

--- a/src/InputInterface.php
+++ b/src/InputInterface.php
@@ -28,7 +28,6 @@ interface InputInterface
     public function setErrorMessage($errorMessage);
 
     /**
-     * @param FilterChain $filterChain
      * @return self
      */
     public function setFilterChain(FilterChain $filterChain);
@@ -46,7 +45,6 @@ interface InputInterface
     public function setRequired($required);
 
     /**
-     * @param ValidatorChain $validatorChain
      * @return self
      */
     public function setValidatorChain(ValidatorChain $validatorChain);
@@ -58,7 +56,6 @@ interface InputInterface
     public function setValue($value);
 
     /**
-     * @param InputInterface $input
      * @return self
      */
     public function merge(InputInterface $input);

--- a/src/Module.php
+++ b/src/Module.php
@@ -2,10 +2,14 @@
 
 namespace Laminas\InputFilter;
 
+use Laminas\ModuleManager\ModuleManager;
+
 class Module
 {
     /**
      * Return default laminas-inputfilter configuration for laminas-mvc applications.
+     *
+     * @return array
      */
     public function getConfig()
     {
@@ -20,13 +24,13 @@ class Module
     /**
      * Register a specification for the InputFilterManager with the ServiceListener.
      *
-     * @param \Laminas\ModuleManager\ModuleManager $moduleManager
+     * @param ModuleManager $moduleManager
      * @return void
      */
     public function init($moduleManager)
     {
-        $event = $moduleManager->getEvent();
-        $container = $event->getParam('ServiceManager');
+        $event           = $moduleManager->getEvent();
+        $container       = $event->getParam('ServiceManager');
         $serviceListener = $container->get('ServiceListener');
 
         $serviceListener->addServiceManager(

--- a/src/ReplaceableInputInterface.php
+++ b/src/ReplaceableInputInterface.php
@@ -4,13 +4,12 @@ namespace Laminas\InputFilter;
 
 /**
  * Mark an input as able to be replaced by another when merging input filters.
- *
  */
 interface ReplaceableInputInterface
 {
     /**
-     * @param $input
-     * @param $name
+     * @param InputInterface $input
+     * @param string $name
      * @return self
      */
     public function replace($input, $name);

--- a/test/ArrayInputTest.php
+++ b/test/ArrayInputTest.php
@@ -4,6 +4,7 @@ namespace LaminasTest\InputFilter;
 
 use Laminas\InputFilter\ArrayInput;
 use Laminas\InputFilter\Exception\InvalidArgumentException;
+use Webmozart\Assert\Assert;
 
 use function array_map;
 use function array_pop;
@@ -72,6 +73,7 @@ class ArrayInputTest extends InputTest
     public function fallbackValueVsIsValidProvider(): array
     {
         $dataSets = parent::fallbackValueVsIsValidProvider();
+        Assert::isArray($dataSets);
         array_walk($dataSets, function (&$set) {
             $set[1] = [$set[1]]; // Wrap fallback value into an array.
             $set[2] = [$set[2]]; // Wrap value into an array.
@@ -90,6 +92,7 @@ class ArrayInputTest extends InputTest
     public function emptyValueProvider(): iterable
     {
         $dataSets = parent::emptyValueProvider();
+        Assert::isArray($dataSets);
         array_walk($dataSets, function (&$set) {
             $set['raw'] = [$set['raw']]; // Wrap value into an array.
         });
@@ -106,6 +109,7 @@ class ArrayInputTest extends InputTest
     public function mixedValueProvider(): array
     {
         $dataSets = parent::mixedValueProvider();
+        Assert::isArray($dataSets);
         array_walk($dataSets, function (&$set) {
             $set['raw'] = [$set['raw']]; // Wrap value into an array.
         });
@@ -115,7 +119,7 @@ class ArrayInputTest extends InputTest
 
     /**
      * @param array $valueMap
-     * @return FilterChain|MockObject
+     * @return FilterChain&MockObject
      */
     protected function createFilterChainMock(array $valueMap = [])
     {
@@ -139,7 +143,7 @@ class ArrayInputTest extends InputTest
     /**
      * @param array $valueMap
      * @param string[] $messages
-     * @return ValidatorChain|MockObject
+     * @return ValidatorChain&MockObject
      */
     protected function createValidatorChainMock(array $valueMap = [], $messages = [])
     {
@@ -161,7 +165,7 @@ class ArrayInputTest extends InputTest
      * @param bool $isValid
      * @param mixed $value
      * @param mixed $context
-     * @return NotEmptyValidator|MockObject
+     * @return NotEmptyValidator&MockObject
      */
     protected function createNonEmptyValidatorMock($isValid, $value, $context = null)
     {

--- a/test/ArrayInputTest.php
+++ b/test/ArrayInputTest.php
@@ -5,6 +5,12 @@ namespace LaminasTest\InputFilter;
 use Laminas\InputFilter\ArrayInput;
 use Laminas\InputFilter\Exception\InvalidArgumentException;
 
+use function array_map;
+use function array_pop;
+use function array_walk;
+use function current;
+use function is_array;
+
 /**
  * @covers \Laminas\InputFilter\ArrayInput
  */
@@ -54,7 +60,16 @@ class ArrayInputTest extends InputTest
         $this->input->setValue('bar');
     }
 
-    public function fallbackValueVsIsValidProvider()
+    /**
+     * @psalm-return array<string, array{
+     *     0: bool,
+     *     1: string[],
+     *     2: string[],
+     *     3: bool,
+     *     4: string[]
+     * }>
+     */
+    public function fallbackValueVsIsValidProvider(): array
     {
         $dataSets = parent::fallbackValueVsIsValidProvider();
         array_walk($dataSets, function (&$set) {
@@ -66,7 +81,13 @@ class ArrayInputTest extends InputTest
         return $dataSets;
     }
 
-    public function emptyValueProvider()
+    /**
+     * @psalm-return iterable<string, array{
+     *     raw: list<null|string|array>,
+     *     filtered: null|string|array
+     * }>
+     */
+    public function emptyValueProvider(): iterable
     {
         $dataSets = parent::emptyValueProvider();
         array_walk($dataSets, function (&$set) {
@@ -76,7 +97,13 @@ class ArrayInputTest extends InputTest
         return $dataSets;
     }
 
-    public function mixedValueProvider()
+    /**
+     * @psalm-return array<string, array{
+     *     raw: list<bool|int|float|string|list<string>|object>,
+     *     filtered:  bool|int|float|string|list<string>|object
+     * }>
+     */
+    public function mixedValueProvider(): array
     {
         $dataSets = parent::mixedValueProvider();
         array_walk($dataSets, function (&$set) {
@@ -86,6 +113,10 @@ class ArrayInputTest extends InputTest
         return $dataSets;
     }
 
+    /**
+     * @param array $valueMap
+     * @return FilterChain|MockObject
+     */
     protected function createFilterChainMock(array $valueMap = [])
     {
         // ArrayInput filters per each array value
@@ -105,6 +136,11 @@ class ArrayInputTest extends InputTest
         return parent::createFilterChainMock($valueMap);
     }
 
+    /**
+     * @param array $valueMap
+     * @param string[] $messages
+     * @return ValidatorChain|MockObject
+     */
     protected function createValidatorChainMock(array $valueMap = [], $messages = [])
     {
         // ArrayInput validates per each array value
@@ -121,6 +157,12 @@ class ArrayInputTest extends InputTest
         return parent::createValidatorChainMock($valueMap, $messages);
     }
 
+    /**
+     * @param bool $isValid
+     * @param mixed $value
+     * @param mixed $context
+     * @return NotEmptyValidator|MockObject
+     */
     protected function createNonEmptyValidatorMock($isValid, $value, $context = null)
     {
         // ArrayInput validates per each array value
@@ -131,7 +173,8 @@ class ArrayInputTest extends InputTest
         return parent::createNonEmptyValidatorMock($isValid, $value, $context);
     }
 
-    protected function getDummyValue($raw = true)
+    /** @return string[] */
+    protected function getDummyValue(bool $raw = true)
     {
         return [parent::getDummyValue($raw)];
     }

--- a/test/BaseInputFilterTest.php
+++ b/test/BaseInputFilterTest.php
@@ -131,7 +131,7 @@ class BaseInputFilterTest extends TestCase
     {
         $inputFilter = $this->inputFilter;
 
-        /** @var InputInterface|MockObject $nestedInput */
+        /** @var InputInterface&MockObject $nestedInput */
         $nestedInput = $this->createMock(InputInterface::class);
         $inputFilter->add($nestedInput, 'fooInput');
 
@@ -149,11 +149,11 @@ class BaseInputFilterTest extends TestCase
 
         $nestedInputFilter = new BaseInputFilter();
 
-        /** @var InputInterface|MockObject $nestedInput1 */
+        /** @var InputInterface&MockObject $nestedInput1 */
         $nestedInput1 = $this->createMock(InputInterface::class);
         $nestedInputFilter->add($nestedInput1, 'nested-input1');
 
-        /** @var InputInterface|MockObject $nestedInput2 */
+        /** @var InputInterface&MockObject $nestedInput2 */
         $nestedInput2 = $this->createMock(InputInterface::class);
         $nestedInputFilter->add($nestedInput2, 'nested-input2');
 
@@ -377,7 +377,7 @@ class BaseInputFilterTest extends TestCase
             ],
         ];
         $expectedData = array_merge($data, ['notSet' => null]);
-        /** @var Input|MockObject $flatInput */
+        /** @var Input&MockObject $flatInput */
         $flatInput = $this->getMockBuilder(Input::class)
             ->enableProxyingToOriginalMethods()
             ->setConstructorArgs(['flat'])
@@ -386,7 +386,7 @@ class BaseInputFilterTest extends TestCase
             ->method('setValue')
             ->with('foo');
         // Inputs without value must be reset for to have clean states when use different setData arguments
-        /** @var Input|MockObject $resetInput */
+        /** @var Input&MockObject $resetInput */
         $resetInput = $this->getMockBuilder(Input::class)
             ->enableProxyingToOriginalMethods()
             ->setConstructorArgs(['notSet'])
@@ -500,7 +500,7 @@ class BaseInputFilterTest extends TestCase
         $filter = $this->inputFilter;
 
         $optionalInputName = 'fooOptionalInput';
-        /** @var InputInterface|MockObject $optionalInput */
+        /** @var InputInterface&MockObject $optionalInput */
         $optionalInput = $this->createMock(InputInterface::class);
         $optionalInput->method('getName')
             ->willReturn($optionalInputName);
@@ -927,7 +927,7 @@ class BaseInputFilterTest extends TestCase
      * @param mixed[] $getRawValues
      * @param mixed[] $getValues
      * @param string[] $getMessages
-     * @return MockObject|InputFilterInterface
+     * @return MockObject&InputFilterInterface
      */
     protected function createInputFilterInterfaceMock(
         $isValid = null,
@@ -936,7 +936,7 @@ class BaseInputFilterTest extends TestCase
         $getValues = [],
         $getMessages = []
     ) {
-        /** @var InputFilterInterface|MockObject $inputFilter */
+        /** @var InputFilterInterface&MockObject $inputFilter */
         $inputFilter = $this->createMock(InputFilterInterface::class);
         $inputFilter->method('getRawValues')
             ->willReturn($getRawValues);
@@ -977,7 +977,7 @@ class BaseInputFilterTest extends TestCase
         $getMessages = [],
         $breakOnFailure = false
     ) {
-        /** @var InputInterface|MockObject $input */
+        /** @var InputInterface&MockObject $input */
         $input = $this->createMock(InputInterface::class);
         $input->method('getName')
             ->willReturn($name);

--- a/test/CollectionInputFilterTest.php
+++ b/test/CollectionInputFilterTest.php
@@ -18,6 +18,7 @@ use Laminas\Validator\NotEmpty;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use stdClass;
+use Traversable;
 
 use function array_merge;
 use function array_walk;
@@ -116,7 +117,7 @@ class CollectionInputFilterTest extends TestCase
         bool $required,
         ?int $count,
         array $data,
-        InputFilterInterface $inputFilter,
+        BaseInputFilter $inputFilter,
         array $expectedRaw,
         array $expectedValues,
         bool $expectedValid,
@@ -811,7 +812,6 @@ class CollectionInputFilterTest extends TestCase
         $baseInputFilter = (new BaseInputFilter())
             ->add(new Input(), 'bar');
 
-        /** @var CollectionInputFilter $collectionInputFilter */
         $collectionInputFilter = (new CollectionInputFilter())->setInputFilter($baseInputFilter);
         $collectionInputFilter->setData($unfilteredArray);
 

--- a/test/ConfigProviderTest.php
+++ b/test/ConfigProviderTest.php
@@ -15,9 +15,9 @@ final class ConfigProviderTest extends TestCase
         $provider = new ConfigProvider();
 
         $expected = [
-            'aliases' => [
-                'InputFilterManager' => InputFilterPluginManager::class,
-                'Zend\InputFilter\InputFilterPluginManager' => InputFilterPluginManager::class,
+            'aliases'   => [
+                'InputFilterManager'                              => InputFilterPluginManager::class,
+                \Zend\InputFilter\InputFilterPluginManager::class => InputFilterPluginManager::class,
             ],
             'factories' => [
                 InputFilterPluginManager::class => InputFilterPluginManagerFactory::class,
@@ -45,7 +45,7 @@ final class ConfigProviderTest extends TestCase
         $provider = new ConfigProvider();
 
         $expected = [
-            'dependencies' => $provider->getDependencyConfig(),
+            'dependencies'  => $provider->getDependencyConfig(),
             'input_filters' => $provider->getInputFilterConfig(),
         ];
         $this->assertEquals($expected, $provider());

--- a/test/FactoryTest.php
+++ b/test/FactoryTest.php
@@ -17,11 +17,15 @@ use Laminas\InputFilter\InputInterface;
 use Laminas\InputFilter\InputProviderInterface;
 use Laminas\ServiceManager;
 use Laminas\Validator;
-use PHPUnit\Framework\TestCase;
+use LaminasTest\InputFilter\TestAsset\CustomInput;
 use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 use ReflectionProperty;
+
+use function count;
+use function sprintf;
 
 /**
  * @covers \Laminas\InputFilter\Factory
@@ -68,7 +72,7 @@ class FactoryTest extends TestCase
         $pluginManager = $this->getMockBuilder(InputFilterPluginManager::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $factory = new Factory();
+        $factory       = new Factory();
         $factory->setInputFilterManager($pluginManager);
         $this->assertSame($pluginManager, $factory->getInputFilterManager());
     }
@@ -78,20 +82,20 @@ class FactoryTest extends TestCase
         $pluginManager = $this->getMockBuilder(InputFilterPluginManager::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $factory = new Factory($pluginManager);
+        $factory       = new Factory($pluginManager);
         $this->assertSame($pluginManager, $factory->getInputFilterManager());
     }
 
     public function testCreateInputWithTypeAsAnInvalidPluginInstanceThrowException()
     {
-        $type = 'fooPlugin';
+        $type          = 'fooPlugin';
         $pluginManager = $this->createInputFilterPluginManagerMockForPlugin($type, 'invalid_value');
-        $factory = new Factory($pluginManager);
+        $factory       = new Factory($pluginManager);
 
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage(
-            'Input factory expects the "type" to be a class implementing Laminas\InputFilter\InputInterface; ' .
-            'received "fooPlugin"'
+            'Input factory expects the "type" to be a class implementing Laminas\InputFilter\InputInterface; '
+            . 'received "fooPlugin"'
         );
         $factory->createInput([
             'type' => $type,
@@ -101,12 +105,12 @@ class FactoryTest extends TestCase
     public function testCreateInputWithTypeAsAnInvalidClassInstanceThrowException()
     {
         $factory = $this->createDefaultFactory();
-        $type = 'stdClass';
+        $type    = 'stdClass';
 
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage(
-            'Input factory expects the "type" to be a class implementing Laminas\InputFilter\InputInterface; ' .
-            'received "stdClass"'
+            'Input factory expects the "type" to be a class implementing Laminas\InputFilter\InputInterface; '
+            . 'received "stdClass"'
         );
         $factory->createInput([
             'type' => $type,
@@ -137,7 +141,7 @@ class FactoryTest extends TestCase
             'filters' => [
                 [
                     // empty
-                ]
+                ],
             ],
         ]);
     }
@@ -163,8 +167,8 @@ class FactoryTest extends TestCase
 
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage(
-            'expects the value associated with "validators" to be an array/Traversable of validators or validator ' .
-            'specifications, or a ValidatorChain; received "string"'
+            'expects the value associated with "validators" to be an array/Traversable of validators or validator '
+            . 'specifications, or a ValidatorChain; received "string"'
         );
         $factory->createInput([
             'validators' => 'invalid_value',
@@ -181,27 +185,28 @@ class FactoryTest extends TestCase
             'validators' => [
                 [
                     // empty
-                ]
+                ],
             ],
         ]);
     }
 
-    public function inputTypeSpecificationProvider()
+    /** @psalm-return array<string, array{0: string}> */
+    public function inputTypeSpecificationProvider(): array
     {
         return [
             // Description => [$specificationKey]
             'continue_if_empty' => ['continue_if_empty'],
-            'fallback_value' => ['fallback_value'],
+            'fallback_value'    => ['fallback_value'],
         ];
     }
 
     /**
      * @dataProvider inputTypeSpecificationProvider
      */
-    public function testCreateInputWithSpecificInputTypeSettingsThrowException($specificationKey)
+    public function testCreateInputWithSpecificInputTypeSettingsThrowException(string $specificationKey)
     {
         $factory = $this->createDefaultFactory();
-        $type = 'pluginInputInterface';
+        $type    = 'pluginInputInterface';
 
         $pluginManager = $this->createInputFilterPluginManagerMockForPlugin(
             $type,
@@ -214,7 +219,7 @@ class FactoryTest extends TestCase
             sprintf('"%s" can only set to inputs of type "Laminas\InputFilter\Input"', $specificationKey)
         );
         $factory->createInput([
-            'type' => $type,
+            'type'            => $type,
             $specificationKey => true,
         ]);
     }
@@ -292,7 +297,7 @@ class FactoryTest extends TestCase
 
     public function testFactoryUsesComposedValidatorChainWhenCreatingNewInputObjects()
     {
-        $smMock = $this->createMock(ContainerInterface::class);
+        $smMock           = $this->createMock(ContainerInterface::class);
         $factory          = $this->createDefaultFactory();
         $validatorChain   = new Validator\ValidatorChain();
         $validatorPlugins = new Validator\ValidatorPluginManager($smMock);
@@ -311,7 +316,7 @@ class FactoryTest extends TestCase
     public function testFactoryInjectsComposedFilterAndValidatorChainsIntoInputObjectsWhenCreatingNewInputFilterObjects()
     {
         // @codingStandardsIgnoreEnd
-        $smMock = $this->createMock(ContainerInterface::class);
+        $smMock           = $this->createMock(ContainerInterface::class);
         $factory          = $this->createDefaultFactory();
         $filterPlugins    = new Filter\FilterPluginManager($smMock);
         $validatorPlugins = new Validator\ValidatorPluginManager($smMock);
@@ -341,7 +346,7 @@ class FactoryTest extends TestCase
     {
         $factory      = $this->createDefaultFactory();
         $htmlEntities = new Filter\HtmlEntities();
-        $input = $factory->createInput([
+        $input        = $factory->createInput([
             'name'    => 'foo',
             'filters' => [
                 [
@@ -349,7 +354,7 @@ class FactoryTest extends TestCase
                 ],
                 $htmlEntities,
                 [
-                    'name' => Filter\StringToLower::class,
+                    'name'    => Filter\StringToLower::class,
                     'options' => [
                         'encoding' => 'ISO-8859-1',
                     ],
@@ -383,7 +388,7 @@ class FactoryTest extends TestCase
     {
         $factory = $this->createDefaultFactory();
         $digits  = new Validator\Digits();
-        $input = $factory->createInput([
+        $input   = $factory->createInput([
             'name'       => 'foo',
             'validators' => [
                 [
@@ -391,7 +396,7 @@ class FactoryTest extends TestCase
                 ],
                 $digits,
                 [
-                    'name' => Validator\StringLength::class,
+                    'name'    => Validator\StringLength::class,
                     'options' => [
                         'min' => 3,
                         'max' => 5,
@@ -430,8 +435,8 @@ class FactoryTest extends TestCase
     {
         $factory = $this->createDefaultFactory();
         $input   = $factory->createInput([
-            'name'     => 'foo',
-            'required' => false,
+            'name'        => 'foo',
+            'required'    => false,
             'allow_empty' => false,
         ]);
         $this->assertInstanceOf(InputInterface::class, $input);
@@ -455,7 +460,7 @@ class FactoryTest extends TestCase
     {
         $factory = $this->createDefaultFactory();
         $input   = $factory->createInput([
-            'name'        => 'foo',
+            'name' => 'foo',
         ]);
         $this->assertInstanceOf(InputInterface::class, $input);
         $this->assertEquals('foo', $input->getName());
@@ -464,7 +469,7 @@ class FactoryTest extends TestCase
     public function testFactoryWillCreateInputWithContinueIfEmptyFlag()
     {
         $factory = $this->createDefaultFactory();
-        $input = $factory->createInput([
+        $input   = $factory->createInput([
             'name'              => 'foo',
             'continue_if_empty' => true,
         ]);
@@ -475,7 +480,7 @@ class FactoryTest extends TestCase
     public function testFactoryAcceptsInputInterface()
     {
         $factory = $this->createDefaultFactory();
-        $input = new Input();
+        $input   = new Input();
 
         $inputFilter = $factory->createInputFilter([
             'foo' => $input,
@@ -489,7 +494,7 @@ class FactoryTest extends TestCase
     public function testFactoryAcceptsInputFilterInterface()
     {
         $factory = $this->createDefaultFactory();
-        $input = new InputFilter();
+        $input   = new InputFilter();
 
         $inputFilter = $factory->createInputFilter([
             'foo' => $input,
@@ -504,7 +509,7 @@ class FactoryTest extends TestCase
     {
         $factory     = $this->createDefaultFactory();
         $inputFilter = $factory->createInputFilter([
-            'foo' => [
+            'foo'  => [
                 'name'       => 'foo',
                 'required'   => false,
                 'validators' => [
@@ -512,7 +517,7 @@ class FactoryTest extends TestCase
                         'name' => Validator\NotEmpty::class,
                     ],
                     [
-                        'name' => Validator\StringLength::class,
+                        'name'    => Validator\StringLength::class,
                         'options' => [
                             'min' => 3,
                             'max' => 5,
@@ -520,23 +525,23 @@ class FactoryTest extends TestCase
                     ],
                 ],
             ],
-            'bar' => [
+            'bar'  => [
                 'allow_empty' => true,
                 'filters'     => [
                     [
                         'name' => Filter\StringTrim::class,
                     ],
                     [
-                        'name' => Filter\StringToLower::class,
+                        'name'    => Filter\StringToLower::class,
                         'options' => [
                             'encoding' => 'ISO-8859-1',
                         ],
                     ],
                 ],
             ],
-            'baz' => [
-                'type'   => InputFilter::class,
-                'foo' => [
+            'baz'  => [
+                'type' => InputFilter::class,
+                'foo'  => [
                     'name'       => 'foo',
                     'required'   => false,
                     'validators' => [
@@ -544,7 +549,7 @@ class FactoryTest extends TestCase
                             'name' => Validator\NotEmpty::class,
                         ],
                         [
-                            'name' => Validator\StringLength::class,
+                            'name'    => Validator\StringLength::class,
                             'options' => [
                                 'min' => 3,
                                 'max' => 5,
@@ -552,14 +557,14 @@ class FactoryTest extends TestCase
                         ],
                     ],
                 ],
-                'bar' => [
+                'bar'  => [
                     'allow_empty' => true,
                     'filters'     => [
                         [
                             'name' => Filter\StringTrim::class,
                         ],
                         [
-                            'name' => Filter\StringToLower::class,
+                            'name'    => Filter\StringToLower::class,
                             'options' => [
                                 'encoding' => 'ISO-8859-1',
                             ],
@@ -567,12 +572,12 @@ class FactoryTest extends TestCase
                     ],
                 ],
             ],
-            'bat' => [
-                'type' => 'LaminasTest\InputFilter\TestAsset\CustomInput',
+            'bat'  => [
+                'type' => CustomInput::class,
                 'name' => 'bat',
             ],
             'zomg' => [
-                'name' => 'zomg',
+                'name'              => 'zomg',
                 'continue_if_empty' => true,
             ],
         ]);
@@ -606,7 +611,7 @@ class FactoryTest extends TestCase
                     $this->assertEquals(2, count($bar->getFilterChain()));
                     break;
                 case 'bat':
-                    $this->assertInstanceOf('LaminasTest\InputFilter\TestAsset\CustomInput', $input);
+                    $this->assertInstanceOf(CustomInput::class, $input);
                     $this->assertEquals('bat', $input->getName());
                     break;
                 case 'zomg':
@@ -689,15 +694,15 @@ class FactoryTest extends TestCase
             'name'    => 'foo',
             'filters' => [
                 [
-                    'name'      => 'StringTrim',
-                    'priority'  => Filter\FilterChain::DEFAULT_PRIORITY - 1, // 999
+                    'name'     => 'StringTrim',
+                    'priority' => Filter\FilterChain::DEFAULT_PRIORITY - 1, // 999
                 ],
                 [
-                    'name'      => 'StringToUpper',
-                    'priority'  => Filter\FilterChain::DEFAULT_PRIORITY + 1, //1001
+                    'name'     => 'StringToUpper',
+                    'priority' => Filter\FilterChain::DEFAULT_PRIORITY + 1, //1001
                 ],
                 [
-                    'name'      => 'StringToLower', // default priority 1000
+                    'name' => 'StringToLower', // default priority 1000
                 ],
             ],
         ]);
@@ -738,7 +743,7 @@ class FactoryTest extends TestCase
                 [
                     'name'     => 'Callback',
                     'priority' => Validator\ValidatorChain::DEFAULT_PRIORITY - 1, // 0
-                    'options' => [
+                    'options'  => [
                         'callback' => static function ($value) use (&$order) {
                             static::assertSame(2, $order);
                             ++$order;
@@ -760,8 +765,8 @@ class FactoryTest extends TestCase
                     ],
                 ],
                 [
-                    'name'     => 'Callback', // default priority 1
-                    'options'  => [
+                    'name'    => 'Callback', // default priority 1
+                    'options' => [
                         'callback' => static function ($value) use (&$order) {
                             static::assertSame(1, $order);
                             ++$order;
@@ -788,7 +793,7 @@ class FactoryTest extends TestCase
             [
                 'type' => [
                     'required' => true,
-                ]
+                ],
             ]
         );
 
@@ -801,7 +806,7 @@ class FactoryTest extends TestCase
         $factory = new TestAsset\CustomFactory();
         /** @var CollectionInputFilter $inputFilter */
         $inputFilter = $factory->createInputFilter([
-            'type'        => 'collection',
+            'type'         => 'collection',
             'input_filter' => new InputFilter(),
         ]);
         $this->assertInstanceOf(TestAsset\CustomFactory::class, $inputFilter->getFactory());
@@ -823,7 +828,7 @@ class FactoryTest extends TestCase
 
     public function testSetInputFilterManagerWithServiceManager()
     {
-        $serviceManager = new ServiceManager\ServiceManager;
+        $serviceManager     = new ServiceManager\ServiceManager();
         $inputFilterManager = new InputFilterPluginManager($serviceManager);
         $serviceManager->setService('ValidatorManager', new Validator\ValidatorPluginManager($serviceManager));
         $serviceManager->setService('FilterManager', new Filter\FilterPluginManager($serviceManager));
@@ -840,23 +845,22 @@ class FactoryTest extends TestCase
 
     public function testSetInputFilterManagerWithoutServiceManager()
     {
-        $smMock = $this->createMock(ContainerInterface::class);
+        $smMock             = $this->createMock(ContainerInterface::class);
         $inputFilterManager = new InputFilterPluginManager($smMock);
-        $factory = new Factory($inputFilterManager);
+        $factory            = new Factory($inputFilterManager);
         $this->assertSame($inputFilterManager, $factory->getInputFilterManager());
     }
 
     public function testSetInputFilterManagerOnConstruct()
     {
-        $smMock = $this->createMock(ContainerInterface::class);
+        $smMock             = $this->createMock(ContainerInterface::class);
         $inputFilterManager = new InputFilterPluginManager($smMock);
-        $factory = new Factory($inputFilterManager);
+        $factory            = new Factory($inputFilterManager);
         $this->assertSame($inputFilterManager, $factory->getInputFilterManager());
     }
 
     /**
      * @group 5691
-     *
      * @covers \Laminas\InputFilter\Factory::createInput
      */
     public function testSetsBreakChainOnFailure()
@@ -925,12 +929,12 @@ class FactoryTest extends TestCase
             ->method('getInputFilterSpecification')
             ->will($this->returnValue([
                 'foo' => [
-                    'name'       => 'foo',
-                    'required'   => false,
+                    'name'     => 'foo',
+                    'required' => false,
                 ],
                 'baz' => [
-                    'name'       => 'baz',
-                    'required'   => true,
+                    'name'     => 'baz',
+                    'required' => true,
                 ],
             ]));
 
@@ -943,7 +947,7 @@ class FactoryTest extends TestCase
     public function testSuggestedTypeMayBePluginNameInInputFilterPluginManager()
     {
         $serviceManager = new ServiceManager\ServiceManager();
-        $pluginManager = new InputFilterPluginManager($serviceManager);
+        $pluginManager  = new InputFilterPluginManager($serviceManager);
         $pluginManager->setService('bar', new Input('bar'));
         $factory = new Factory($pluginManager);
 
@@ -962,7 +966,7 @@ class FactoryTest extends TestCase
         $factory->setInputFilterManager($pluginManager);
 
         $input = $factory->createInput([
-            'type' => 'bar',
+            'type'     => 'bar',
             'required' => false,
         ]);
 
@@ -972,7 +976,7 @@ class FactoryTest extends TestCase
 
     public function testCreateInputFilterConfiguredNameWhenSpecIsIntegerIndexed()
     {
-        $factory = $this->createDefaultFactory();
+        $factory     = $this->createDefaultFactory();
         $inputFilter = $factory->createInputFilter([
             1 => [
                 'type' => InputFilter::class,
@@ -985,7 +989,7 @@ class FactoryTest extends TestCase
 
     public function testCreateInputFilterUsesAssociatedNameMappingOverConfiguredName()
     {
-        $factory = $this->createDefaultFactory();
+        $factory     = $this->createDefaultFactory();
         $inputFilter = $factory->createInputFilter([
             'foo' => [
                 'type' => InputFilter::class,
@@ -999,21 +1003,21 @@ class FactoryTest extends TestCase
 
     public function testCreateInputFilterUsesConfiguredNameForNestedInputFilters()
     {
-        $factory = $this->createDefaultFactory();
+        $factory     = $this->createDefaultFactory();
         $inputFilter = $factory->createInputFilter([
             0 => [
                 'type' => InputFilter::class,
                 'name' => 'bar',
-                '0' => [
+                '0'    => [
                     'name' => 'bat',
                 ],
-                '1' => [
+                '1'    => [
                     'name' => 'baz',
                 ],
             ],
             1 => [
-                'type' => CollectionInputFilter::class,
-                'name' => 'foo',
+                'type'         => CollectionInputFilter::class,
+                'name'         => 'foo',
                 'input_filter' => [
                     '0' => [
                         'name' => 'bat',
@@ -1059,7 +1063,6 @@ class FactoryTest extends TestCase
      */
     public function testWhenCreateInputPullsInputFromThePluginManagerItMustNotOverwriteFilterAndValidatorChains()
     {
-
         $input = $this->prophesize(InputInterface::class);
         $input->setFilterChain(Argument::any())->shouldNotBeCalled();
         $input->setValidatorChain(Argument::any())->shouldNotBeCalled();
@@ -1126,7 +1129,6 @@ class FactoryTest extends TestCase
     /**
      * @param string $pluginName
      * @param mixed $pluginValue
-     *
      * @return MockObject|InputFilterPluginManager
      */
     protected function createInputFilterPluginManagerMockForPlugin($pluginName, $pluginValue)
@@ -1139,13 +1141,11 @@ class FactoryTest extends TestCase
         $pluginManager->expects($this->atLeastOnce())
             ->method('has')
             ->with($pluginName)
-            ->willReturn(true)
-        ;
+            ->willReturn(true);
         $pluginManager->expects($this->atLeastOnce())
             ->method('get')
             ->with($pluginName)
-            ->willReturn($pluginValue)
-        ;
+            ->willReturn($pluginValue);
         return $pluginManager;
     }
 }

--- a/test/FactoryTest.php
+++ b/test/FactoryTest.php
@@ -744,7 +744,7 @@ class FactoryTest extends TestCase
                     'name'     => 'Callback',
                     'priority' => Validator\ValidatorChain::DEFAULT_PRIORITY - 1, // 0
                     'options'  => [
-                        'callback' => static function ($value) use (&$order) {
+                        'callback' => static function () use (&$order) {
                             static::assertSame(2, $order);
                             ++$order;
 
@@ -756,7 +756,7 @@ class FactoryTest extends TestCase
                     'name'     => 'Callback',
                     'priority' => Validator\ValidatorChain::DEFAULT_PRIORITY + 1, // 2
                     'options'  => [
-                        'callback' => static function ($value) use (&$order) {
+                        'callback' => static function () use (&$order) {
                             static::assertSame(0, $order);
                             ++$order;
 
@@ -767,7 +767,7 @@ class FactoryTest extends TestCase
                 [
                     'name'    => 'Callback', // default priority 1
                     'options' => [
-                        'callback' => static function ($value) use (&$order) {
+                        'callback' => static function () use (&$order) {
                             static::assertSame(1, $order);
                             ++$order;
 

--- a/test/FileInput/HttpServerFileInputDecoratorTest.php
+++ b/test/FileInput/HttpServerFileInputDecoratorTest.php
@@ -7,6 +7,12 @@ use Laminas\InputFilter\FileInput\HttpServerFileInputDecorator;
 use Laminas\Validator;
 use LaminasTest\InputFilter\InputTest;
 
+use function count;
+use function json_encode;
+
+use const UPLOAD_ERR_NO_FILE;
+use const UPLOAD_ERR_OK;
+
 /**
  * @covers \Laminas\InputFilter\FileInput\HttpServerFileInputDecorator
  * @covers \Laminas\InputFilter\FileInput
@@ -53,7 +59,7 @@ class HttpServerFileInputDecoratorTest extends InputTest
         ];
         $this->input->setValue($values);
 
-        $newValue = ['tmp_name' => 'new'];
+        $newValue      = ['tmp_name' => 'new'];
         $filteredValue = [$newValue, $newValue, $newValue];
         $this->input->setFilterChain($this->createFilterChainMock([
             [$values[0], $newValue],
@@ -182,10 +188,10 @@ class HttpServerFileInputDecoratorTest extends InputTest
 
         $expectedNormalizedValue = [
             'tmp_name' => '',
-            'name' => '',
-            'size' => 0,
-            'type' => '',
-            'error' => UPLOAD_ERR_NO_FILE,
+            'name'     => '',
+            'size'     => 0,
+            'type'     => '',
+            'error'    => UPLOAD_ERR_NO_FILE,
         ];
         $this->input->setValidatorChain($this->createValidatorChainMock([[$expectedNormalizedValue, null, false]]));
         $this->assertFalse($this->input->isValid());
@@ -208,29 +214,36 @@ class HttpServerFileInputDecoratorTest extends InputTest
         $this->assertFalse($this->input->isValid());
     }
 
+    /** @param mixed $value */
     public function testNotEmptyValidatorAddedWhenIsValidIsCalled($value = null)
     {
         $this->markTestSkipped('Test is not enabled in FileInputTest');
     }
 
+    /** @param mixed $value */
     public function testRequiredNotEmptyValidatorNotAddedWhenOneExists($value = null)
     {
         $this->markTestSkipped('Test is not enabled in FileInputTest');
     }
 
+    /**
+     * @param null|string|string[] $fallbackValue
+     * @param null|string|string[] $originalValue
+     * @param null|string|string[] $expectedValue
+     */
     public function testFallbackValueVsIsValidRules(
-        $required = null,
+        ?bool $required = null,
         $fallbackValue = null,
         $originalValue = null,
-        $isValid = null,
+        ?bool $isValid = null,
         $expectedValue = null
     ) {
         $this->markTestSkipped('Input::setFallbackValue is not implemented on FileInput');
     }
 
-
+    /** @param null|string|string[] $fallbackValue */
     public function testFallbackValueVsIsValidRulesWhenValueNotSet(
-        $required = null,
+        ?bool $required = null,
         $fallbackValue = null
     ) {
         $this->markTestSkipped('Input::setFallbackValue is not implemented on FileInput');
@@ -246,7 +259,7 @@ class HttpServerFileInputDecoratorTest extends InputTest
     {
         $rawValue = [
             'tmp_name' => '',
-            'error' => \UPLOAD_ERR_NO_FILE,
+            'error'    => UPLOAD_ERR_NO_FILE,
         ];
         $this->assertTrue($this->input->isEmptyFile($rawValue));
     }
@@ -255,17 +268,19 @@ class HttpServerFileInputDecoratorTest extends InputTest
     {
         $rawValue = [
             'tmp_name' => 'name',
-            'error' => \UPLOAD_ERR_OK,
+            'error'    => UPLOAD_ERR_OK,
         ];
         $this->assertFalse($this->input->isEmptyFile($rawValue));
     }
 
     public function testIsEmptyMultiFileUploadNoFile()
     {
-        $rawValue = [[
-            'tmp_name' => 'foo',
-            'error'    => \UPLOAD_ERR_NO_FILE,
-        ]];
+        $rawValue = [
+            [
+                'tmp_name' => 'foo',
+                'error'    => UPLOAD_ERR_NO_FILE,
+            ],
+        ];
         $this->assertTrue($this->input->isEmptyFile($rawValue));
     }
 
@@ -274,11 +289,11 @@ class HttpServerFileInputDecoratorTest extends InputTest
         $rawValue = [
             [
                 'tmp_name' => 'foo',
-                'error'    => \UPLOAD_ERR_OK,
+                'error'    => UPLOAD_ERR_OK,
             ],
             [
                 'tmp_name' => 'bar',
-                'error'    => \UPLOAD_ERR_OK,
+                'error'    => UPLOAD_ERR_OK,
             ],
         ];
         $this->assertFalse($this->input->isEmptyFile($rawValue));
@@ -286,9 +301,9 @@ class HttpServerFileInputDecoratorTest extends InputTest
 
     public function testDefaultInjectedUploadValidatorRespectsRelease2Convention()
     {
-        $input = new FileInput('foo');
+        $input          = new FileInput('foo');
         $validatorChain = $input->getValidatorChain();
-        $pluginManager = $validatorChain->getPluginManager();
+        $pluginManager  = $validatorChain->getPluginManager();
         $pluginManager->setInvokableClass('fileuploadfile', TestAsset\FileUploadMock::class);
         $input->setValue('');
 
@@ -316,7 +331,7 @@ class HttpServerFileInputDecoratorTest extends InputTest
         );
     }
 
-    public function isRequiredVsAllowEmptyVsContinueIfEmptyVsIsValidProvider()
+    public function isRequiredVsAllowEmptyVsContinueIfEmptyVsIsValidProvider(): iterable
     {
         $dataSets = parent::isRequiredVsAllowEmptyVsContinueIfEmptyVsIsValidProvider();
 
@@ -328,58 +343,58 @@ class HttpServerFileInputDecoratorTest extends InputTest
         return $dataSets;
     }
 
-    public function emptyValueProvider()
+    public function emptyValueProvider(): iterable
     {
         return [
             'tmp_name' => [
-                'raw' => 'file',
+                'raw'      => 'file',
                 'filtered' => [
                     'tmp_name' => 'file',
-                    'name' => 'file',
-                    'size' => 0,
-                    'type' => '',
-                    'error' => UPLOAD_ERR_NO_FILE,
+                    'name'     => 'file',
+                    'size'     => 0,
+                    'type'     => '',
+                    'error'    => UPLOAD_ERR_NO_FILE,
                 ],
             ],
-            'single' => [
-                'raw' => [
+            'single'   => [
+                'raw'      => [
                     'tmp_name' => '',
-                    'error' => UPLOAD_ERR_NO_FILE,
+                    'error'    => UPLOAD_ERR_NO_FILE,
                 ],
                 'filtered' => [
                     'tmp_name' => '',
-                    'error' => UPLOAD_ERR_NO_FILE,
+                    'error'    => UPLOAD_ERR_NO_FILE,
                 ],
             ],
-            'multi' => [
-                'raw' => [
+            'multi'    => [
+                'raw'      => [
                     [
                         'tmp_name' => 'foo',
-                        'error' => UPLOAD_ERR_NO_FILE,
+                        'error'    => UPLOAD_ERR_NO_FILE,
                     ],
                 ],
                 'filtered' => [
                     'tmp_name' => 'foo',
-                    'error' => UPLOAD_ERR_NO_FILE,
+                    'error'    => UPLOAD_ERR_NO_FILE,
                 ],
             ],
         ];
     }
 
-    public function mixedValueProvider()
+    public function mixedValueProvider(): array
     {
         $fooUploadErrOk = [
             'tmp_name' => 'foo',
-            'error' => UPLOAD_ERR_OK,
+            'error'    => UPLOAD_ERR_OK,
         ];
 
         return [
             'single' => [
-                'raw' => $fooUploadErrOk,
+                'raw'      => $fooUploadErrOk,
                 'filtered' => $fooUploadErrOk,
             ],
-            'multi' => [
-                'raw' => [
+            'multi'  => [
+                'raw'      => [
                     $fooUploadErrOk,
                 ],
                 'filtered' => $fooUploadErrOk,
@@ -387,7 +402,8 @@ class HttpServerFileInputDecoratorTest extends InputTest
         ];
     }
 
-    protected function getDummyValue($raw = true)
+    /** @return array<string, string> */
+    protected function getDummyValue(bool $raw = true)
     {
         return ['tmp_name' => 'bar'];
     }

--- a/test/FileInput/HttpServerFileInputDecoratorTest.php
+++ b/test/FileInput/HttpServerFileInputDecoratorTest.php
@@ -6,6 +6,7 @@ use Laminas\InputFilter\FileInput;
 use Laminas\InputFilter\FileInput\HttpServerFileInputDecorator;
 use Laminas\Validator;
 use LaminasTest\InputFilter\InputTest;
+use Webmozart\Assert\Assert;
 
 use function count;
 use function json_encode;
@@ -334,6 +335,7 @@ class HttpServerFileInputDecoratorTest extends InputTest
     public function isRequiredVsAllowEmptyVsContinueIfEmptyVsIsValidProvider(): iterable
     {
         $dataSets = parent::isRequiredVsAllowEmptyVsContinueIfEmptyVsIsValidProvider();
+        Assert::isArrayAccessible($dataSets);
 
         // FileInput do not use NotEmpty validator so the only validator present in the chain is the custom one.
         unset($dataSets['Required: T; AEmpty: F; CIEmpty: F; Validator: X, Value: Empty / tmp_name']);

--- a/test/FileInput/PsrFileInputDecoratorTest.php
+++ b/test/FileInput/PsrFileInputDecoratorTest.php
@@ -10,6 +10,15 @@ use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Http\Message\UploadedFileInterface;
 
+use function count;
+use function in_array;
+use function is_array;
+use function json_encode;
+
+use const UPLOAD_ERR_CANT_WRITE;
+use const UPLOAD_ERR_NO_FILE;
+use const UPLOAD_ERR_OK;
+
 /**
  * @covers \Laminas\InputFilter\FileInput\PsrFileInputDecorator
  * @covers \Laminas\InputFilter\FileInput
@@ -42,10 +51,12 @@ class PsrFileInputDecoratorTest extends InputTest
 
         $filteredUpload = $this->prophesize(UploadedFileInterface::class);
 
-        $this->input->setFilterChain($this->createFilterChainMock([[
-            $upload->reveal(),
-            $filteredUpload->reveal(),
-        ]]));
+        $this->input->setFilterChain($this->createFilterChainMock([
+            [
+                $upload->reveal(),
+                $filteredUpload->reveal(),
+            ],
+        ]));
 
         $this->assertEquals($upload->reveal(), $this->input->getValue());
         $this->assertTrue(
@@ -68,7 +79,7 @@ class PsrFileInputDecoratorTest extends InputTest
 
         $filteredValues = [];
         for ($i = 0; $i < 3; $i += 1) {
-            $upload = $this->prophesize(UploadedFileInterface::class);
+            $upload           = $this->prophesize(UploadedFileInterface::class);
             $filteredValues[] = $upload->reveal();
         }
 
@@ -196,29 +207,36 @@ class PsrFileInputDecoratorTest extends InputTest
         $this->assertEquals($validator->reveal(), $validators[0]['instance']);
     }
 
+    /** @param mixed $value */
     public function testNotEmptyValidatorAddedWhenIsValidIsCalled($value = null)
     {
         $this->markTestSkipped('Test is not enabled in PsrFileInputTest');
     }
 
+    /** @param mixed $value */
     public function testRequiredNotEmptyValidatorNotAddedWhenOneExists($value = null)
     {
         $this->markTestSkipped('Test is not enabled in PsrFileInputTest');
     }
 
+    /**
+     * @param null|string|string[] $fallbackValue
+     * @param null|string|string[] $originalValue
+     * @param null|string|string[] $expectedValue
+     */
     public function testFallbackValueVsIsValidRules(
-        $required = null,
+        ?bool $required = null,
         $fallbackValue = null,
         $originalValue = null,
-        $isValid = null,
+        ?bool $isValid = null,
         $expectedValue = null
     ) {
         $this->markTestSkipped('Input::setFallbackValue is not implemented on PsrFileInput');
     }
 
-
+    /** @param null|string|string[] $fallbackValue */
     public function testFallbackValueVsIsValidRulesWhenValueNotSet(
-        $required = null,
+        ?bool $required = null,
         $fallbackValue = null
     ) {
         $this->markTestSkipped('Input::setFallbackValue is not implemented on PsrFileInput');
@@ -281,7 +299,18 @@ class PsrFileInputDecoratorTest extends InputTest
         );
     }
 
-    public function isRequiredVsAllowEmptyVsContinueIfEmptyVsIsValidProvider()
+    /**
+     * @psalm-return iterable<string, array{
+     *     0: bool,
+     *     1: bool,
+     *     2: bool,
+     *     3: callable,
+     *     4: mixed,
+     *     5: bool,
+     *     6: string[]
+     * }>
+     */
+    public function isRequiredVsAllowEmptyVsContinueIfEmptyVsIsValidProvider(): iterable
     {
         $generator = parent::isRequiredVsAllowEmptyVsContinueIfEmptyVsIsValidProvider();
         if (! is_array($generator)) {
@@ -303,7 +332,13 @@ class PsrFileInputDecoratorTest extends InputTest
         }
     }
 
-    public function emptyValueProvider()
+    /**
+     * @psalm-return iterable<string, array{
+     *     raw: UploadedFileInterface|list<UploadedFileInterface>,
+     *     filtered: UploadedFileInterface
+     * }>
+     */
+    public function emptyValueProvider(): iterable
     {
         foreach (['single', 'multi'] as $type) {
             $raw = $this->prophesize(UploadedFileInterface::class);
@@ -321,18 +356,24 @@ class PsrFileInputDecoratorTest extends InputTest
         }
     }
 
-    public function mixedValueProvider()
+    /**
+     * @psalm-return array<string, array{
+     *     raw: UploadedFileInterface|list<UploadedFileInterface>,
+     *     filtered: UploadedFileInterface
+     * }>
+     */
+    public function mixedValueProvider(): array
     {
         $fooUploadErrOk = $this->prophesize(UploadedFileInterface::class);
         $fooUploadErrOk->getError()->willReturn(UPLOAD_ERR_OK);
 
         return [
             'single' => [
-                'raw' => $fooUploadErrOk->reveal(),
+                'raw'      => $fooUploadErrOk->reveal(),
                 'filtered' => $fooUploadErrOk->reveal(),
             ],
-            'multi' => [
-                'raw' => [
+            'multi'  => [
+                'raw'      => [
                     $fooUploadErrOk->reveal(),
                 ],
                 'filtered' => $fooUploadErrOk->reveal(),
@@ -340,7 +381,8 @@ class PsrFileInputDecoratorTest extends InputTest
         ];
     }
 
-    protected function getDummyValue($raw = true)
+    /** @return UploadedFileInterface */
+    protected function getDummyValue(bool $raw = true)
     {
         $upload = $this->prophesize(UploadedFileInterface::class);
         $upload->getError()->willReturn(UPLOAD_ERR_OK);

--- a/test/FileInput/PsrFileInputDecoratorTest.php
+++ b/test/FileInput/PsrFileInputDecoratorTest.php
@@ -2,6 +2,7 @@
 
 namespace LaminasTest\InputFilter\FileInput;
 
+use Generator;
 use Laminas\InputFilter\FileInput;
 use Laminas\InputFilter\FileInput\PsrFileInputDecorator;
 use Laminas\Validator;
@@ -12,7 +13,6 @@ use Psr\Http\Message\UploadedFileInterface;
 
 use function count;
 use function in_array;
-use function is_array;
 use function json_encode;
 
 use const UPLOAD_ERR_CANT_WRITE;
@@ -313,7 +313,7 @@ class PsrFileInputDecoratorTest extends InputTest
     public function isRequiredVsAllowEmptyVsContinueIfEmptyVsIsValidProvider(): iterable
     {
         $generator = parent::isRequiredVsAllowEmptyVsContinueIfEmptyVsIsValidProvider();
-        if (! is_array($generator)) {
+        if ($generator instanceof Generator) {
             $generator = clone $generator;
             $generator->rewind();
         }

--- a/test/FileInput/TestAsset/FileUploadMock.php
+++ b/test/FileInput/TestAsset/FileUploadMock.php
@@ -6,11 +6,16 @@ use Laminas\Validator\ValidatorInterface;
 
 final class FileUploadMock implements ValidatorInterface
 {
+    /**
+     * @param mixed $value
+     * @return bool
+     */
     public function isValid($value)
     {
         return true;
     }
 
+    /** @return array */
     public function getMessages()
     {
         return [];

--- a/test/InputFilterAbstractServiceFactoryTest.php
+++ b/test/InputFilterAbstractServiceFactoryTest.php
@@ -102,7 +102,7 @@ class InputFilterAbstractServiceFactoryTest extends TestCase
     public function testUsesConfiguredValidationAndFilterManagerServicesWhenCreatingInputFilter()
     {
         $filters = new FilterPluginManager($this->services);
-        $filter  = function ($value) {
+        $filter  = function () {
         };
         $filters->setService('foo', $filter);
 
@@ -175,7 +175,7 @@ class InputFilterAbstractServiceFactoryTest extends TestCase
         $validators->setService('foo', $validator);
 
         $filters = new FilterPluginManager($this->services);
-        $filter  = function ($value) {
+        $filter  = function () {
         };
         $filters->setService('foo', $filter);
 

--- a/test/InputFilterAbstractServiceFactoryTest.php
+++ b/test/InputFilterAbstractServiceFactoryTest.php
@@ -12,9 +12,13 @@ use Laminas\ServiceManager\ServiceManager;
 use Laminas\Validator;
 use Laminas\Validator\ValidatorInterface;
 use Laminas\Validator\ValidatorPluginManager;
-use PHPUnit\Framework\TestCase;
+use LaminasTest\InputFilter\TestAsset\Foo;
 use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
+
+use function call_user_func_array;
+use function count;
 
 /**
  * @covers \Laminas\InputFilter\InputFilterAbstractServiceFactory
@@ -23,19 +27,13 @@ class InputFilterAbstractServiceFactoryTest extends TestCase
 {
     use ProphecyTrait;
 
-    /**
-     * @var ServiceManager
-     */
+    /** @var ServiceManager */
     protected $services;
 
-    /**
-     * @var InputFilterPluginManager
-    */
+    /** @var InputFilterPluginManager */
     protected $filters;
 
-    /**
-     * @var InputFilterAbstractServiceFactory
-     */
+    /** @var InputFilterAbstractServiceFactory */
     protected $factory;
 
     protected function setUp(): void
@@ -58,7 +56,7 @@ class InputFilterAbstractServiceFactoryTest extends TestCase
     {
         $this->services->setService('config', []);
         $method = 'canCreate';
-        $args = [$this->getCompatContainer(), 'filter'];
+        $args   = [$this->getCompatContainer(), 'filter'];
 
         $this->assertFalse(call_user_func_array([$this->factory, $method], $args));
     }
@@ -110,7 +108,7 @@ class InputFilterAbstractServiceFactoryTest extends TestCase
 
         $validators = new ValidatorPluginManager($this->services);
         /** @var ValidatorInterface|MockObject $validator */
-        $validator  = $this->createMock(ValidatorInterface::class);
+        $validator = $this->createMock(ValidatorInterface::class);
         $validators->setService('foo', $validator);
 
         $this->services->setService('FilterManager', $filters);
@@ -119,21 +117,21 @@ class InputFilterAbstractServiceFactoryTest extends TestCase
             'input_filter_specs' => [
                 'filter' => [
                     'input' => [
-                        'name' => 'input',
-                        'required' => true,
-                        'filters' => [
-                            [ 'name' => 'foo' ],
+                        'name'       => 'input',
+                        'required'   => true,
+                        'filters'    => [
+                            ['name' => 'foo'],
                         ],
                         'validators' => [
-                            [ 'name' => 'foo' ],
+                            ['name' => 'foo'],
                         ],
                     ],
                 ],
             ],
         ]);
 
-        $method = '__invoke';
-        $args = [$this->getCompatContainer(), 'filter'];
+        $method      = '__invoke';
+        $args        = [$this->getCompatContainer(), 'filter'];
         $inputFilter = call_user_func_array([$this->factory, $method], $args);
         $this->assertTrue($inputFilter->has('input'));
 
@@ -158,13 +156,13 @@ class InputFilterAbstractServiceFactoryTest extends TestCase
             'input_filter_specs' => [
                 'foobar' => [
                     'input' => [
-                        'name' => 'input',
-                        'required' => true,
-                        'filters' => [
-                            [ 'name' => 'foo' ],
+                        'name'       => 'input',
+                        'required'   => true,
+                        'filters'    => [
+                            ['name' => 'foo'],
                         ],
                         'validators' => [
-                            [ 'name' => 'foo' ],
+                            ['name' => 'foo'],
                         ],
                     ],
                 ],
@@ -172,7 +170,7 @@ class InputFilterAbstractServiceFactoryTest extends TestCase
         ]);
         $validators = new ValidatorPluginManager($this->services);
         /** @var ValidatorInterface|MockObject $validator */
-        $validator  = $this->createMock(ValidatorInterface::class);
+        $validator = $this->createMock(ValidatorInterface::class);
         $this->services->setService('ValidatorManager', $validators);
         $validators->setService('foo', $validator);
 
@@ -193,7 +191,7 @@ class InputFilterAbstractServiceFactoryTest extends TestCase
      *
      * v3 passes the 'creationContext' (ie the root SM) to the AbstractFactory
      */
-    protected function getCompatContainer()
+    protected function getCompatContainer(): ServiceManager
     {
         return $this->services;
     }
@@ -209,11 +207,11 @@ class InputFilterAbstractServiceFactoryTest extends TestCase
             ],
         ]);
         $this->filters->addAbstractFactory(TestAsset\FooAbstractFactory::class);
-        $filter = $this->factory->__invoke($this->services, 'filter');
+        $filter             = $this->factory->__invoke($this->services, 'filter');
         $inputFilterManager = $filter->getFactory()->getInputFilterManager();
 
-        $this->assertInstanceOf('Laminas\InputFilter\InputFilterPluginManager', $inputFilterManager);
-        $this->assertInstanceOf('LaminasTest\InputFilter\TestAsset\Foo', $inputFilterManager->get('foo'));
+        $this->assertInstanceOf(InputFilterPluginManager::class, $inputFilterManager);
+        $this->assertInstanceOf(Foo::class, $inputFilterManager->get('foo'));
     }
 
     /**
@@ -227,8 +225,8 @@ class InputFilterAbstractServiceFactoryTest extends TestCase
             ],
         ]);
         $canCreate = 'canCreate';
-        $create = '__invoke';
-        $args = [$this->services, 'filter'];
+        $create    = '__invoke';
+        $args      = [$this->services, 'filter'];
         $this->assertTrue(call_user_func_array([$this->factory, $canCreate], $args));
         $inputFilter = call_user_func_array([$this->factory, $create], $args);
         $this->assertInstanceOf(InputFilterInterface::class, $inputFilter);
@@ -253,32 +251,32 @@ class InputFilterAbstractServiceFactoryTest extends TestCase
             'input_filter_specs' => [
                 'test' => [
                     [
-                        'name' => 'a-file-element',
-                        'type' => FileInput::class,
-                        'required' => true,
+                        'name'       => 'a-file-element',
+                        'type'       => FileInput::class,
+                        'required'   => true,
                         'validators' => [
                             [
-                                'name' => Validator\File\UploadFile::class,
+                                'name'    => Validator\File\UploadFile::class,
                                 'options' => [
                                     'breakchainonfailure' => true,
                                 ],
                             ],
                             [
-                                'name' => Validator\File\Size::class,
+                                'name'    => Validator\File\Size::class,
                                 'options' => [
                                     'breakchainonfailure' => true,
-                                    'max' => '6GB',
+                                    'max'                 => '6GB',
                                 ],
                             ],
                             [
-                                'name' => Validator\File\Extension::class,
+                                'name'    => Validator\File\Extension::class,
                                 'options' => [
                                     'breakchainonfailure' => true,
-                                    'extension' => 'csv,zip',
+                                    'extension'           => 'csv,zip',
                                 ],
                             ],
                         ],
-                        'filters' => [
+                        'filters'    => [
                             ['name' => 'CustomFilter'],
                         ],
                     ],

--- a/test/InputFilterAwareTraitTest.php
+++ b/test/InputFilterAwareTraitTest.php
@@ -22,7 +22,7 @@ class InputFilterAwareTraitTest extends TestCase
         $p->setAccessible(true);
         $this->assertNull($p->getValue($object));
 
-        $inputFilter = new InputFilter;
+        $inputFilter = new InputFilter();
 
         $object->setInputFilter($inputFilter);
 
@@ -35,7 +35,7 @@ class InputFilterAwareTraitTest extends TestCase
 
         $this->assertNull($object->getInputFilter());
 
-        $inputFilter = new InputFilter;
+        $inputFilter = new InputFilter();
 
         $object->setInputFilter($inputFilter);
 

--- a/test/InputFilterPluginManagerCompatibilityTest.php
+++ b/test/InputFilterPluginManagerCompatibilityTest.php
@@ -4,7 +4,6 @@ namespace LaminasTest\InputFilter;
 
 use Laminas\InputFilter\Exception\RuntimeException;
 use Laminas\InputFilter\InputFilterPluginManager;
-use Laminas\ServiceManager\Config;
 use Laminas\ServiceManager\ServiceManager;
 use Laminas\ServiceManager\Test\CommonPluginManagerTrait;
 use PHPUnit\Framework\TestCase;
@@ -13,17 +12,17 @@ class InputFilterPluginManagerCompatibilityTest extends TestCase
 {
     use CommonPluginManagerTrait;
 
-    public function testInstanceOfMatches()
+    public function testInstanceOfMatches(): void
     {
         $this->markTestSkipped("InputFilterPluginManager accepts multiple instances");
     }
 
-    protected function getPluginManager()
+    protected function getPluginManager(): InputFilterPluginManager
     {
         return new InputFilterPluginManager(new ServiceManager());
     }
 
-    protected function getV2InvalidPluginException()
+    protected function getV2InvalidPluginException(): string
     {
         return RuntimeException::class;
     }
@@ -31,6 +30,5 @@ class InputFilterPluginManagerCompatibilityTest extends TestCase
     protected function getInstanceOf()
     {
         // InputFilterManager accepts multiple instance types
-        return;
     }
 }

--- a/test/InputFilterPluginManagerFactoryTest.php
+++ b/test/InputFilterPluginManagerFactoryTest.php
@@ -42,6 +42,7 @@ class InputFilterPluginManagerFactoryTest extends TestCase
     /**
      * @depends testFactoryReturnsPluginManager
      * @dataProvider pluginProvider
+     * @psalm-param class-string $pluginType
      */
     public function testFactoryConfiguresPluginManagerUnderContainerInterop(string $pluginType)
     {
@@ -60,6 +61,7 @@ class InputFilterPluginManagerFactoryTest extends TestCase
     /**
      * @depends testFactoryReturnsPluginManager
      * @dataProvider pluginProvider
+     * @psalm-param class-string $pluginType
      */
     public function testFactoryConfiguresPluginManagerUnderServiceManagerV2(string $pluginType)
     {
@@ -88,7 +90,7 @@ class InputFilterPluginManagerFactoryTest extends TestCase
                     'test' => 'test-too',
                 ],
                 'factories' => [
-                    'test-too' => function ($container) use ($inputFilter) {
+                    'test-too' => function () use ($inputFilter) {
                         return $inputFilter;
                     },
                 ],
@@ -114,20 +116,6 @@ class InputFilterPluginManagerFactoryTest extends TestCase
 
     public function testDoesNotConfigureInputFilterServicesWhenServiceListenerPresent()
     {
-        $inputFilter = $this->prophesize(InputFilterInterface::class)->reveal();
-        $config      = [
-            'input_filters' => [
-                'aliases'   => [
-                    'test' => 'test-too',
-                ],
-                'factories' => [
-                    'test-too' => function ($container) use ($inputFilter) {
-                        return $inputFilter;
-                    },
-                ],
-            ],
-        ];
-
         $container = $this->prophesize(ServiceLocatorInterface::class);
         $container->willImplement(ContainerInterface::class);
 

--- a/test/InputFilterPluginManagerFactoryTest.php
+++ b/test/InputFilterPluginManagerFactoryTest.php
@@ -19,7 +19,7 @@ class InputFilterPluginManagerFactoryTest extends TestCase
     public function testFactoryReturnsPluginManager()
     {
         $container = $this->prophesize(ContainerInterface::class)->reveal();
-        $factory = new InputFilterPluginManagerFactory();
+        $factory   = new InputFilterPluginManagerFactory();
 
         $filters = $factory($container, InputFilterPluginManagerFactory::class);
         $this->assertInstanceOf(InputFilterPluginManager::class, $filters);
@@ -30,10 +30,11 @@ class InputFilterPluginManagerFactoryTest extends TestCase
         $this->assertSame($container, $p->getValue($filters));
     }
 
-    public function pluginProvider()
+    /** @psalm-return array<string, array{0: class-string<InputInterface>}> */
+    public function pluginProvider(): array
     {
         return [
-            'input' => [InputInterface::class],
+            'input'        => [InputInterface::class],
             'input-filter' => [InputFilterInterface::class],
         ];
     }
@@ -42,10 +43,10 @@ class InputFilterPluginManagerFactoryTest extends TestCase
      * @depends testFactoryReturnsPluginManager
      * @dataProvider pluginProvider
      */
-    public function testFactoryConfiguresPluginManagerUnderContainerInterop($pluginType)
+    public function testFactoryConfiguresPluginManagerUnderContainerInterop(string $pluginType)
     {
         $container = $this->prophesize(ContainerInterface::class)->reveal();
-        $plugin = $this->prophesize($pluginType)->reveal();
+        $plugin    = $this->prophesize($pluginType)->reveal();
 
         $factory = new InputFilterPluginManagerFactory();
         $filters = $factory($container, InputFilterPluginManagerFactory::class, [
@@ -60,7 +61,7 @@ class InputFilterPluginManagerFactoryTest extends TestCase
      * @depends testFactoryReturnsPluginManager
      * @dataProvider pluginProvider
      */
-    public function testFactoryConfiguresPluginManagerUnderServiceManagerV2($pluginType)
+    public function testFactoryConfiguresPluginManagerUnderServiceManagerV2(string $pluginType)
     {
         $container = $this->prophesize(ServiceLocatorInterface::class);
         $container->willImplement(ContainerInterface::class);
@@ -81,9 +82,9 @@ class InputFilterPluginManagerFactoryTest extends TestCase
     public function testConfiguresInputFilterServicesWhenFound()
     {
         $inputFilter = $this->prophesize(InputFilterInterface::class)->reveal();
-        $config = [
+        $config      = [
             'input_filters' => [
-                'aliases' => [
+                'aliases'   => [
                     'test' => 'test-too',
                 ],
                 'factories' => [
@@ -101,7 +102,7 @@ class InputFilterPluginManagerFactoryTest extends TestCase
         $container->has('config')->willReturn(true);
         $container->get('config')->willReturn($config);
 
-        $factory = new InputFilterPluginManagerFactory();
+        $factory      = new InputFilterPluginManagerFactory();
         $inputFilters = $factory($container->reveal(), 'InputFilterManager');
 
         $this->assertInstanceOf(InputFilterPluginManager::class, $inputFilters);
@@ -114,9 +115,9 @@ class InputFilterPluginManagerFactoryTest extends TestCase
     public function testDoesNotConfigureInputFilterServicesWhenServiceListenerPresent()
     {
         $inputFilter = $this->prophesize(InputFilterInterface::class)->reveal();
-        $config = [
+        $config      = [
             'input_filters' => [
-                'aliases' => [
+                'aliases'   => [
                     'test' => 'test-too',
                 ],
                 'factories' => [
@@ -134,7 +135,7 @@ class InputFilterPluginManagerFactoryTest extends TestCase
         $container->has('config')->shouldNotBeCalled();
         $container->get('config')->shouldNotBeCalled();
 
-        $factory = new InputFilterPluginManagerFactory();
+        $factory      = new InputFilterPluginManagerFactory();
         $inputFilters = $factory($container->reveal(), 'InputFilterManager');
 
         $this->assertInstanceOf(InputFilterPluginManager::class, $inputFilters);
@@ -151,7 +152,7 @@ class InputFilterPluginManagerFactoryTest extends TestCase
         $container->has('config')->willReturn(false);
         $container->get('config')->shouldNotBeCalled();
 
-        $factory = new InputFilterPluginManagerFactory();
+        $factory      = new InputFilterPluginManagerFactory();
         $inputFilters = $factory($container->reveal(), 'InputFilterManager');
 
         $this->assertInstanceOf(InputFilterPluginManager::class, $inputFilters);
@@ -166,7 +167,7 @@ class InputFilterPluginManagerFactoryTest extends TestCase
         $container->has('config')->willReturn(true);
         $container->get('config')->willReturn(['foo' => 'bar']);
 
-        $factory = new InputFilterPluginManagerFactory();
+        $factory      = new InputFilterPluginManagerFactory();
         $inputFilters = $factory($container->reveal(), 'InputFilterManager');
 
         $this->assertInstanceOf(InputFilterPluginManager::class, $inputFilters);

--- a/test/InputFilterPluginManagerTest.php
+++ b/test/InputFilterPluginManagerTest.php
@@ -70,8 +70,7 @@ class InputFilterPluginManagerTest extends TestCase
         $this->manager->get('test');
     }
 
-    /**
-     * @psalm-return array<string, array{0: string, 1: class-string<InputFilter>}> */
+    /** @psalm-return array<string, array{0: string, 1: class-string<InputFilter>}> */
     public function defaultInvokableClassesProvider(): array
     {
         return [
@@ -83,9 +82,11 @@ class InputFilterPluginManagerTest extends TestCase
 
     /**
      * @dataProvider defaultInvokableClassesProvider
+     * @psalm-param class-string $expectedInstance
      */
     public function testDefaultInvokableClasses(string $alias, string $expectedInstance)
     {
+        /** @var object $service */
         $service = $this->manager->get($alias);
 
         $this->assertInstanceOf($expectedInstance, $service, 'get() return type not match');
@@ -144,7 +145,7 @@ class InputFilterPluginManagerTest extends TestCase
     /**
      * @psalm-return array<string, array{
      *     0: string,
-     *     1: InputInterface::class,
+     *     1: InputInterface,
      *     2: class-string<InputInterface>
      * }>
      */
@@ -174,6 +175,7 @@ class InputFilterPluginManagerTest extends TestCase
 
     /**
      * @dataProvider serviceProvider
+     * @param class-string<InputInterface> $instanceOf
      */
     public function testServicesAreInitiatedIfImplementsInitializableInterface(
         string $serviceName,

--- a/test/InputFilterPluginManagerTest.php
+++ b/test/InputFilterPluginManagerTest.php
@@ -15,10 +15,12 @@ use Laminas\ServiceManager\ServiceLocatorInterface;
 use Laminas\ServiceManager\ServiceManager;
 use Laminas\Stdlib\InitializableInterface;
 use Laminas\Validator\ValidatorPluginManager;
-use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
 use ReflectionObject;
+
+use function method_exists;
 
 /**
  * @covers \Laminas\InputFilter\InputFilterPluginManager
@@ -27,20 +29,16 @@ class InputFilterPluginManagerTest extends TestCase
 {
     use ProphecyTrait;
 
-    /**
-     * @var InputFilterPluginManager
-     */
+    /** @var InputFilterPluginManager */
     protected $manager;
 
-    /**
-     * @var ServiceManager
-     */
+    /** @var ServiceManager */
     protected $services;
 
     protected function setUp(): void
     {
         $this->services = new ServiceManager();
-        $this->manager = new InputFilterPluginManager($this->services);
+        $this->manager  = new InputFilterPluginManager($this->services);
     }
 
     public function testIsASubclassOfAbstractPluginManager()
@@ -67,24 +65,26 @@ class InputFilterPluginManagerTest extends TestCase
 
     public function testLoadingInvalidElementRaisesException()
     {
-        $this->manager->setInvokableClass('test', get_class($this));
+        $this->manager->setInvokableClass('test', static::class);
         $this->expectException($this->getServiceNotFoundException());
         $this->manager->get('test');
     }
 
-    public function defaultInvokableClassesProvider()
+    /**
+     * @psalm-return array<string, array{0: string, 1: class-string<InputFilter>}> */
+    public function defaultInvokableClassesProvider(): array
     {
         return [
             // Description => [$alias, $expectedInstance]
             'inputfilter' => ['inputfilter', InputFilter::class],
-            'collection' => ['collection', CollectionInputFilter::class],
+            'collection'  => ['collection', CollectionInputFilter::class],
         ];
     }
 
     /**
      * @dataProvider defaultInvokableClassesProvider
      */
-    public function testDefaultInvokableClasses($alias, $expectedInstance)
+    public function testDefaultInvokableClasses(string $alias, string $expectedInstance)
     {
         $service = $this->manager->get($alias);
 
@@ -106,7 +106,7 @@ class InputFilterPluginManagerTest extends TestCase
 
     public function testInputFilterInvokableClassSMDependenciesArePopulatedWithServiceLocator()
     {
-        $filterManager = $this->getMockBuilder(FilterPluginManager::class)
+        $filterManager    = $this->getMockBuilder(FilterPluginManager::class)
             ->disableOriginalConstructor()
             ->getMock();
         $validatorManager = $this->getMockBuilder(ValidatorPluginManager::class)
@@ -141,24 +141,31 @@ class InputFilterPluginManagerTest extends TestCase
         );
     }
 
-    public function serviceProvider()
+    /**
+     * @psalm-return array<string, array{
+     *     0: string,
+     *     1: InputInterface::class,
+     *     2: class-string<InputInterface>
+     * }>
+     */
+    public function serviceProvider(): array
     {
         $inputFilterInterfaceMock = $this->createInputFilterInterfaceMock();
-        $inputInterfaceMock = $this->createInputInterfaceMock();
+        $inputInterfaceMock       = $this->createInputInterfaceMock();
 
-        // @codingStandardsIgnoreStart
+        // phpcs:disable
         return [
             // Description         => [$serviceName,                  $service,                  $instanceOf]
             'InputFilterInterface' => ['inputFilterInterfaceService', $inputFilterInterfaceMock, InputFilterInterface::class],
             'InputInterface'       => ['inputInterfaceService',       $inputInterfaceMock,       InputInterface::class],
         ];
-        // @codingStandardsIgnoreEnd
+        // phpcs:enable
     }
 
     /**
      * @dataProvider serviceProvider
      */
-    public function testGet($serviceName, $service)
+    public function testGet(string $serviceName, object $service)
     {
         $this->manager->setService($serviceName, $service);
 
@@ -168,10 +175,13 @@ class InputFilterPluginManagerTest extends TestCase
     /**
      * @dataProvider serviceProvider
      */
-    public function testServicesAreInitiatedIfImplementsInitializableInterface($serviceName, $service, $instanceOf)
-    {
+    public function testServicesAreInitiatedIfImplementsInitializableInterface(
+        string $serviceName,
+        object $service,
+        string $instanceOf
+    ) {
         $initializableProphecy = $this->prophesize($instanceOf)->willImplement(InitializableInterface::class);
-        $service = $initializableProphecy->reveal();
+        $service               = $initializableProphecy->reveal();
 
         $this->manager->setService($serviceName, $service);
         $this->assertSame($service, $this->manager->get($serviceName), 'get() value not match');
@@ -221,7 +231,7 @@ class InputFilterPluginManagerTest extends TestCase
         return $serviceLocator;
     }
 
-    protected function getServiceNotFoundException()
+    protected function getServiceNotFoundException(): string
     {
         if (method_exists($this->manager, 'configure')) {
             return InvalidServiceException::class;

--- a/test/InputFilterTest.php
+++ b/test/InputFilterTest.php
@@ -7,6 +7,7 @@ use Laminas\InputFilter\Factory;
 use Laminas\InputFilter\Input;
 use Laminas\InputFilter\InputFilter;
 use PHPUnit\Framework\MockObject\MockObject;
+use Traversable;
 
 use function array_merge;
 

--- a/test/InputFilterTest.php
+++ b/test/InputFilterTest.php
@@ -8,14 +8,14 @@ use Laminas\InputFilter\Input;
 use Laminas\InputFilter\InputFilter;
 use PHPUnit\Framework\MockObject\MockObject;
 
+use function array_merge;
+
 /**
  * @covers \Laminas\InputFilter\InputFilter
  */
 class InputFilterTest extends BaseInputFilterTest
 {
-    /**
-     * @var InputFilter
-     */
+    /** @var InputFilter */
     protected $inputFilter;
 
     protected function setUp(): void
@@ -36,11 +36,18 @@ class InputFilterTest extends BaseInputFilterTest
         $this->assertSame($factory, $this->inputFilter->getFactory());
     }
 
-    public function inputProvider()
+    /**
+     * @psalm-return array<string, array{
+     *     0: array|Traversable,
+     *     1: string,
+     *     2: Input
+     * }>
+     */
+    public function inputProvider(): array
     {
         $dataSets = parent::inputProvider();
 
-        $inputSpecificationAsArray = [
+        $inputSpecificationAsArray       = [
             'name' => 'inputFoo',
         ];
         $inputSpecificationAsTraversable = new ArrayIterator($inputSpecificationAsArray);
@@ -49,13 +56,13 @@ class InputFilterTest extends BaseInputFilterTest
         $inputSpecificationResult->getFilterChain(); // Fill input with a default chain just for make the test pass
         $inputSpecificationResult->getValidatorChain(); // Fill input with a default chain just for make the test pass
 
-        // @codingStandardsIgnoreStart
+        // phpcs:disable
         $inputFilterDataSets = [
             // Description => [input, expected name, $expectedReturnInput]
             'array' =>       [$inputSpecificationAsArray      , 'inputFoo', $inputSpecificationResult],
             'Traversable' => [$inputSpecificationAsTraversable, 'inputFoo', $inputSpecificationResult],
         ];
-        // @codingStandardsIgnoreEnd
+        // phpcs:enable
         $dataSets = array_merge($dataSets, $inputFilterDataSets);
 
         return $dataSets;
@@ -83,10 +90,10 @@ class InputFilterTest extends BaseInputFilterTest
     {
         $filter1 = new InputFilter();
         $filter1->add([
-            'type' => InputFilter::class,
+            'type'         => InputFilter::class,
             'nestedField1' => [
-                'required' => false
-            ]
+                'required' => false,
+            ],
         ], 'nested');
 
         // Empty set of data

--- a/test/InputTest.php
+++ b/test/InputTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
 use stdClass;
+use Webmozart\Assert\Assert;
 
 use function array_diff_key;
 use function array_merge;
@@ -698,6 +699,9 @@ class InputTest extends TestCase
         $emptyValues = $emptyValues instanceof Iterator ? iterator_to_array($emptyValues) : $emptyValues;
         $mixedValues = $mixedValues instanceof Iterator ? iterator_to_array($mixedValues) : $mixedValues;
 
+        Assert::isArray($emptyValues);
+        Assert::isArray($mixedValues);
+
         return array_merge($emptyValues, $mixedValues);
     }
 
@@ -718,6 +722,7 @@ class InputTest extends TestCase
 
         $emptyValues = $this->emptyValueProvider();
         $emptyValues = $emptyValues instanceof Iterator ? iterator_to_array($emptyValues) : $emptyValues;
+        Assert::isArray($emptyValues);
 
         $nonEmptyValues = array_diff_key($allValues, $emptyValues);
 
@@ -806,10 +811,12 @@ class InputTest extends TestCase
                 'raw'      => '',
                 'filtered' => '',
             ],
-//            '"0"' => ['0'],
-//            '0' => [0],
-//            '0.0' => [0.0],
-//            'false' => [false],
+            /* @todo Should these cases be tested?
+            '"0"' => ['0'],
+            '0' => [0],
+            '0.0' => [0.0],
+            'false' => [false],
+             */
             '[]' => [
                 'raw'      => [],
                 'filtered' => [],
@@ -820,7 +827,7 @@ class InputTest extends TestCase
     /**
      * @psalm-return array<string, array{
      *     raw: bool|int|float|string|list<string>|object,
-     *     filtered:  bool|int|float|string|list<string>|object
+     *     filtered: bool|int|float|string|list<string>|object
      * }>
      */
     public function mixedValueProvider(): array
@@ -839,20 +846,22 @@ class InputTest extends TestCase
                 'raw'      => 0.0,
                 'filtered' => 0.0,
             ],
-//            TODO enable me
-//            'false' => [
-//                'raw' => false,
-//                'filtered' => false,
-//            ],
+            /* @todo enable me
+            'false' => [
+                'raw' => false,
+                'filtered' => false,
+            ],
+             */
             'php' => [
                 'raw'      => 'php',
                 'filtered' => 'php',
             ],
-//            TODO enable me
-//            'whitespace' => [
-//                'raw' => ' ',
-//                'filtered' => ' ',
-//            ],
+            /* @todo enable me
+            'whitespace' => [
+                'raw' => ' ',
+                'filtered' => ' ',
+            ],
+             */
             '1'       => [
                 'raw'      => 1,
                 'filtered' => 1,

--- a/test/ModuleTest.php
+++ b/test/ModuleTest.php
@@ -25,8 +25,6 @@ class ModuleTest extends TestCase
     {
         $config = $this->module->getConfig();
 
-        $this->assertIsArray($config);
-
         // Service manager
         $this->assertArrayHasKey('service_manager', $config);
 

--- a/test/OptionalInputFilterTest.php
+++ b/test/OptionalInputFilterTest.php
@@ -3,6 +3,7 @@
 namespace LaminasTest\InputFilter;
 
 use ArrayIterator;
+use Exception;
 use Laminas\InputFilter\Input;
 use Laminas\InputFilter\InputFilter;
 use Laminas\InputFilter\InputFilterInterface;
@@ -25,7 +26,7 @@ class OptionalInputFilterTest extends TestCase
             'car' => [
                 'brand' => 'Volkswagen',
                 'model' => 'Golf',
-            ]
+            ],
         ];
 
         $inputFilter = $this->getNestedCarInputFilter();
@@ -65,7 +66,7 @@ class OptionalInputFilterTest extends TestCase
         $inputFilter->setData([
             'car' => [
                 'brand' => 'Volkswagen',
-            ]
+            ],
         ]);
 
         $this->assertFalse($inputFilter->isValid());
@@ -91,7 +92,7 @@ class OptionalInputFilterTest extends TestCase
      */
     public function testIteratorBehavesTheSameAsArray()
     {
-        $optionalInputFilter = new OptionalInputFilter;
+        $optionalInputFilter = new OptionalInputFilter();
         $optionalInputFilter->add(new Input('brand'));
 
         $optionalInputFilter->setData(['model' => 'Golf']);
@@ -110,21 +111,22 @@ class OptionalInputFilterTest extends TestCase
             $inputFilter->getValues();
             $this->assertTrue(false);
         // TODO: issue #143 narrow which exception should be thrown
-        } catch (\Exception $exception) {
+        } catch (Exception $exception) {
             $this->assertTrue(true);
         }
     }
 
+    /** @var null|OptionalInputFilter */
     private $nestedCarInputFilter;
 
-    protected function getNestedCarInputFilter()
+    protected function getNestedCarInputFilter(): InputFilter
     {
         if (! $this->nestedCarInputFilter) {
-            $optionalInputFilter = new OptionalInputFilter;
+            $optionalInputFilter = new OptionalInputFilter();
             $optionalInputFilter->add(new Input('brand'));
             $optionalInputFilter->add(new Input('model'));
 
-            $this->nestedCarInputFilter = new InputFilter;
+            $this->nestedCarInputFilter = new InputFilter();
             $this->nestedCarInputFilter->add($optionalInputFilter, 'car');
         }
 

--- a/test/OptionalInputFilterTest.php
+++ b/test/OptionalInputFilterTest.php
@@ -116,7 +116,7 @@ class OptionalInputFilterTest extends TestCase
         }
     }
 
-    /** @var null|OptionalInputFilter */
+    /** @var null|InputFilter */
     private $nestedCarInputFilter;
 
     protected function getNestedCarInputFilter(): InputFilter

--- a/test/TestAsset/FooAbstractFactory.php
+++ b/test/TestAsset/FooAbstractFactory.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:disable
 
 namespace LaminasTest\InputFilter\TestAsset;
 
@@ -8,7 +8,7 @@ use Laminas\ServiceManager\ServiceLocatorInterface;
 
 class FooAbstractFactory implements AbstractFactoryInterface
 {
-    public function __invoke(ContainerInterface $container, $name, array $options = null)
+    public function __invoke(ContainerInterface $container, $name, ?array $options = null)
     {
         return new Foo();
     }

--- a/test/TestAsset/ModuleEventInterface.php
+++ b/test/TestAsset/ModuleEventInterface.php
@@ -9,5 +9,10 @@ namespace LaminasTest\InputFilter\TestAsset;
  */
 interface ModuleEventInterface
 {
+    /**
+     * @param string $name
+     * @param mixed $default
+     * @return mixed
+     */
     public function getParam($name, $default = null);
 }


### PR DESCRIPTION
To prepare for PHP 8.1, we need to first update to a version of laminas-coding-standard that will work with PHP 7.4 forward, which means moving to laminas-coding-standard 2.2.

This patch updates the constraint in `composer.json`, and updates the `phpcs.xml.dist` to reflect the new schema.
I then applied fixes, and resolved Psalm errors that arose due to touching files again.
