### PR TITLE
Introduce allowNull setting for Input.

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -254,6 +254,9 @@ class Factory
                     }
                     $this->populateValidators($input->getValidatorChain(), $value);
                     break;
+                case 'allow_null':
+                    $input->setAllowNull($value);
+                    break;
                 default:
                     // ignore unknown keys
                     break;

--- a/src/Input.php
+++ b/src/Input.php
@@ -302,7 +302,7 @@ class Input implements
      */
     public function getValue()
     {
-        if($this->allowNull && is_null($this->value)){
+        if ($this->allowNull && $this->value === null) {
             return null;
         }
         $filter = $this->getFilterChain();
@@ -409,7 +409,7 @@ class Input implements
         }
 
         // no need to run validators because null is valid value
-        if(is_null($value) && $allowNull){
+        if ($value === null && $allowNull) {
             return true;
         }
 

--- a/src/InputInterface.php
+++ b/src/InputInterface.php
@@ -116,4 +116,8 @@ interface InputInterface
      * @return string[]
      */
     public function getMessages();
+
+    public function setAllowNull(bool $allowNull): InputInterface;
+
+    public function allowNull(): bool;
 }

--- a/test/FactoryTest.php
+++ b/test/FactoryTest.php
@@ -579,6 +579,7 @@ class FactoryTest extends TestCase
             'zomg' => [
                 'name'              => 'zomg',
                 'continue_if_empty' => true,
+                'allow_null'        => true,
             ],
         ]);
         $this->assertInstanceOf(InputFilter::class, $inputFilter);
@@ -617,6 +618,7 @@ class FactoryTest extends TestCase
                 case 'zomg':
                     $this->assertInstanceOf(Input::class, $input);
                     $this->assertTrue($input->continueIfEmpty());
+                    $this->assertTrue($input->allowNull());
             }
         }
     }

--- a/test/InputTest.php
+++ b/test/InputTest.php
@@ -657,6 +657,41 @@ class InputTest extends TestCase
         $this->assertSame($translatedMessage, $messages['isEmpty']);
     }
 
+    public function testInputDoesNotAllowNullValuesByDefault()
+    {
+        $this->assertFalse($this->input->allowNull());
+    }
+
+    public function testAllowNullFlagIsMutable()
+    {
+        $this->input->setAllowNull(true);
+        $this->assertTrue($this->input->allowNull());
+    }
+
+    public function testDoNotRunValidatorsOnNullableInputWithNullValue()
+    {
+        $input = new Input();
+        $input->setAllowNull(true);
+        $input->setValue(null);
+        $input->getValidatorChain()->attach($this->createValidatorMock(null));
+        $this->assertTrue(
+            $input->isValid(),
+            "The validators must not be executed when 'allow_null' set to true and value is null"
+        );
+    }
+
+    public function testDoNotRunFiltersOnNullableInputWithNullValue()
+    {
+        $input = new Input();
+        $input->setAllowNull(true);
+        $input->setValue(null);
+        $filterChain = $this->createFilterChainMock([[null, 'Value']]);
+        $filterChain->expects($this->never())
+            ->method('filter');
+        $input->setFilterChain($filterChain);
+        $this->assertNull($input->getValue(), 'getValue() must return null');
+    }
+
     /**
      * @psalm-return array<string, array{
      *     0: bool,


### PR DESCRIPTION
Signed-off-by: illia <illia.hapak@scharc.com>

<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: master branch
  * Bugfix: master branch
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | yes
| New Feature   | yes
| RFC           | no
| QA            | no

### Description

I want propose alternative for deprecated allowEmpty and continueIfEmpty settings.
Why ?
Let's think about following example. We have 3 entities: Store, Product, Category. Product has Category as optional relation. Categories have relation to Store.
```php
$inputFilterSpecs = [
    //... the other inputs like name, cost, etc
    'category' => [
        'name' => 'category',
        'required' => false,
        'filters' => [
            ['name' => EntityFilter::class], // find Category entity in DB by id
        ],
        'validators' => [
            [
                'name' => ObjectExistsValidator::class, // make sure that Category exists before continue
                'break_chain_on_failure' => true,
            ],
            ['name' => CategoryValidator::class], // check if user can add product to this category, etc
        ],
    ],
];
```
I set data to Product using Laminas\Hydrator\ClassMethodsHydrator
```php
class Product {
    ...
    public function setCategory(?Category $category){
        $this->category = $category
    }
    ...
}
```
Problem of 'category' input: 
required = false AND allowEmpty = false AND continueIfEmpty = false. 
As a consequence empty array "[]" and empty string "" are accepted as valid values and lead to **TypeError**.

To avoid this I can add 'continue_if_empty' => true XOR make input required and force client explicitly send null value. But it means that null will be filtered and validated.

Solution using $allowNull setting
```php
$inputFilterSpecs = [
    //... the other inputs like name, cost, etc
    'category' => [
        'name' => 'category',
        'required' => false,
        'allow_null' => true,
        'continue_if_empty' => true,
        // ... filter, validators, etc
    ],
];
```