### PR TITLE
Remove dependency on prophecy

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,12 +40,10 @@
     "require-dev": {
         "laminas/laminas-coding-standard": "~2.3.0",
         "laminas/laminas-db": "^2.13.4",
-        "phpspec/prophecy": "^1.14",
-        "phpspec/prophecy-phpunit": "^2.0",
-        "phpunit/phpunit": "^9.5.5",
+        "phpunit/phpunit": "^9.5.21",
         "psalm/plugin-phpunit": "^0.17.0",
         "psr/http-message": "^1.0",
-        "vimeo/psalm": "^4.6"
+        "vimeo/psalm": "^4.24.0"
     },
     "suggest": {
         "psr/http-message-implementation": "PSR-7 is required if you wish to validate PSR-7 UploadedFileInterface payloads"

--- a/composer.lock
+++ b/composer.lock
@@ -4,23 +4,24 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1c84b4b7e580b214d4ad7671950d368f",
+    "content-hash": "a2867a41e58dc78a9ae5970fd0daa7ca",
     "packages": [
         {
             "name": "laminas/laminas-filter",
-            "version": "2.14.0",
+            "version": "2.17.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-filter.git",
-                "reference": "98a126b8cd069a446054680c9be5f37a61f6dc17"
+                "reference": "7c78483f22e118fbc98be41dc24b39e8c17cdcae"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-filter/zipball/98a126b8cd069a446054680c9be5f37a61f6dc17",
-                "reference": "98a126b8cd069a446054680c9be5f37a61f6dc17",
+                "url": "https://api.github.com/repos/laminas/laminas-filter/zipball/7c78483f22e118fbc98be41dc24b39e8c17cdcae",
+                "reference": "7c78483f22e118fbc98be41dc24b39e8c17cdcae",
                 "shasum": ""
             },
             "require": {
+                "laminas/laminas-servicemanager": "^3.14.0",
                 "laminas/laminas-stdlib": "^3.6.1",
                 "php": "^7.4 || ~8.0.0 || ~8.1.0"
             },
@@ -31,19 +32,17 @@
             "require-dev": {
                 "laminas/laminas-coding-standard": "^2.3.0",
                 "laminas/laminas-crypt": "^3.5.1",
-                "laminas/laminas-servicemanager": "^3.7.0",
                 "laminas/laminas-uri": "^2.9.1",
                 "pear/archive_tar": "^1.4.14",
                 "phpspec/prophecy-phpunit": "^2.0.1",
                 "phpunit/phpunit": "^9.5.10",
-                "psalm/plugin-phpunit": "^0.15.2",
+                "psalm/plugin-phpunit": "^0.17.0",
                 "psr/http-factory": "^1.0.1",
-                "vimeo/psalm": "^4.13.1"
+                "vimeo/psalm": "^4.24.0"
             },
             "suggest": {
                 "laminas/laminas-crypt": "Laminas\\Crypt component, for encryption filters",
                 "laminas/laminas-i18n": "Laminas\\I18n component for filters depending on i18n functionality",
-                "laminas/laminas-servicemanager": "Laminas\\ServiceManager component, for using the filter chain functionality",
                 "laminas/laminas-uri": "Laminas\\Uri component, for the UriNormalize filter",
                 "psr/http-factory-implementation": "psr/http-factory-implementation, for creating file upload instances when consuming PSR-7 in file upload filters"
             },
@@ -83,20 +82,20 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2022-02-22T23:09:15+00:00"
+            "time": "2022-07-17T11:58:06+00:00"
         },
         {
             "name": "laminas/laminas-servicemanager",
-            "version": "3.12.0",
+            "version": "3.15.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-servicemanager.git",
-                "reference": "05ac4b1fb1fe9333313eeafced9b6c7946589487"
+                "reference": "216f972b179191b14c33a79337947b63bf7808ff"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-servicemanager/zipball/05ac4b1fb1fe9333313eeafced9b6c7946589487",
-                "reference": "05ac4b1fb1fe9333313eeafced9b6c7946589487",
+                "url": "https://api.github.com/repos/laminas/laminas-servicemanager/zipball/216f972b179191b14c33a79337947b63bf7808ff",
+                "reference": "216f972b179191b14c33a79337947b63bf7808ff",
                 "shasum": ""
             },
             "require": {
@@ -126,7 +125,7 @@
                 "phpbench/phpbench": "^1.1",
                 "phpspec/prophecy-phpunit": "^2.0",
                 "phpunit/phpunit": "^9.5.5",
-                "psalm/plugin-phpunit": "^0.16.1",
+                "psalm/plugin-phpunit": "^0.17.0",
                 "vimeo/psalm": "^4.8"
             },
             "suggest": {
@@ -174,7 +173,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2022-06-13T16:20:56+00:00"
+            "time": "2022-07-20T09:48:45+00:00"
         },
         {
             "name": "laminas/laminas-stdlib",
@@ -237,22 +236,22 @@
         },
         {
             "name": "laminas/laminas-validator",
-            "version": "2.19.0",
+            "version": "2.20.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-validator.git",
-                "reference": "4875d4e58b6f728981bb767a60530540f82ee1df"
+                "reference": "90304417929a51e42999b115907a39f4b658c131"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-validator/zipball/4875d4e58b6f728981bb767a60530540f82ee1df",
-                "reference": "4875d4e58b6f728981bb767a60530540f82ee1df",
+                "url": "https://api.github.com/repos/laminas/laminas-validator/zipball/90304417929a51e42999b115907a39f4b658c131",
+                "reference": "90304417929a51e42999b115907a39f4b658c131",
                 "shasum": ""
             },
             "require": {
-                "container-interop/container-interop": "^1.1",
+                "laminas/laminas-servicemanager": "^3.12.0",
                 "laminas/laminas-stdlib": "^3.10",
-                "php": "^7.3 || ~8.0.0 || ~8.1.0"
+                "php": "^7.4 || ~8.0.0 || ~8.1.0"
             },
             "conflict": {
                 "zendframework/zend-validator": "*"
@@ -261,27 +260,24 @@
                 "laminas/laminas-cache": "^2.6.1",
                 "laminas/laminas-coding-standard": "~2.2.1",
                 "laminas/laminas-db": "^2.7",
-                "laminas/laminas-filter": "^2.6",
+                "laminas/laminas-filter": "^2.14.0",
                 "laminas/laminas-http": "^2.14.2",
-                "laminas/laminas-i18n": "^2.6",
-                "laminas/laminas-math": "^2.6",
-                "laminas/laminas-servicemanager": "^2.7.11 || ^3.0.3",
-                "laminas/laminas-session": "^2.8",
-                "laminas/laminas-uri": "^2.7",
+                "laminas/laminas-i18n": "^2.15.0",
+                "laminas/laminas-session": "^2.12.1",
+                "laminas/laminas-uri": "^2.9.1",
                 "phpspec/prophecy-phpunit": "^2.0",
                 "phpunit/phpunit": "^9.5.5",
                 "psalm/plugin-phpunit": "^0.15.0",
                 "psr/http-client": "^1.0",
                 "psr/http-factory": "^1.0",
                 "psr/http-message": "^1.0",
-                "vimeo/psalm": "^4.3"
+                "vimeo/psalm": "^4.23"
             },
             "suggest": {
                 "laminas/laminas-db": "Laminas\\Db component, required by the (No)RecordExists validator",
                 "laminas/laminas-filter": "Laminas\\Filter component, required by the Digits validator",
                 "laminas/laminas-i18n": "Laminas\\I18n component to allow translation of validation error messages",
                 "laminas/laminas-i18n-resources": "Translations of validator messages",
-                "laminas/laminas-math": "Laminas\\Math component, required by the Csrf validator",
                 "laminas/laminas-servicemanager": "Laminas\\ServiceManager component to allow using the ValidatorPluginManager and validator chains",
                 "laminas/laminas-session": "Laminas\\Session component, ^2.8; required by the Csrf validator",
                 "laminas/laminas-uri": "Laminas\\Uri component, required by the Uri and Sitemap\\Loc validators",
@@ -323,7 +319,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2022-06-09T21:49:40+00:00"
+            "time": "2022-07-01T07:39:15+00:00"
         },
         {
             "name": "psr/container",
@@ -1797,58 +1793,6 @@
             "time": "2021-12-08T12:19:24+00:00"
         },
         {
-            "name": "phpspec/prophecy-phpunit",
-            "version": "v2.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpspec/prophecy-phpunit.git",
-                "reference": "2d7a9df55f257d2cba9b1d0c0963a54960657177"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy-phpunit/zipball/2d7a9df55f257d2cba9b1d0c0963a54960657177",
-                "reference": "2d7a9df55f257d2cba9b1d0c0963a54960657177",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.3 || ^8",
-                "phpspec/prophecy": "^1.3",
-                "phpunit/phpunit": "^9.1"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Prophecy\\PhpUnit\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Christophe Coevoet",
-                    "email": "stof@notk.org"
-                }
-            ],
-            "description": "Integrating the Prophecy mocking library in PHPUnit test cases",
-            "homepage": "http://phpspec.net",
-            "keywords": [
-                "phpunit",
-                "prophecy"
-            ],
-            "support": {
-                "issues": "https://github.com/phpspec/prophecy-phpunit/issues",
-                "source": "https://github.com/phpspec/prophecy-phpunit/tree/v2.0.1"
-            },
-            "time": "2020-07-09T08:33:42+00:00"
-        },
-        {
             "name": "phpstan/phpdoc-parser",
             "version": "1.6.4",
             "source": {
@@ -2213,16 +2157,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.5.20",
+            "version": "9.5.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "12bc8879fb65aef2138b26fc633cb1e3620cffba"
+                "reference": "0e32b76be457de00e83213528f6bb37e2a38fcb1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/12bc8879fb65aef2138b26fc633cb1e3620cffba",
-                "reference": "12bc8879fb65aef2138b26fc633cb1e3620cffba",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/0e32b76be457de00e83213528f6bb37e2a38fcb1",
+                "reference": "0e32b76be457de00e83213528f6bb37e2a38fcb1",
                 "shasum": ""
             },
             "require": {
@@ -2256,7 +2200,6 @@
                 "sebastian/version": "^3.0.2"
             },
             "require-dev": {
-                "ext-pdo": "*",
                 "phpspec/prophecy-phpunit": "^2.0.1"
             },
             "suggest": {
@@ -2300,7 +2243,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.20"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.21"
             },
             "funding": [
                 {
@@ -2312,7 +2255,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-04-01T12:37:26+00:00"
+            "time": "2022-06-19T12:14:25+00:00"
         },
         {
             "name": "psalm/plugin-phpunit",
@@ -3560,16 +3503,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v5.4.9",
+            "version": "v5.4.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "829d5d1bf60b2efeb0887b7436873becc71a45eb"
+                "reference": "4d671ab4ddac94ee439ea73649c69d9d200b5000"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/829d5d1bf60b2efeb0887b7436873becc71a45eb",
-                "reference": "829d5d1bf60b2efeb0887b7436873becc71a45eb",
+                "url": "https://api.github.com/repos/symfony/console/zipball/4d671ab4ddac94ee439ea73649c69d9d200b5000",
+                "reference": "4d671ab4ddac94ee439ea73649c69d9d200b5000",
                 "shasum": ""
             },
             "require": {
@@ -3639,7 +3582,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v5.4.9"
+                "source": "https://github.com/symfony/console/tree/v5.4.10"
             },
             "funding": [
                 {
@@ -3655,11 +3598,11 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-05-18T06:17:34+00:00"
+            "time": "2022-06-26T13:00:04+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v2.5.1",
+            "version": "v2.5.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
@@ -3706,7 +3649,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v2.5.1"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v2.5.2"
             },
             "funding": [
                 {
@@ -4218,16 +4161,16 @@
         },
         {
             "name": "symfony/service-contracts",
-            "version": "v2.5.1",
+            "version": "v2.5.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "24d9dc654b83e91aa59f9d167b131bc3b5bea24c"
+                "reference": "4b426aac47d6427cc1a1d0f7e2ac724627f5966c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/24d9dc654b83e91aa59f9d167b131bc3b5bea24c",
-                "reference": "24d9dc654b83e91aa59f9d167b131bc3b5bea24c",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/4b426aac47d6427cc1a1d0f7e2ac724627f5966c",
+                "reference": "4b426aac47d6427cc1a1d0f7e2ac724627f5966c",
                 "shasum": ""
             },
             "require": {
@@ -4281,7 +4224,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/service-contracts/tree/v2.5.1"
+                "source": "https://github.com/symfony/service-contracts/tree/v2.5.2"
             },
             "funding": [
                 {
@@ -4297,20 +4240,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-03-13T20:07:29+00:00"
+            "time": "2022-05-30T19:17:29+00:00"
         },
         {
             "name": "symfony/string",
-            "version": "v5.4.9",
+            "version": "v5.4.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "985e6a9703ef5ce32ba617c9c7d97873bb7b2a99"
+                "reference": "4432bc7df82a554b3e413a8570ce2fea90e94097"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/985e6a9703ef5ce32ba617c9c7d97873bb7b2a99",
-                "reference": "985e6a9703ef5ce32ba617c9c7d97873bb7b2a99",
+                "url": "https://api.github.com/repos/symfony/string/zipball/4432bc7df82a554b3e413a8570ce2fea90e94097",
+                "reference": "4432bc7df82a554b3e413a8570ce2fea90e94097",
                 "shasum": ""
             },
             "require": {
@@ -4367,7 +4310,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v5.4.9"
+                "source": "https://github.com/symfony/string/tree/v5.4.10"
             },
             "funding": [
                 {
@@ -4383,7 +4326,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-04-19T10:40:37+00:00"
+            "time": "2022-06-26T15:57:47+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -4437,16 +4380,16 @@
         },
         {
             "name": "vimeo/psalm",
-            "version": "4.23.0",
+            "version": "4.24.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vimeo/psalm.git",
-                "reference": "f1fe6ff483bf325c803df9f510d09a03fd796f88"
+                "reference": "06dd975cb55d36af80f242561738f16c5f58264f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vimeo/psalm/zipball/f1fe6ff483bf325c803df9f510d09a03fd796f88",
-                "reference": "f1fe6ff483bf325c803df9f510d09a03fd796f88",
+                "url": "https://api.github.com/repos/vimeo/psalm/zipball/06dd975cb55d36af80f242561738f16c5f58264f",
+                "reference": "06dd975cb55d36af80f242561738f16c5f58264f",
                 "shasum": ""
             },
             "require": {
@@ -4538,9 +4481,9 @@
             ],
             "support": {
                 "issues": "https://github.com/vimeo/psalm/issues",
-                "source": "https://github.com/vimeo/psalm/tree/4.23.0"
+                "source": "https://github.com/vimeo/psalm/tree/4.24.0"
             },
-            "time": "2022-04-28T17:35:49+00:00"
+            "time": "2022-06-26T11:47:54+00:00"
         },
         {
             "name": "webimpress/coding-standard",

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="4.23.0@f1fe6ff483bf325c803df9f510d09a03fd796f88">
+<files psalm-version="4.24.0@06dd975cb55d36af80f242561738f16c5f58264f">
   <file src="src/ArrayInput.php">
     <DeprecatedInterface occurrences="1">
       <code>ArrayInput</code>
@@ -39,9 +39,6 @@
     <DocblockTypeContradiction occurrences="1">
       <code>! is_string($name)</code>
     </DocblockTypeContradiction>
-    <InvalidPropertyAssignmentValue occurrences="1">
-      <code>$this-&gt;inputs</code>
-    </InvalidPropertyAssignmentValue>
     <InvalidReturnStatement occurrences="1">
       <code>$messages</code>
     </InvalidReturnStatement>
@@ -122,7 +119,8 @@
       <code>$value</code>
       <code>$value['type']</code>
     </MixedArgument>
-    <MixedArgumentTypeCoercion occurrences="2">
+    <MixedArgumentTypeCoercion occurrences="3">
+      <code>$filter</code>
       <code>$inputSpecification</code>
       <code>$key</code>
     </MixedArgumentTypeCoercion>
@@ -256,9 +254,18 @@
     <InvalidPropertyAssignmentValue occurrences="1">
       <code>$this-&gt;prepareRequiredValidationFailureMessage()</code>
     </InvalidPropertyAssignmentValue>
-    <MixedAssignment occurrences="1">
+    <MixedArgument occurrences="1">
+      <code>$notEmpty-&gt;getTranslatorTextDomain()</code>
+    </MixedArgument>
+    <MixedAssignment occurrences="2">
+      <code>$translator</code>
       <code>$value</code>
     </MixedAssignment>
+    <PossiblyUndefinedMethod occurrences="3">
+      <code>getOption</code>
+      <code>getTranslator</code>
+      <code>getTranslatorTextDomain</code>
+    </PossiblyUndefinedMethod>
     <RedundantCastGivenDocblockType occurrences="4">
       <code>(bool) $allowEmpty</code>
       <code>(bool) $breakOnFailure</code>
@@ -551,16 +558,10 @@
       <code>'invalid_value'</code>
       <code>'invalid_value'</code>
     </InvalidArgument>
-    <MixedAssignment occurrences="2">
-      <code>$defaultFilterChain</code>
-      <code>$defaultValidatorChain</code>
-    </MixedAssignment>
-    <MixedMethodCall occurrences="9">
+    <MixedMethodCall occurrences="7">
       <code>count</code>
       <code>count</code>
       <code>getFilters</code>
-      <code>getPluginManager</code>
-      <code>getPluginManager</code>
       <code>method</code>
       <code>method</code>
       <code>will</code>
@@ -629,9 +630,6 @@
       <code>UploadedFileInterface</code>
     </ImplementedReturnTypeMismatch>
     <InvalidReturnType occurrences="1"/>
-    <MixedArgumentTypeCoercion occurrences="1">
-      <code>[$upload, 'reveal']</code>
-    </MixedArgumentTypeCoercion>
     <NonInvariantDocblockPropertyType occurrences="1">
       <code>$input</code>
     </NonInvariantDocblockPropertyType>
@@ -692,9 +690,6 @@
   </file>
   <file src="test/InputFilterPluginManagerFactoryTest.php">
     <LessSpecificReturnStatement occurrences="1"/>
-    <MissingClosureReturnType occurrences="1">
-      <code>function () use ($inputFilter) {</code>
-    </MissingClosureReturnType>
     <MoreSpecificReturnType occurrences="1">
       <code>array&lt;string, array{0: class-string&lt;InputInterface&gt;}&gt;</code>
     </MoreSpecificReturnType>
@@ -710,9 +705,6 @@
       <code>getPluginManager</code>
       <code>getPluginManager</code>
     </PossiblyNullReference>
-    <RedundantConditionGivenDocblockType occurrences="1">
-      <code>method_exists($this-&gt;manager, 'configure')</code>
-    </RedundantConditionGivenDocblockType>
   </file>
   <file src="test/InputFilterTest.php">
     <ImplementedReturnTypeMismatch occurrences="1"/>
@@ -771,7 +763,7 @@
   </file>
   <file src="test/ModuleTest.php">
     <InvalidArgument occurrences="1">
-      <code>$moduleManager-&gt;reveal()</code>
+      <code>$moduleManager</code>
     </InvalidArgument>
     <MixedArgument occurrences="3">
       <code>$config['input_filters']['abstract_factories']</code>

--- a/test/FactoryTest.php
+++ b/test/FactoryTest.php
@@ -22,20 +22,17 @@ use Laminas\Validator;
 use LaminasTest\InputFilter\TestAsset\CustomInput;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use Prophecy\Argument;
-use Prophecy\PhpUnit\ProphecyTrait;
-use ReflectionProperty;
 
 use function count;
 use function sprintf;
+
+// phpcs:ignore
 
 /**
  * @covers \Laminas\InputFilter\Factory
  */
 class FactoryTest extends TestCase
 {
-    use ProphecyTrait;
-
     public function testCreateInputWithInvalidDataTypeThrowsInvalidArgumentException(): void
     {
         $factory = $this->createDefaultFactory();
@@ -1049,37 +1046,29 @@ class FactoryTest extends TestCase
 
     public function testWhenCreateInputPullsInputFromThePluginManagerItMustNotOverwriteFilterAndValidatorChains(): void
     {
-        $input = $this->prophesize(InputInterface::class);
-        $input->setFilterChain(Argument::any())->shouldNotBeCalled();
-        $input->setValidatorChain(Argument::any())->shouldNotBeCalled();
+        $input          = new Input();
+        $filterChain    = new Filter\FilterChain();
+        $validatorChain = new Validator\ValidatorChain();
+        $input->setFilterChain($filterChain);
+        $input->setValidatorChain($validatorChain);
 
-        $pluginManager = $this->prophesize(InputFilterPluginManager::class);
-        $pluginManager->populateFactoryPluginManagers(Argument::type(Factory::class))->shouldBeCalled();
-        $pluginManager->has('Some\Test\Input')->willReturn(true);
-        $pluginManager->get('Some\Test\Input')->will([$input, 'reveal']);
+        $pluginManager = new InputFilterPluginManager(new ServiceManager\ServiceManager());
+        $pluginManager->setService('Some\Test\Input', $input);
 
-        $spec = ['type' => 'Some\Test\Input'];
+        $factory               = new Factory($pluginManager);
+        $defaultFilterChain    = new Filter\FilterChain();
+        $defaultValidatorChain = new Validator\ValidatorChain();
+        $factory->setDefaultFilterChain($defaultFilterChain);
+        $factory->setDefaultValidatorChain($defaultValidatorChain);
 
-        $factory = new Factory($pluginManager->reveal());
+        $spec         = ['type' => 'Some\Test\Input'];
+        $createdInput = $factory->createInput($spec);
 
-        $r = new ReflectionProperty($factory, 'defaultFilterChain');
-        $r->setAccessible(true);
-        $defaultFilterChain = $r->getValue($factory);
-
-        $filterChain = $this->prophesize(Filter\FilterChain::class);
-        $filterChain->setPluginManager($defaultFilterChain->getPluginManager())->shouldBeCalled();
-
-        $r = new ReflectionProperty($factory, 'defaultValidatorChain');
-        $r->setAccessible(true);
-        $defaultValidatorChain = $r->getValue($factory);
-
-        $validatorChain = $this->prophesize(Validator\ValidatorChain::class);
-        $validatorChain->setPluginManager($defaultValidatorChain->getPluginManager())->shouldBeCalled();
-
-        $input->getFilterChain()->will([$filterChain, 'reveal'])->shouldBeCalled();
-        $input->getValidatorChain()->will([$validatorChain, 'reveal'])->shouldBeCalled();
-
-        $this->assertSame($input->reveal(), $factory->createInput($spec));
+        self::assertSame($input, $createdInput);
+        self::assertSame($filterChain, $input->getFilterChain());
+        self::assertSame($validatorChain, $input->getValidatorChain());
+        self::assertNotSame($defaultFilterChain, $input->getFilterChain());
+        self::assertNotSame($defaultValidatorChain, $input->getValidatorChain());
     }
 
     public function testFactoryCanCreateCollectionInputFilterWithRequiredMessage(): void

--- a/test/FactoryTest.php
+++ b/test/FactoryTest.php
@@ -26,8 +26,6 @@ use PHPUnit\Framework\TestCase;
 use function count;
 use function sprintf;
 
-// phpcs:ignore
-
 /**
  * @covers \Laminas\InputFilter\Factory
  */

--- a/test/FileInput/TestAsset/InitializableInputFilterInterface.php
+++ b/test/FileInput/TestAsset/InitializableInputFilterInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\InputFilter\FileInput\TestAsset;
+
+use Laminas\InputFilter\InputFilterInterface;
+use Laminas\Stdlib\InitializableInterface;
+
+interface InitializableInputFilterInterface extends InputFilterInterface, InitializableInterface
+{
+}

--- a/test/InputFilterAbstractServiceFactoryTest.php
+++ b/test/InputFilterAbstractServiceFactoryTest.php
@@ -15,9 +15,7 @@ use Laminas\Validator;
 use Laminas\Validator\ValidatorInterface;
 use Laminas\Validator\ValidatorPluginManager;
 use LaminasTest\InputFilter\TestAsset\Foo;
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use Prophecy\PhpUnit\ProphecyTrait;
 
 use function call_user_func_array;
 use function count;
@@ -27,8 +25,6 @@ use function count;
  */
 class InputFilterAbstractServiceFactoryTest extends TestCase
 {
-    use ProphecyTrait;
-
     /** @var ServiceManager */
     protected $services;
 
@@ -109,8 +105,7 @@ class InputFilterAbstractServiceFactoryTest extends TestCase
         $filters->setService('foo', $filter);
 
         $validators = new ValidatorPluginManager($this->services);
-        /** @var ValidatorInterface|MockObject $validator */
-        $validator = $this->createMock(ValidatorInterface::class);
+        $validator  = $this->createMock(ValidatorInterface::class);
         $validators->setService('foo', $validator);
 
         $this->services->setService(FilterPluginManager::class, $filters);
@@ -171,8 +166,7 @@ class InputFilterAbstractServiceFactoryTest extends TestCase
             ],
         ]);
         $validators = new ValidatorPluginManager($this->services);
-        /** @var ValidatorInterface|MockObject $validator */
-        $validator = $this->createMock(ValidatorInterface::class);
+        $validator  = $this->createMock(ValidatorInterface::class);
         $this->services->setService(ValidatorPluginManager::class, $validators);
         $validators->setService('foo', $validator);
 
@@ -227,7 +221,7 @@ class InputFilterAbstractServiceFactoryTest extends TestCase
      */
     public function testWillUseCustomFiltersWhenProvided(): void
     {
-        $filter = $this->prophesize(Filter\FilterInterface::class)->reveal();
+        $filter = $this->createMock(Filter\FilterInterface::class);
 
         $filters = new FilterPluginManager($this->services);
         $filters->setService('CustomFilter', $filter);

--- a/test/InputFilterPluginManagerTest.php
+++ b/test/InputFilterPluginManagerTest.php
@@ -177,7 +177,8 @@ class InputFilterPluginManagerTest extends TestCase
     public function testServicesAreInitiatedIfImplementsInitializableInterface(): void
     {
         $mock = $this->createMock(InitializableInputFilterInterface::class);
-        $mock->expects(self::once())->method('init');
+        // Init is called twice. Once during `setService` and once during `get`
+        $mock->expects(self::exactly(2))->method('init');
         $this->manager->setService('PluginName', $mock);
         $this->assertSame($mock, $this->manager->get('PluginName'), 'get() value not match');
     }

--- a/test/InputFilterPluginManagerTest.php
+++ b/test/InputFilterPluginManagerTest.php
@@ -15,11 +15,10 @@ use Laminas\ServiceManager\AbstractPluginManager;
 use Laminas\ServiceManager\Exception\InvalidServiceException;
 use Laminas\ServiceManager\ServiceLocatorInterface;
 use Laminas\ServiceManager\ServiceManager;
-use Laminas\Stdlib\InitializableInterface;
 use Laminas\Validator\ValidatorPluginManager;
+use LaminasTest\InputFilter\FileInput\TestAsset\InitializableInputFilterInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use Prophecy\PhpUnit\ProphecyTrait;
 use ReflectionObject;
 
 use function method_exists;
@@ -29,8 +28,6 @@ use function method_exists;
  */
 class InputFilterPluginManagerTest extends TestCase
 {
-    use ProphecyTrait;
-
     /** @var InputFilterPluginManager */
     protected $manager;
 
@@ -157,7 +154,7 @@ class InputFilterPluginManagerTest extends TestCase
         $inputFilterInterfaceMock = $this->createInputFilterInterfaceMock();
         $inputInterfaceMock       = $this->createInputInterfaceMock();
 
-        // phpcs:disable
+        // phpcs:disable Generic.Files.LineLength.TooLong
         return [
             // Description         => [$serviceName,                  $service,                  $instanceOf]
             'InputFilterInterface' => ['inputFilterInterfaceService', $inputFilterInterfaceMock, InputFilterInterface::class],
@@ -177,23 +174,12 @@ class InputFilterPluginManagerTest extends TestCase
         $this->assertSame($service, $this->manager->get($serviceName), 'get() value not match');
     }
 
-    /**
-     * @dataProvider serviceProvider
-     * @param class-string<InputInterface> $instanceOf
-     */
-    public function testServicesAreInitiatedIfImplementsInitializableInterface(
-        string $serviceName,
-        object $service,
-        string $instanceOf
-    ): void {
-        $initializableProphecy = $this->prophesize($instanceOf)->willImplement(InitializableInterface::class);
-        $service               = $initializableProphecy->reveal();
-
-        $this->manager->setService($serviceName, $service);
-        $this->assertSame($service, $this->manager->get($serviceName), 'get() value not match');
-
-        /** @noinspection PhpUndefinedMethodInspection */
-        $initializableProphecy->init()->shouldBeCalled();
+    public function testServicesAreInitiatedIfImplementsInitializableInterface(): void
+    {
+        $mock = $this->createMock(InitializableInputFilterInterface::class);
+        $mock->expects(self::once())->method('init');
+        $this->manager->setService('PluginName', $mock);
+        $this->assertSame($mock, $this->manager->get('PluginName'), 'get() value not match');
     }
 
     public function testPopulateFactoryCanAcceptInputFilterAsFirstArgumentAndWillUseFactoryWhenItDoes(): void

--- a/test/InputTest.php
+++ b/test/InputTest.php
@@ -13,7 +13,6 @@ use Laminas\Validator\ValidatorChain;
 use Laminas\Validator\ValidatorInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use Prophecy\PhpUnit\ProphecyTrait;
 use stdClass;
 use Webmozart\Assert\Assert;
 
@@ -28,8 +27,6 @@ use function json_encode;
  */
 class InputTest extends TestCase
 {
-    use ProphecyTrait;
-
     /** @var Input */
     protected $input;
 
@@ -732,13 +729,14 @@ class InputTest extends TestCase
         $validatorMsg = ['FooValidator' => 'Invalid Value'];
         $notEmptyMsg  = ['isEmpty' => "Value is required and can't be empty"];
 
+        // phpcs:disable Generic.Formatting.MultipleStatementAlignment.NotSame
         $validatorNotCall = function ($value, $context = null): ValidatorInterface {
             return $this->createValidatorMock(null, $value, $context);
         };
         $validatorInvalid = function ($value, $context = null) use ($validatorMsg): ValidatorInterface {
             return $this->createValidatorMock(false, $value, $context, $validatorMsg);
         };
-        $validatorValid   = function ($value, $context = null): ValidatorInterface {
+        $validatorValid = function ($value, $context = null): ValidatorInterface {
             return $this->createValidatorMock(true, $value, $context);
         };
 

--- a/test/ModuleTest.php
+++ b/test/ModuleTest.php
@@ -9,12 +9,9 @@ use Laminas\InputFilter\InputFilterAbstractServiceFactory;
 use Laminas\InputFilter\InputFilterPluginManager;
 use Laminas\InputFilter\Module;
 use PHPUnit\Framework\TestCase;
-use Prophecy\PhpUnit\ProphecyTrait;
 
 class ModuleTest extends TestCase
 {
-    use ProphecyTrait;
-
     /** @var Module */
     private $module;
 
@@ -67,26 +64,36 @@ class ModuleTest extends TestCase
     public function testInitMethodShouldRegisterPluginManagerSpecificationWithServiceListener(): void
     {
         // Service listener
-        $serviceListener = $this->prophesize(TestAsset\ServiceListenerInterface::class);
-        $serviceListener->addServiceManager(
-            'InputFilterManager',
-            'input_filters',
-            'Laminas\ModuleManager\Feature\InputFilterProviderInterface',
-            'getInputFilterConfig'
-        )->shouldBeCalled();
+        $serviceListener = $this->createMock(TestAsset\ServiceListenerInterface::class);
+        $serviceListener->expects(self::once())
+            ->method('addServiceManager')
+            ->with(
+                'InputFilterManager',
+                'input_filters',
+                'Laminas\ModuleManager\Feature\InputFilterProviderInterface',
+                'getInputFilterConfig'
+            );
 
         // Container
-        $container = $this->prophesize(ContainerInterface::class);
-        $container->get('ServiceListener')->will([$serviceListener, 'reveal']);
+        $container = $this->createMock(ContainerInterface::class);
+        $container->expects(self::once())
+            ->method('get')
+            ->with('ServiceListener')
+            ->willReturn($serviceListener);
 
         // Event
-        $event = $this->prophesize(TestAsset\ModuleEventInterface::class);
-        $event->getParam('ServiceManager')->will([$container, 'reveal']);
+        $event = $this->createMock(TestAsset\ModuleEventInterface::class);
+        $event->expects(self::once())
+            ->method('getParam')
+            ->with('ServiceManager')
+            ->willReturn($container);
 
         // Module manager
-        $moduleManager = $this->prophesize(TestAsset\ModuleManagerInterface::class);
-        $moduleManager->getEvent()->will([$event, 'reveal']);
+        $moduleManager = $this->createMock(TestAsset\ModuleManagerInterface::class);
+        $moduleManager->expects(self::once())
+            ->method('getEvent')
+            ->willReturn($event);
 
-        $this->assertNull($this->module->init($moduleManager->reveal()));
+        $this->module->init($moduleManager);
     }
 }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| QA            | yes

### Description

- Alters tests to use PHPUnit mocks enabling the removal of 2 dev dependencies
- Updates locked dependencies
- Bumps dev dependencies to most recent versions
- Expands psalm baseline with newly discovered issues, removing those solved by using phpunit mocks

There is 1 failing test case that should pass IMO - the previous prophecy constraint did not assert that `init()` is called only once for input filters. It is called twice because `init` is called from `validate` in input filter plugin manager, and `validate` is called both in `setService` and in `get` of `AbstractPluginManager`. I'm not convinced this is desirable behaviour, regardless, it can't be fixed here.
