### PR TITLE
Improve type inference for plugin manager

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     "require": {
         "php": "^7.4 || ~8.0.0 || ~8.1.0",
         "laminas/laminas-filter": "^2.13",
-        "laminas/laminas-servicemanager": "^3.3.1",
+        "laminas/laminas-servicemanager": "^3.12.0",
         "laminas/laminas-stdlib": "^3.0",
         "laminas/laminas-validator": "^2.15"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "53f38233dacf2b64b07daad58d574517",
+    "content-hash": "87202727d455197035daa0ce8b5a79e1",
     "packages": [
         {
             "name": "laminas/laminas-filter",

--- a/composer.lock
+++ b/composer.lock
@@ -87,16 +87,16 @@
         },
         {
             "name": "laminas/laminas-servicemanager",
-            "version": "3.11.2",
+            "version": "3.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-servicemanager.git",
-                "reference": "8a1f4d53ec93b2e18174f6f186922ef44d11a75a"
+                "reference": "05ac4b1fb1fe9333313eeafced9b6c7946589487"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-servicemanager/zipball/8a1f4d53ec93b2e18174f6f186922ef44d11a75a",
-                "reference": "8a1f4d53ec93b2e18174f6f186922ef44d11a75a",
+                "url": "https://api.github.com/repos/laminas/laminas-servicemanager/zipball/05ac4b1fb1fe9333313eeafced9b6c7946589487",
+                "reference": "05ac4b1fb1fe9333313eeafced9b6c7946589487",
                 "shasum": ""
             },
             "require": {
@@ -174,20 +174,20 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2022-04-07T17:21:25+00:00"
+            "time": "2022-06-13T16:20:56+00:00"
         },
         {
             "name": "laminas/laminas-stdlib",
-            "version": "3.10.0",
+            "version": "3.10.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-stdlib.git",
-                "reference": "449c0405e182bfe77702604a474668fbb63e9907"
+                "reference": "0d669074845fc80a99add0f64025192f143ef836"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-stdlib/zipball/449c0405e182bfe77702604a474668fbb63e9907",
-                "reference": "449c0405e182bfe77702604a474668fbb63e9907",
+                "url": "https://api.github.com/repos/laminas/laminas-stdlib/zipball/0d669074845fc80a99add0f64025192f143ef836",
+                "reference": "0d669074845fc80a99add0f64025192f143ef836",
                 "shasum": ""
             },
             "require": {
@@ -233,7 +233,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2022-06-09T08:43:49+00:00"
+            "time": "2022-06-10T14:49:09+00:00"
         },
         {
             "name": "laminas/laminas-validator",
@@ -3512,16 +3512,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.6.2",
+            "version": "3.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "5e4e71592f69da17871dba6e80dd51bce74a351a"
+                "reference": "a2cd51b45bcaef9c1f2a4bda48f2dd2fa2b95563"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/5e4e71592f69da17871dba6e80dd51bce74a351a",
-                "reference": "5e4e71592f69da17871dba6e80dd51bce74a351a",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/a2cd51b45bcaef9c1f2a4bda48f2dd2fa2b95563",
+                "reference": "a2cd51b45bcaef9c1f2a4bda48f2dd2fa2b95563",
                 "shasum": ""
             },
             "require": {
@@ -3564,7 +3564,7 @@
                 "source": "https://github.com/squizlabs/PHP_CodeSniffer",
                 "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
             },
-            "time": "2021-12-12T21:44:58+00:00"
+            "time": "2022-06-13T06:31:38+00:00"
         },
         {
             "name": "symfony/console",

--- a/src/InputFilterPluginManager.php
+++ b/src/InputFilterPluginManager.php
@@ -23,8 +23,10 @@ use function sprintf;
  *
  * @link ServiceManager
  *
- * @method InputFilterInterface|InputInterface get(string $name, ?array $options = null)
  * @psalm-import-type ServiceManagerConfiguration from ServiceManager
+ * @template InstanceType of InputFilterInterface|InputInterface
+ * @extends AbstractPluginManager<InstanceType>
+ * @method InputFilterInterface|InputInterface get(string $name, ?array $options = null)
  */
 class InputFilterPluginManager extends AbstractPluginManager
 {
@@ -141,7 +143,7 @@ class InputFilterPluginManager extends AbstractPluginManager
     /**
      * {@inheritDoc} (v3)
      *
-     * @psalm-assert InputFilterInterface|InputInterface $instance
+     * @psalm-assert InstanceType $instance
      */
     public function validate($instance)
     {

--- a/test/FactoryTest.php
+++ b/test/FactoryTest.php
@@ -46,11 +46,8 @@ class FactoryTest extends TestCase
 
     public function testCreateInputWithTypeAsAnUnknownPluginAndNotExistsAsClassNameThrowException(): void
     {
-        $type = 'foo';
-        /** @var InputFilterPluginManager&MockObject $pluginManager */
-        $pluginManager = $this->getMockBuilder(InputFilterPluginManager::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $type          = 'foo';
+        $pluginManager = $this->createMock(InputFilterPluginManager::class);
         $pluginManager->expects($this->atLeastOnce())
             ->method('has')
             ->with($type)
@@ -69,9 +66,7 @@ class FactoryTest extends TestCase
 
     public function testGetInputFilterManagerSettedByItsSetter(): void
     {
-        $pluginManager = $this->getMockBuilder(InputFilterPluginManager::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $pluginManager = $this->createMock(InputFilterPluginManager::class);
         $factory       = new Factory();
         $factory->setInputFilterManager($pluginManager);
         $this->assertSame($pluginManager, $factory->getInputFilterManager());
@@ -79,9 +74,7 @@ class FactoryTest extends TestCase
 
     public function testGetInputFilterManagerWhenYouConstructFactoryWithIt(): void
     {
-        $pluginManager = $this->getMockBuilder(InputFilterPluginManager::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $pluginManager = $this->createMock(InputFilterPluginManager::class);
         $factory       = new Factory($pluginManager);
         $this->assertSame($pluginManager, $factory->getInputFilterManager());
     }

--- a/test/FactoryTest.php
+++ b/test/FactoryTest.php
@@ -53,6 +53,7 @@ class FactoryTest extends TestCase
             ->with($type)
             ->willReturn(false);
 
+        /** @psalm-suppress MixedArgumentTypeCoercion */
         $factory = new Factory($pluginManager);
 
         $this->expectException(RuntimeException::class);
@@ -68,6 +69,7 @@ class FactoryTest extends TestCase
     {
         $pluginManager = $this->createMock(InputFilterPluginManager::class);
         $factory       = new Factory();
+        /** @psalm-suppress MixedArgumentTypeCoercion */
         $factory->setInputFilterManager($pluginManager);
         $this->assertSame($pluginManager, $factory->getInputFilterManager());
     }
@@ -75,7 +77,8 @@ class FactoryTest extends TestCase
     public function testGetInputFilterManagerWhenYouConstructFactoryWithIt(): void
     {
         $pluginManager = $this->createMock(InputFilterPluginManager::class);
-        $factory       = new Factory($pluginManager);
+        /** @psalm-suppress MixedArgumentTypeCoercion */
+        $factory = new Factory($pluginManager);
         $this->assertSame($pluginManager, $factory->getInputFilterManager());
     }
 

--- a/test/InputFilterPluginManagerTest.php
+++ b/test/InputFilterPluginManagerTest.php
@@ -60,6 +60,7 @@ class InputFilterPluginManagerTest extends TestCase
         $this->expectExceptionMessage(
             'must implement Laminas\InputFilter\InputFilterInterface or Laminas\InputFilter\InputInterface'
         );
+        /** @psalm-suppress InvalidArgument */
         $this->manager->setService('test', $this);
     }
 
@@ -165,6 +166,7 @@ class InputFilterPluginManagerTest extends TestCase
 
     /**
      * @dataProvider serviceProvider
+     * @param InputInterface|InputFilterInterface $service
      */
     public function testGet(string $serviceName, object $service): void
     {


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| QA            | yes

### Description

If https://github.com/laminas/laminas-servicemanager/pull/137 gets merged, this is what I had in mind for `inputfilter`, `filter`, `validator` and `view` … and others??
