### PR TITLE
Remove Interop\Container & Bump minimum Service Manager to 3.16

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,17 +33,17 @@
     "require": {
         "php": "^7.4 || ~8.0.0 || ~8.1.0",
         "laminas/laminas-filter": "^2.13",
-        "laminas/laminas-servicemanager": "^3.12.0",
+        "laminas/laminas-servicemanager": "^3.16.0",
         "laminas/laminas-stdlib": "^3.0",
         "laminas/laminas-validator": "^2.15"
     },
     "require-dev": {
         "laminas/laminas-coding-standard": "~2.4.0",
-        "laminas/laminas-db": "^2.13.4",
-        "phpunit/phpunit": "^9.5.21",
+        "laminas/laminas-db": "^2.15.0",
+        "phpunit/phpunit": "^9.5.24",
         "psalm/plugin-phpunit": "^0.17.0",
         "psr/http-message": "^1.0",
-        "vimeo/psalm": "^4.24.0"
+        "vimeo/psalm": "^4.27.0"
     },
     "suggest": {
         "psr/http-message-implementation": "PSR-7 is required if you wish to validate PSR-7 UploadedFileInterface payloads"

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,8 @@
         "phpunit/phpunit": "^9.5.24",
         "psalm/plugin-phpunit": "^0.17.0",
         "psr/http-message": "^1.0",
-        "vimeo/psalm": "^4.27.0"
+        "vimeo/psalm": "^4.27.0",
+        "webmozart/assert": "^1.11"
     },
     "suggest": {
         "psr/http-message-implementation": "PSR-7 is required if you wish to validate PSR-7 UploadedFileInterface payloads"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "98bc2992b302cdfc96ab6512f923470c",
+    "content-hash": "08aa92300a56ddf47ebe41dbf462abbe",
     "packages": [
         {
             "name": "laminas/laminas-filter",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "08aa92300a56ddf47ebe41dbf462abbe",
+    "content-hash": "6bd9a64e397c06da13f6729669f299c3",
     "packages": [
         {
             "name": "laminas/laminas-filter",

--- a/docs/book/application-integration/usage-in-a-laminas-mvc-application.md
+++ b/docs/book/application-integration/usage-in-a-laminas-mvc-application.md
@@ -90,7 +90,7 @@ e.g. `src/Album/Handler/ListHandlerFactory.php`:
 namespace Album\Controller;
 
 use Album\InputFilter\QueryInputFilter;
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use Laminas\InputFilter\InputFilterPluginManager;
 use Laminas\ServiceManager\Factory\FactoryInterface;
 

--- a/src/InputFilterAbstractServiceFactory.php
+++ b/src/InputFilterAbstractServiceFactory.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace Laminas\InputFilter;
 
-use Interop\Container\ContainerInterface; // phpcs:ignore
 use Laminas\Filter\FilterChain;
 use Laminas\Filter\FilterPluginManager;
 use Laminas\ServiceManager\AbstractFactoryInterface;
 use Laminas\ServiceManager\ServiceLocatorInterface;
 use Laminas\Validator\ValidatorChain;
 use Laminas\Validator\ValidatorPluginManager;
+use Psr\Container\ContainerInterface;
 
 use function assert;
 use function is_array;

--- a/src/InputFilterPluginManager.php
+++ b/src/InputFilterPluginManager.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Laminas\InputFilter;
 
-use Interop\Container\ContainerInterface; // phpcs:ignore
 use Laminas\Filter\FilterPluginManager;
 use Laminas\ServiceManager\AbstractPluginManager;
 use Laminas\ServiceManager\ConfigInterface;
@@ -13,6 +12,7 @@ use Laminas\ServiceManager\Factory\InvokableFactory;
 use Laminas\ServiceManager\ServiceManager;
 use Laminas\Stdlib\InitializableInterface;
 use Laminas\Validator\ValidatorPluginManager;
+use Psr\Container\ContainerInterface;
 use Psr\Container\ContainerInterface as PsrContainerInterface;
 
 use function get_class;

--- a/src/InputFilterPluginManagerFactory.php
+++ b/src/InputFilterPluginManagerFactory.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 namespace Laminas\InputFilter;
 
 use ArrayAccess;
-use Interop\Container\ContainerInterface; // phpcs:ignore
 use Laminas\ServiceManager\Config;
 use Laminas\ServiceManager\FactoryInterface;
 use Laminas\ServiceManager\ServiceLocatorInterface;
 use Laminas\ServiceManager\ServiceManager;
+use Psr\Container\ContainerInterface;
 use Psr\Container\ContainerInterface as PsrContainer;
 
 use function assert;

--- a/test/FactoryTest.php
+++ b/test/FactoryTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace LaminasTest\InputFilter;
 
-use Interop\Container\ContainerInterface; // phpcs:ignore
 use Laminas\Filter;
 use Laminas\InputFilter\CollectionInputFilter;
 use Laminas\InputFilter\Exception\InvalidArgumentException;
@@ -22,6 +21,7 @@ use Laminas\Validator;
 use LaminasTest\InputFilter\TestAsset\CustomInput;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
 
 use function count;
 use function sprintf;

--- a/test/InputFilterPluginManagerFactoryTest.php
+++ b/test/InputFilterPluginManagerFactoryTest.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace LaminasTest\InputFilter;
 
-use Interop\Container\ContainerInterface; // phpcs:ignore
 use Laminas\InputFilter\InputFilterInterface;
 use Laminas\InputFilter\InputFilterPluginManager;
 use Laminas\InputFilter\InputFilterPluginManagerFactory;
 use Laminas\InputFilter\InputInterface;
 use Laminas\ServiceManager\ServiceLocatorInterface;
 use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
 use ReflectionObject;
 
 class InputFilterPluginManagerFactoryTest extends TestCase

--- a/test/ModuleTest.php
+++ b/test/ModuleTest.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace LaminasTest\InputFilter;
 
-use Interop\Container\ContainerInterface; // phpcs:ignore
 use Laminas\InputFilter\InputFilterAbstractServiceFactory;
 use Laminas\InputFilter\InputFilterPluginManager;
 use Laminas\InputFilter\Module;
 use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
 
 class ModuleTest extends TestCase
 {

--- a/test/TestAsset/FooAbstractFactory.php
+++ b/test/TestAsset/FooAbstractFactory.php
@@ -2,9 +2,9 @@
 
 namespace LaminasTest\InputFilter\TestAsset;
 
-use Interop\Container\ContainerInterface;
 use Laminas\ServiceManager\AbstractFactoryInterface;
 use Laminas\ServiceManager\ServiceLocatorInterface;
+use Psr\Container\ContainerInterface;
 
 class FooAbstractFactory implements AbstractFactoryInterface
 {


### PR DESCRIPTION
Because service manager is directly required, all references to `Interop\Container` can be completely removed

Closes #51 