### PR TITLE
Adjusted tests so that stubbed `ContainerInterface#has()` returns `bool` instead of `null`

### DIFF
--- a/test/InputFilterPluginManagerFactoryTest.php
+++ b/test/InputFilterPluginManagerFactoryTest.php
@@ -18,7 +18,7 @@ class InputFilterPluginManagerFactoryTest extends TestCase
 
     public function testFactoryReturnsPluginManager(): void
     {
-        $container = $this->prophesize(ContainerInterface::class)->reveal();
+        $container = $this->createMock(ContainerInterface::class);
         $factory   = new InputFilterPluginManagerFactory();
 
         $filters = $factory($container, InputFilterPluginManagerFactory::class);
@@ -46,8 +46,8 @@ class InputFilterPluginManagerFactoryTest extends TestCase
      */
     public function testFactoryConfiguresPluginManagerUnderContainerInterop(string $pluginType): void
     {
-        $container = $this->prophesize(ContainerInterface::class)->reveal();
-        $plugin    = $this->prophesize($pluginType)->reveal();
+        $container = $this->createMock(ContainerInterface::class);
+        $plugin    = $this->createMock($pluginType);
 
         $factory = new InputFilterPluginManagerFactory();
         $filters = $factory($container, InputFilterPluginManagerFactory::class, [
@@ -60,7 +60,7 @@ class InputFilterPluginManagerFactoryTest extends TestCase
 
     public function testConfiguresInputFilterServicesWhenFound(): void
     {
-        $inputFilter = $this->prophesize(InputFilterInterface::class)->reveal();
+        $inputFilter = $this->createMock(InputFilterInterface::class);
         $config      = [
             'input_filters' => [
                 'aliases'   => [


### PR DESCRIPTION
This is necessary, as `psr/container:^2` has a stricter return type declaration, and prophecy is
not respecting the return types upfront (unless stubbed methods are explicitly configured).

While this is an upstream BC break in `psr/container:^2`, this component is not really affected
by the BC issue, other than some stubbing being broken in it.

Fixes:

```
1) LaminasTest\InputFilter\InputFilterPluginManagerFactoryTest::testFactoryConfiguresPluginManagerUnderContainerInterop with data set "input" ('Laminas\InputFilter\InputInterface')
TypeError: Double\ContainerInterface\P8::has(): Return value must be of type bool, null returned
2) LaminasTest\InputFilter\InputFilterPluginManagerFactoryTest::testFactoryConfiguresPluginManagerUnderContainerInterop with data set "input-filter" ('Laminas\InputFilter\InputFilt...erface')
TypeError: Double\ContainerInterface\P8::has(): Return value must be of type bool, null returned
```

Ref: https://github.com/laminas/laminas-servicemanager/issues/146#issue-1310587609
Ref: https://github.com/laminas/laminas-servicemanager/issues/146#issuecomment-1189956888

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | yes
