### PR TITLE
Regression for input filter collections

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -36,9 +36,6 @@
     </NonInvariantDocblockPropertyType>
   </file>
   <file src="src/BaseInputFilter.php">
-    <DocblockTypeContradiction occurrences="1">
-      <code>! is_string($name)</code>
-    </DocblockTypeContradiction>
     <InvalidPropertyAssignmentValue occurrences="1">
       <code>$this-&gt;inputs</code>
     </InvalidPropertyAssignmentValue>

--- a/src/BaseInputFilter.php
+++ b/src/BaseInputFilter.php
@@ -497,7 +497,7 @@ class BaseInputFilter implements
     protected function validateValidationGroup(array $inputs)
     {
         foreach ($inputs as $name) {
-            if (! is_string($name) || ! array_key_exists($name, $this->inputs)) {
+            if (! array_key_exists($name, $this->inputs)) {
                 throw new Exception\InvalidArgumentException(sprintf(
                     'setValidationGroup() expects a list of valid input names; "%s" was not found',
                     (string) $name

--- a/src/BaseInputFilter.php
+++ b/src/BaseInputFilter.php
@@ -21,7 +21,6 @@ use function gettype;
 use function is_array;
 use function is_int;
 use function is_object;
-use function is_string;
 use function sprintf;
 
 class BaseInputFilter implements

--- a/test/ValidationGroup/InputFilterCollectionsValidationGroupTest.php
+++ b/test/ValidationGroup/InputFilterCollectionsValidationGroupTest.php
@@ -1,0 +1,200 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\InputFilter\ValidationGroup;
+
+use Laminas\InputFilter\CollectionInputFilter;
+use Laminas\InputFilter\Input;
+use Laminas\InputFilter\InputFilter;
+use PHPUnit\Framework\TestCase;
+
+final class InputFilterCollectionsValidationGroupTest extends TestCase
+{
+    private InputFilter $inputFilter;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $collection = new CollectionInputFilter();
+        $collection->setIsRequired(true);
+
+        $first = new Input('first');
+        $first->setRequired(true);
+        $second = new Input('second');
+        $second->setRequired(true);
+
+        $nestedFilter = new InputFilter();
+        $nestedFilter->add($first);
+        $nestedFilter->add($second);
+        $collection->setInputFilter($nestedFilter);
+
+        $this->inputFilter = new InputFilter();
+        $this->inputFilter->add($collection, 'stuff');
+    }
+
+    /** @return array<string, array{0: int|null}> */
+    public function collectionCountProvider(): array
+    {
+        return [
+            'Collection Count: None'  => [null],
+            'Collection Count: One'   => [1],
+            'Collection Count: Two'   => [2],
+            'Collection Count: Three' => [3],
+            'Collection Count: Four'  => [4],
+        ];
+    }
+
+    private function setCollectionCount(?int $count): void
+    {
+        if ($count === null) {
+            return;
+        }
+
+        $collection = $this->inputFilter->get('stuff');
+        self::assertInstanceOf(CollectionInputFilter::class, $collection);
+        $collection->setCount($count);
+    }
+
+    /** @dataProvider collectionCountProvider */
+    public function testIncompleteDataFailsValidation(?int $count): void
+    {
+        $this->setCollectionCount($count);
+        $this->inputFilter->setData([
+            'stuff' => [
+                ['first' => 'Foo'],
+            ],
+        ]);
+        self::assertFalse($this->inputFilter->isValid());
+    }
+
+    /** @dataProvider collectionCountProvider */
+    public function testCompleteDataPassesValidation(?int $count): void
+    {
+        $this->setCollectionCount($count);
+        $this->inputFilter->setData([
+            'stuff' => [
+                ['first' => 'Foo', 'second' => 'Bar'],
+                ['first' => 'Foo', 'second' => 'Bar'],
+                ['first' => 'Foo', 'second' => 'Bar'],
+                ['first' => 'Foo', 'second' => 'Bar'],
+            ],
+        ]);
+
+        self::assertTrue($this->inputFilter->isValid());
+    }
+
+    /** @dataProvider collectionCountProvider */
+    public function testValidationFailsForCollectionItemValidity(?int $count): void
+    {
+        $this->setCollectionCount($count);
+        $this->inputFilter->setData([
+            'stuff' => [
+                ['first' => 'Foo', 'second' => 'Bar'],
+                ['first' => '', 'second' => 'Bar'],
+                ['first' => 'Foo', 'second' => ''],
+                ['first' => '', 'second' => ''],
+            ],
+        ]);
+
+        self::assertFalse($this->inputFilter->isValid());
+    }
+
+    /** @dataProvider collectionCountProvider */
+    public function testValidationGroupWithCollectionInputFilter(?int $count): void
+    {
+        $this->setCollectionCount($count);
+        $collection = $this->inputFilter->get('stuff');
+        self::assertInstanceOf(CollectionInputFilter::class, $collection);
+        $collection->getInputFilter()->setValidationGroup('first');
+
+        $this->inputFilter->setData([
+            'stuff' => [
+                ['first' => 'Foo'],
+                ['first' => 'Foo'],
+                ['first' => 'Foo'],
+                ['first' => 'Foo'],
+            ],
+        ]);
+
+        self::assertTrue($this->inputFilter->isValid());
+    }
+
+    /** @dataProvider collectionCountProvider */
+    public function testValidationGroupViaCollection(?int $count): void
+    {
+        $this->setCollectionCount($count);
+        $collection = $this->inputFilter->get('stuff');
+        self::assertInstanceOf(CollectionInputFilter::class, $collection);
+        $collection->setValidationGroup([
+            0 => 'first',
+            1 => 'second',
+            2 => 'first',
+            3 => 'first',
+        ]);
+
+        $this->inputFilter->setData([
+            'stuff' => [
+                ['first' => 'Foo'],
+                ['second' => 'Foo'],
+                ['first' => 'Foo'],
+                ['first' => 'Foo'],
+            ],
+        ]);
+
+        self::assertTrue($this->inputFilter->isValid());
+    }
+
+    /**
+     * This test fails because of an undefined offset - the validation group must be set for elements 0 through 3
+     *
+     * @dataProvider collectionCountProvider
+     */
+    public function testValidationGroupViaCollectionMustSpecifyAllKeys(?int $count): void
+    {
+        $this->setCollectionCount($count);
+        $collection = $this->inputFilter->get('stuff');
+        self::assertInstanceOf(CollectionInputFilter::class, $collection);
+
+        $collection->setValidationGroup([
+            0 => 'first',
+        ]);
+
+        $this->inputFilter->setData([
+            'stuff' => [
+                ['first' => 'Foo'],
+                ['first' => 'Foo'],
+                ['first' => 'Foo'],
+                ['first' => 'Foo'],
+            ],
+        ]);
+
+        self::assertTrue($this->inputFilter->isValid());
+    }
+
+    /** @dataProvider collectionCountProvider */
+    public function testValidationGroupViaTopLevelInputFilter(?int $count): void
+    {
+        $this->setCollectionCount($count);
+        $this->inputFilter->setValidationGroup([
+            'stuff' => [
+                0 => 'first',
+                1 => 'second',
+                2 => 'first',
+                3 => 'first',
+            ],
+        ]);
+
+        $this->inputFilter->setData([
+            'stuff' => [
+                ['first' => 'Foo'],
+                ['second' => 'Foo'],
+                ['first' => 'Foo'],
+                ['first' => 'Foo'],
+            ],
+        ]);
+
+        self::assertTrue($this->inputFilter->isValid());
+    }
+}

--- a/test/ValidationGroup/InputFilterStringValidationGroupTest.php
+++ b/test/ValidationGroup/InputFilterStringValidationGroupTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\InputFilter\ValidationGroup;
+
+use Laminas\InputFilter\Exception\InvalidArgumentException;
+use Laminas\InputFilter\Input;
+use Laminas\InputFilter\InputFilter;
+use Laminas\Validator\StringLength;
+use PHPUnit\Framework\TestCase;
+
+final class InputFilterStringValidationGroupTest extends TestCase
+{
+    private InputFilter $inputFilter;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $first = new Input('first');
+        $first->setRequired(true);
+        $first->getValidatorChain()->attach(new StringLength(['min' => 5]));
+        $second = new Input('second');
+        $second->setRequired(true);
+        $second->getValidatorChain()->attach(new StringLength(['min' => 5]));
+        $third = new Input('third');
+        $third->setRequired(true);
+        $third->getValidatorChain()->attach(new StringLength(['min' => 5]));
+
+        $this->inputFilter = new InputFilter();
+        $this->inputFilter->add($first);
+        $this->inputFilter->add($second);
+        $this->inputFilter->add($third);
+    }
+
+    public function testValidationFailsForIncompleteInput(): void
+    {
+        $this->inputFilter->setData(['first' => 'Freddy']);
+        self::assertFalse($this->inputFilter->isValid());
+    }
+
+    public function testValidationSucceedsForCompleteInput(): void
+    {
+        $this->inputFilter->setData(['first' => 'Freddy', 'second' => 'Fruit Bat', 'third' => 'Muppet']);
+        self::assertTrue($this->inputFilter->isValid());
+    }
+
+    public function testValidationSucceedsForIncompleteInputWhenValidationGroupIsProvided(): void
+    {
+        $this->inputFilter->setValidationGroup('first');
+        $this->inputFilter->setData(['first' => 'Freddy']);
+
+        self::assertTrue($this->inputFilter->isValid());
+    }
+
+    public function testThatValidationGroupIsVariadic(): void
+    {
+        $this->inputFilter->setValidationGroup('first', 'second');
+        $this->inputFilter->setData(['first' => 'Freddy', 'second' => 'Fruit Bat']);
+
+        self::assertTrue($this->inputFilter->isValid());
+    }
+
+    public function testThatValidationGroupAcceptsListOfInputNames(): void
+    {
+        $this->inputFilter->setValidationGroup(['first', 'second']);
+        $this->inputFilter->setData(['first' => 'Freddy', 'second' => 'Fruit Bat']);
+
+        self::assertTrue($this->inputFilter->isValid());
+    }
+
+    public function testValidationGroupWithUnknownInput(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('"doughnuts" was not found');
+        $this->inputFilter->setValidationGroup(['doughnuts']);
+    }
+}


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Bugfix        | yes/no
| QA            | yes/no

### Description

Reference #58 

Validation groups appear to make sense for a regular "top-level" input filters and they also appear to work as advertised.

Applying validation groups to collection input filters doesn't appear to work unless I'm missing something… I've tried the tests here back to 2.15 with the same results.

Back in 2013, there was some `array_fill` shenanigans going on with the validation group, I assume to get around the problem where you have to repeatedly specify the grouped inputs per iteration of the collection, i.e. in a top-level input filter:

```php
$inputFilter->setValidationGroup([
    'collectionName' => [
        ['input1', 'input2'],
        ['input1', 'input2'],
        ['input1', 'input2'],
        // ... an so on, depending on the value of "count"
    ],
]);
```

FTR, I'm not expecting this to be merged, but it looks like there's a lot of reflection and mocking going on in the relevant tests here, hence the separate test cases - I'm not convinced the existing tests are covering the expected behaviour and when it comes to collections,I'm not even sure what the expected behaviour is - also, CI is broken in `laminas-form` for recent versions of input filter so there's definitely something broken…
