### PR TITLE
qa: Fix several psalm issues

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -36,13 +36,8 @@
     </NonInvariantDocblockPropertyType>
   </file>
   <file src="src/BaseInputFilter.php">
-    <DocblockTypeContradiction occurrences="6">
-      <code>$input instanceof InputInterface &amp;&amp; (empty($name) || is_int($name))</code>
-      <code>[]</code>
-      <code>[]</code>
-      <code>gettype($input)</code>
+    <DocblockTypeContradiction occurrences="1">
       <code>is_array($data)</code>
-      <code>is_int($name)</code>
     </DocblockTypeContradiction>
     <InvalidReturnStatement occurrences="2">
       <code>is_array($this-&gt;invalidInputs) ? $this-&gt;invalidInputs : []</code>
@@ -55,18 +50,6 @@
     <LessSpecificImplementedReturnType occurrences="1">
       <code>array</code>
     </LessSpecificImplementedReturnType>
-    <MissingConstructor occurrences="10">
-      <code>$invalidInputs</code>
-      <code>$invalidInputs</code>
-      <code>$invalidInputs</code>
-      <code>$invalidInputs</code>
-      <code>$invalidInputs</code>
-      <code>$validInputs</code>
-      <code>$validInputs</code>
-      <code>$validInputs</code>
-      <code>$validInputs</code>
-      <code>$validInputs</code>
-    </MissingConstructor>
     <MixedArgument occurrences="1">
       <code>$input</code>
     </MixedArgument>
@@ -100,11 +83,6 @@
     <PossiblyNullArrayOffset occurrences="1">
       <code>$this-&gt;inputs</code>
     </PossiblyNullArrayOffset>
-    <RedundantConditionGivenDocblockType occurrences="3">
-      <code>is_array($this-&gt;invalidInputs)</code>
-      <code>is_array($this-&gt;validInputs)</code>
-      <code>is_object($input)</code>
-    </RedundantConditionGivenDocblockType>
     <TooManyArguments occurrences="2">
       <code>isValid</code>
       <code>isValid</code>
@@ -422,17 +400,9 @@
     </RedundantCastGivenDocblockType>
   </file>
   <file src="src/InputFilter.php">
-    <DocblockTypeContradiction occurrences="1">
-      <code>null === $this-&gt;factory</code>
-    </DocblockTypeContradiction>
     <LessSpecificReturnStatement occurrences="1">
       <code>parent::add($input, $name)</code>
     </LessSpecificReturnStatement>
-    <MissingConstructor occurrences="3">
-      <code>$factory</code>
-      <code>$factory</code>
-      <code>$factory</code>
-    </MissingConstructor>
     <MoreSpecificReturnType occurrences="1">
       <code>InputFilter</code>
     </MoreSpecificReturnType>
@@ -492,9 +462,6 @@
     <InvalidScalarArgument occurrences="1">
       <code>$e-&gt;getCode()</code>
     </InvalidScalarArgument>
-    <MethodSignatureMismatch occurrences="1">
-      <code>InputFilterPluginManager</code>
-    </MethodSignatureMismatch>
     <MissingReturnType occurrences="1">
       <code>populateFactory</code>
     </MissingReturnType>

--- a/src/BaseInputFilter.php
+++ b/src/BaseInputFilter.php
@@ -38,13 +38,13 @@ class BaseInputFilter implements
     /** @var InputInterface[]|InputFilterInterface[] */
     protected $inputs = [];
 
-    /** @var InputInterface[]|InputFilterInterface[] */
+    /** @var InputInterface[]|InputFilterInterface[]|null */
     protected $invalidInputs;
 
-    /** @var null|string[] Input names */
+    /** @var null|string[]|null Input names */
     protected $validationGroup;
 
-    /** @var InputInterface[]|InputFilterInterface[] */
+    /** @var InputInterface[]|InputFilterInterface[]|null */
     protected $validInputs;
 
     /**
@@ -80,6 +80,7 @@ class BaseInputFilter implements
      */
     public function add($input, $name = null)
     {
+        /** @psalm-suppress RedundantConditionGivenDocblockType,DocblockTypeContradiction */
         if (! $input instanceof InputInterface && ! $input instanceof InputFilterInterface) {
             throw new Exception\InvalidArgumentException(sprintf(
                 '%s expects an instance of %s or %s as its first argument; received "%s"',
@@ -90,6 +91,7 @@ class BaseInputFilter implements
             ));
         }
 
+        /** @psalm-suppress DocblockTypeContradiction */
         if ($input instanceof InputInterface && (empty($name) || is_int($name))) {
             $name = $input->getName();
         }

--- a/src/InputFilter.php
+++ b/src/InputFilter.php
@@ -8,12 +8,13 @@ use function is_array;
 
 class InputFilter extends BaseInputFilter
 {
-    /** @var Factory */
+    /** @var Factory|null */
     protected $factory;
 
     /**
      * Set factory to use when adding inputs and filters by spec
      *
+     * @psalm-assert Factory $this->factory
      * @return InputFilter
      */
     public function setFactory(Factory $factory)

--- a/src/InputFilterPluginManager.php
+++ b/src/InputFilterPluginManager.php
@@ -18,7 +18,7 @@ use function sprintf;
 /**
  * Plugin manager implementation for input filters.
  *
- * @method InputFilterInterface|InputInterface get($name)
+ * @method InputFilterInterface|InputInterface get($name, ?array $options = null)
  */
 class InputFilterPluginManager extends AbstractPluginManager
 {


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| QA            | yes

### Description

- Solves PropertyNotSetInConstructor errors for user InputFilter implementations
- Corrects possibly null factory in InputFilter
- Corrects argument list for inherited `get` in the plugin manager
