### PR TITLE
Reduce Psalm Baseline, refine types returned by configurator objects

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,7 @@
         "laminas/laminas-validator": "^2.15"
     },
     "require-dev": {
+        "ext-json": "*",
         "laminas/laminas-coding-standard": "~2.4.0",
         "laminas/laminas-db": "^2.15.0",
         "phpunit/phpunit": "^9.5.24",
@@ -62,6 +63,7 @@
     "scripts": {
         "check": [
             "@cs-check",
+            "@static-analysis",
             "@test"
         ],
         "cs-check": "phpcs",

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="4.24.0@06dd975cb55d36af80f242561738f16c5f58264f">
+<files psalm-version="4.27.0@faf106e717c37b8c81721845dba9de3d8deed8ff">
   <file src="src/ArrayInput.php">
     <DeprecatedInterface occurrences="1">
       <code>ArrayInput</code>
@@ -36,9 +36,6 @@
     </NonInvariantDocblockPropertyType>
   </file>
   <file src="src/BaseInputFilter.php">
-    <InvalidPropertyAssignmentValue occurrences="1">
-      <code>$this-&gt;inputs</code>
-    </InvalidPropertyAssignmentValue>
     <InvalidReturnStatement occurrences="1">
       <code>$messages</code>
     </InvalidReturnStatement>
@@ -159,9 +156,6 @@
     <DeprecatedProperty occurrences="1">
       <code>$this-&gt;notEmptyValidator</code>
     </DeprecatedProperty>
-    <DocblockTypeContradiction occurrences="1">
-      <code>$this-&gt;implementation === null</code>
-    </DocblockTypeContradiction>
     <InvalidPropertyAssignmentValue occurrences="1">
       <code>$this-&gt;prepareRequiredValidationFailureMessage()</code>
     </InvalidPropertyAssignmentValue>
@@ -171,12 +165,6 @@
     <MoreSpecificImplementedParamType occurrences="1">
       <code>$value</code>
     </MoreSpecificImplementedParamType>
-    <PossiblyNullPropertyAssignmentValue occurrences="1">
-      <code>null</code>
-    </PossiblyNullPropertyAssignmentValue>
-    <PropertyNotSetInConstructor occurrences="1">
-      <code>$implementation</code>
-    </PropertyNotSetInConstructor>
   </file>
   <file src="src/FileInput/HttpServerFileInputDecorator.php">
     <DeprecatedInterface occurrences="1">
@@ -331,7 +319,7 @@
     </ImplementedReturnTypeMismatch>
   </file>
   <file src="test/ArrayInputTest.php">
-    <ImplementedReturnTypeMismatch occurrences="3">
+    <ImplementedReturnTypeMismatch occurrences="2">
       <code>string[]</code>
     </ImplementedReturnTypeMismatch>
     <InvalidReturnStatement occurrences="1">
@@ -376,12 +364,10 @@
     </RedundantCondition>
   </file>
   <file src="test/BaseInputFilterTest.php">
-    <InvalidArgument occurrences="5">
+    <InvalidArgument occurrences="3">
       <code>$input</code>
       <code>$input</code>
       <code>['nested' =&gt; ['nested-input1', 'nested-input2']]</code>
-      <code>new stdClass()</code>
-      <code>new stdClass()</code>
     </InvalidArgument>
     <InvalidDocblock occurrences="1">
       <code>public function addMethodArgumentsProvider(): array</code>
@@ -396,12 +382,7 @@
       <code>$inputTypeData</code>
       <code>$set</code>
     </MissingClosureParamType>
-    <MissingClosureReturnType occurrences="5">
-      <code>function ($data) {</code>
-      <code>function ($inputTypeData) {</code>
-      <code>function ($inputTypeData) {</code>
-      <code>fn ($inputTypeData)</code>
-    </MissingClosureReturnType>
+    <MissingClosureReturnType occurrences="3"/>
     <MixedArgument occurrences="6">
       <code>$data</code>
       <code>$dataTypes['Traversable']($data)</code>
@@ -483,8 +464,7 @@
     <ArgumentTypeCoercion occurrences="1">
       <code>$expectedType</code>
     </ArgumentTypeCoercion>
-    <InvalidArgument occurrences="2">
-      <code>new stdClass()</code>
+    <InvalidArgument occurrences="1">
       <code>testDataVsValid</code>
     </InvalidArgument>
     <InvalidReturnStatement occurrences="2"/>
@@ -494,12 +474,7 @@
     <MissingClosureParamType occurrences="1">
       <code>$set</code>
     </MissingClosureParamType>
-    <MissingClosureReturnType occurrences="6">
-      <code>function () use ($dataRaw, $dataFiltered) {</code>
-      <code>function () use ($dataRaw, $dataFiltered) {</code>
-      <code>function () use ($dataRaw, $dataFiltered, $errorMessage) {</code>
-      <code>fn ()</code>
-    </MissingClosureReturnType>
+    <MissingClosureReturnType occurrences="3"/>
     <MixedArgumentTypeCoercion occurrences="1">
       <code>$inputFilter</code>
     </MixedArgumentTypeCoercion>
@@ -516,81 +491,26 @@
     <MixedFunctionCall occurrences="1">
       <code>$set[3]()</code>
     </MixedFunctionCall>
-    <MixedMethodCall occurrences="11">
-      <code>method</code>
-      <code>method</code>
-      <code>method</code>
-      <code>method</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>with</code>
-      <code>with</code>
-    </MixedMethodCall>
     <MixedReturnTypeCoercion occurrences="2">
       <code>$dataSets</code>
     </MixedReturnTypeCoercion>
-    <PossiblyInvalidArgument occurrences="2">
-      <code>$baseInputFilter</code>
-      <code>$baseInputFilter</code>
-    </PossiblyInvalidArgument>
-    <PossiblyUndefinedMethod occurrences="7">
-      <code>expects</code>
-      <code>expects</code>
-      <code>expects</code>
-      <code>expects</code>
-      <code>method</code>
-      <code>method</code>
-      <code>method</code>
-    </PossiblyUndefinedMethod>
   </file>
   <file src="test/FactoryTest.php">
-    <DeprecatedMethod occurrences="7">
+    <DeprecatedMethod occurrences="5">
       <code>allowEmpty</code>
       <code>allowEmpty</code>
       <code>allowEmpty</code>
       <code>allowEmpty</code>
       <code>continueIfEmpty</code>
-      <code>setMethods</code>
-      <code>setMethods</code>
     </DeprecatedMethod>
-    <InvalidArgument occurrences="3">
-      <code>'invalid_value'</code>
-      <code>'invalid_value'</code>
-    </InvalidArgument>
-    <MixedMethodCall occurrences="7">
-      <code>count</code>
-      <code>count</code>
-      <code>getFilters</code>
-      <code>method</code>
-      <code>method</code>
-      <code>will</code>
-      <code>will</code>
-    </MixedMethodCall>
-    <PossiblyInvalidArgument occurrences="2">
-      <code>$provider</code>
-      <code>$provider</code>
-    </PossiblyInvalidArgument>
+    <InvalidArgument occurrences="1"/>
     <PossiblyNullReference occurrences="2">
       <code>getPluginManager</code>
       <code>getPluginManager</code>
     </PossiblyNullReference>
-    <PossiblyUndefinedMethod occurrences="13">
+    <PossiblyUndefinedMethod occurrences="2">
       <code>breakOnFailure</code>
       <code>breakOnFailure</code>
-      <code>expects</code>
-      <code>expects</code>
-      <code>getErrorMessage</code>
-      <code>getErrorMessage</code>
-      <code>getFilterChain</code>
-      <code>getFilterChain</code>
-      <code>getName</code>
-      <code>getName</code>
-      <code>getValidatorChain</code>
-      <code>isRequired</code>
-      <code>setValue</code>
     </PossiblyUndefinedMethod>
     <RawObjectIteration occurrences="1">
       <code>$chain</code>
@@ -600,9 +520,6 @@
     </UndefinedInterfaceMethod>
   </file>
   <file src="test/FileInput/HttpServerFileInputDecoratorTest.php">
-    <DeprecatedMethod occurrences="1">
-      <code>setMethods</code>
-    </DeprecatedMethod>
     <ImplementedReturnTypeMismatch occurrences="1">
       <code>array&lt;string, string&gt;</code>
     </ImplementedReturnTypeMismatch>
@@ -616,10 +533,6 @@
     <InvalidReturnType occurrences="1">
       <code>iterable</code>
     </InvalidReturnType>
-    <LessSpecificReturnStatement occurrences="1"/>
-    <MoreSpecificReturnType occurrences="1">
-      <code>array</code>
-    </MoreSpecificReturnType>
     <NonInvariantDocblockPropertyType occurrences="1">
       <code>$input</code>
     </NonInvariantDocblockPropertyType>
@@ -628,7 +541,7 @@
     </PropertyTypeCoercion>
   </file>
   <file src="test/FileInput/PsrFileInputDecoratorTest.php">
-    <ImplementedReturnTypeMismatch occurrences="4">
+    <ImplementedReturnTypeMismatch occurrences="3">
       <code>UploadedFileInterface</code>
     </ImplementedReturnTypeMismatch>
     <InvalidReturnType occurrences="1"/>
@@ -641,40 +554,6 @@
     <TypeDoesNotContainType occurrences="1">
       <code>$generator instanceof Generator</code>
     </TypeDoesNotContainType>
-  </file>
-  <file src="test/InputFilterAbstractServiceFactoryTest.php">
-    <MissingClosureReturnType occurrences="1">
-      <code>function () {</code>
-    </MissingClosureReturnType>
-    <MixedArgument occurrences="4">
-      <code>$filterChain</code>
-      <code>$filterChain</code>
-      <code>$validatorChain</code>
-      <code>$validatorChain</code>
-    </MixedArgument>
-    <MixedAssignment occurrences="4">
-      <code>$filterChain</code>
-      <code>$input</code>
-      <code>$inputFilter</code>
-      <code>$validatorChain</code>
-    </MixedAssignment>
-    <MixedMethodCall occurrences="9">
-      <code>get</code>
-      <code>getFilterChain</code>
-      <code>getInputFilterManager</code>
-      <code>getPluginManager</code>
-      <code>getPluginManager</code>
-      <code>getValidatorChain</code>
-      <code>has</code>
-      <code>plugin</code>
-      <code>plugin</code>
-    </MixedMethodCall>
-    <UndefinedInterfaceMethod occurrences="1">
-      <code>getFactory</code>
-    </UndefinedInterfaceMethod>
-    <MissingClosureReturnType occurrences="1">
-      <code>static function () {</code>
-    </MissingClosureReturnType>
   </file>
   <file src="test/InputFilterAwareTraitTest.php">
     <InvalidScalarArgument occurrences="2">
@@ -693,33 +572,15 @@
       <code>getInstanceOf</code>
     </InvalidReturnType>
   </file>
-  <file src="test/InputFilterPluginManagerFactoryTest.php">
-    <LessSpecificReturnStatement occurrences="1"/>
-    <MoreSpecificReturnType occurrences="1">
-      <code>array&lt;string, array{0: class-string&lt;InputInterface&gt;}&gt;</code>
-    </MoreSpecificReturnType>
-  </file>
   <file src="test/InputFilterPluginManagerTest.php">
-    <ArgumentTypeCoercion occurrences="2">
-      <code>$this-&gt;getServiceNotFoundException()</code>
-      <code>$this-&gt;getServiceNotFoundException()</code>
-    </ArgumentTypeCoercion>
     <LessSpecificReturnStatement occurrences="1"/>
     <MoreSpecificReturnType occurrences="1"/>
-    <PossiblyNullReference occurrences="2">
-      <code>getPluginManager</code>
-      <code>getPluginManager</code>
-    </PossiblyNullReference>
   </file>
   <file src="test/InputFilterTest.php">
     <ImplementedReturnTypeMismatch occurrences="1"/>
     <LessSpecificReturnStatement occurrences="1">
       <code>$dataSets</code>
     </LessSpecificReturnStatement>
-    <MixedArrayAccess occurrences="2">
-      <code>$filter1-&gt;getValues()['nested']['nestedField1']</code>
-      <code>$filter1-&gt;getValues()['nested']['nestedField1']</code>
-    </MixedArrayAccess>
     <MoreSpecificReturnType occurrences="1"/>
     <NonInvariantDocblockPropertyType occurrences="1">
       <code>$inputFilter</code>
@@ -766,37 +627,9 @@
       <code>isArray</code>
     </RedundantCondition>
   </file>
-  <file src="test/ModuleTest.php">
-    <InvalidArgument occurrences="1">
-      <code>$moduleManager</code>
-    </InvalidArgument>
-    <MixedArgument occurrences="3">
-      <code>$config['input_filters']['abstract_factories']</code>
-      <code>$config['service_manager']['aliases']</code>
-      <code>$config['service_manager']['factories']</code>
-    </MixedArgument>
-    <MixedArrayAccess occurrences="3">
-      <code>$config['input_filters']['abstract_factories']</code>
-      <code>$config['service_manager']['aliases']</code>
-      <code>$config['service_manager']['factories']</code>
-    </MixedArrayAccess>
-  </file>
   <file src="test/TestAsset/CustomInput.php">
     <DeprecatedInterface occurrences="1">
       <code>CustomInput</code>
     </DeprecatedInterface>
-  </file>
-  <file src="test/TestAsset/FooAbstractFactory.php">
-    <DeprecatedInterface occurrences="1">
-      <code>FooAbstractFactory</code>
-    </DeprecatedInterface>
-    <InvalidNullableReturnType occurrences="1">
-      <code>canCreate</code>
-    </InvalidNullableReturnType>
-    <ParamNameMismatch occurrences="3">
-      <code>$container</code>
-      <code>$container</code>
-      <code>$name</code>
-    </ParamNameMismatch>
   </file>
 </files>

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -4,12 +4,18 @@ declare(strict_types=1);
 
 namespace Laminas\InputFilter;
 
+use Laminas\ServiceManager\ConfigInterface;
+
+/** @psalm-import-type ServiceManagerConfigurationType from ConfigInterface */
 class ConfigProvider
 {
     /**
      * Return configuration for this component.
      *
-     * @return array
+     * @return array{
+     *     dependencies: ServiceManagerConfigurationType,
+     *     input_filters: ServiceManagerConfigurationType,
+     * }
      */
     public function __invoke()
     {
@@ -22,7 +28,7 @@ class ConfigProvider
     /**
      * Return dependency mappings for this component.
      *
-     * @return array
+     * @return ServiceManagerConfigurationType
      */
     public function getDependencyConfig()
     {
@@ -31,7 +37,7 @@ class ConfigProvider
                 'InputFilterManager' => InputFilterPluginManager::class,
 
                 // Legacy Zend Framework aliases
-                \Zend\InputFilter\InputFilterPluginManager::class => InputFilterPluginManager::class,
+                'Zend\InputFilter\InputFilterPluginManager' => InputFilterPluginManager::class,
             ],
             'factories' => [
                 InputFilterPluginManager::class => InputFilterPluginManagerFactory::class,
@@ -42,7 +48,7 @@ class ConfigProvider
     /**
      * Get input filter configuration
      *
-     * @return array
+     * @return ServiceManagerConfigurationType
      */
     public function getInputFilterConfig()
     {

--- a/src/InputFilterPluginManager.php
+++ b/src/InputFilterPluginManager.php
@@ -48,9 +48,9 @@ class InputFilterPluginManager extends AbstractPluginManager
         'OptionalInputFilter' => OptionalInputFilter::class,
 
         // Legacy Zend Framework aliases
-        \Zend\InputFilter\InputFilter::class           => InputFilter::class,
-        \Zend\InputFilter\CollectionInputFilter::class => CollectionInputFilter::class,
-        \Zend\InputFilter\OptionalInputFilter::class   => OptionalInputFilter::class,
+        'Zend\InputFilter\InputFilter'           => InputFilter::class,
+        'Zend\InputFilter\CollectionInputFilter' => CollectionInputFilter::class,
+        'Zend\InputFilter\OptionalInputFilter'   => OptionalInputFilter::class,
 
         // v2 normalized FQCNs
         'zendinputfilterinputfilter'           => InputFilter::class,

--- a/src/Module.php
+++ b/src/Module.php
@@ -5,13 +5,19 @@ declare(strict_types=1);
 namespace Laminas\InputFilter;
 
 use Laminas\ModuleManager\ModuleManager;
+use Laminas\ServiceManager\ConfigInterface;
 
+/** @psalm-import-type ServiceManagerConfigurationType from ConfigInterface */
 class Module
 {
     /**
      * Return default laminas-inputfilter configuration for laminas-mvc applications.
      *
-     * @return array
+     * @return array<string, mixed>
+     * @psalm-return array{
+     *     service_manager: ServiceManagerConfigurationType,
+     *     input_filters: ServiceManagerConfigurationType,
+     * }
      */
     public function getConfig()
     {

--- a/test/ArrayInputTest.php
+++ b/test/ArrayInputTest.php
@@ -30,7 +30,7 @@ class ArrayInputTest extends InputTest
 
     public function testDefaultGetValue(): void
     {
-        $this->assertCount(0, $this->input->getValue());
+        self::assertCount(0, $this->input->getValue());
     }
 
     public function testArrayInputMarkedRequiredWithoutAFallbackFailsValidationForEmptyArrays(): void
@@ -39,7 +39,7 @@ class ArrayInputTest extends InputTest
         $input->setRequired(true);
         $input->setValue([]);
 
-        $this->assertFalse($input->isValid());
+        self::assertFalse($input->isValid());
         $this->assertRequiredValidationErrorMessage($input);
     }
 
@@ -52,12 +52,12 @@ class ArrayInputTest extends InputTest
         $input->setErrorMessage($expected);
         $input->setValue([]);
 
-        $this->assertFalse($input->isValid());
+        self::assertFalse($input->isValid());
 
         $messages = $input->getMessages();
-        $this->assertCount(1, $messages);
+        self::assertCount(1, $messages);
         $message = array_pop($messages);
-        $this->assertEquals($expected, $message);
+        self::assertEquals($expected, $message);
     }
 
     public function testSetValueWithInvalidInputTypeThrowsInvalidArgumentException(): void

--- a/test/BaseInputFilterTest.php
+++ b/test/BaseInputFilterTest.php
@@ -44,7 +44,7 @@ class BaseInputFilterTest extends TestCase
     public function testInputFilterIsEmptyByDefault(): void
     {
         $filter = $this->inputFilter;
-        $this->assertEquals(0, count($filter));
+        self::assertCount(0, $filter);
     }
 
     public function testAddWithInvalidInputTypeThrowsInvalidArgumentException(): void
@@ -56,7 +56,7 @@ class BaseInputFilterTest extends TestCase
             'expects an instance of Laminas\InputFilter\InputInterface or Laminas\InputFilter\InputFilterInterface '
             . 'as its first argument; received "stdClass"'
         );
-        /** @noinspection PhpParamsInspection */
+        /** @psalm-suppress InvalidArgument */
         $inputFilter->add(new stdClass());
     }
 
@@ -116,7 +116,7 @@ class BaseInputFilterTest extends TestCase
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('expects an array or Traversable argument; received stdClass');
-        /** @noinspection PhpParamsInspection */
+        /** @psalm-suppress InvalidArgument */
         $inputFilter->setData(new stdClass());
     }
 
@@ -142,7 +142,7 @@ class BaseInputFilterTest extends TestCase
         $r = new ReflectionObject($inputFilter);
         $p = $r->getProperty('validationGroup');
         $p->setAccessible(true);
-        $this->assertEquals(['fooInput'], $p->getValue($inputFilter));
+        self::assertEquals(['fooInput'], $p->getValue($inputFilter));
     }
 
     public function testSetValidationGroupAllowsSpecifyingArrayOfInputsToNestedInputFilter(): void
@@ -166,8 +166,8 @@ class BaseInputFilterTest extends TestCase
         $r = new ReflectionObject($inputFilter);
         $p = $r->getProperty('validationGroup');
         $p->setAccessible(true);
-        $this->assertEquals(['nested'], $p->getValue($inputFilter));
-        $this->assertEquals(['nested-input1', 'nested-input2'], $p->getValue($nestedInputFilter));
+        self::assertEquals(['nested'], $p->getValue($inputFilter));
+        self::assertEquals(['nested-input1', 'nested-input2'], $p->getValue($nestedInputFilter));
     }
 
     public function testSetValidationGroupThrowExceptionIfInputFilterNotExists(): void
@@ -221,21 +221,21 @@ class BaseInputFilterTest extends TestCase
         object $expectedInput
     ): void {
         $inputFilter = $this->inputFilter;
-        $this->assertFalse(
+        self::assertFalse(
             $inputFilter->has($expectedInputName),
             "InputFilter shouldn't have an input with the name $expectedInputName yet"
         );
         $currentNumberOfFilters = count($inputFilter);
 
         $return = $inputFilter->add($input, $name);
-        $this->assertSame($inputFilter, $return, "add() must return it self");
+        self::assertSame($inputFilter, $return, "add() must return it self");
 
         // **Check input collection state**
-        $this->assertTrue($inputFilter->has($expectedInputName), "There is no input with name $expectedInputName");
-        $this->assertCount($currentNumberOfFilters + 1, $inputFilter, 'Number of filters must be increased by 1');
+        self::assertTrue($inputFilter->has($expectedInputName), "There is no input with name $expectedInputName");
+        self::assertCount($currentNumberOfFilters + 1, $inputFilter, 'Number of filters must be increased by 1');
 
         $returnInput = $inputFilter->get($expectedInputName);
-        $this->assertEquals($expectedInput, $returnInput, 'get() does not match the expected input');
+        self::assertEquals($expectedInput, $returnInput, 'get() does not match the expected input');
     }
 
     /**
@@ -252,10 +252,10 @@ class BaseInputFilterTest extends TestCase
         $currentNumberOfFilters = count($inputFilter);
 
         $return = $inputFilter->remove($expectedInputName);
-        $this->assertSame($inputFilter, $return, 'remove() must return it self');
+        self::assertSame($inputFilter, $return, 'remove() must return it self');
 
-        $this->assertFalse($inputFilter->has($expectedInputName), "There is no input with name $expectedInputName");
-        $this->assertCount($currentNumberOfFilters - 1, $inputFilter, 'Number of filters must be decreased by 1');
+        self::assertFalse($inputFilter->has($expectedInputName), "There is no input with name $expectedInputName");
+        self::assertCount($currentNumberOfFilters - 1, $inputFilter, 'Number of filters must be decreased by 1');
     }
 
     public function testAddingInputWithNameDoesNotInjectNameInInput(): void
@@ -266,8 +266,8 @@ class BaseInputFilterTest extends TestCase
         $inputFilter->add($foo, 'bas');
 
         $test = $inputFilter->get('bas');
-        $this->assertSame($foo, $test, 'get() does not match the input added');
-        $this->assertEquals('foo', $foo->getName(), 'Input name should not change');
+        self::assertSame($foo, $test, 'get() does not match the input added');
+        self::assertEquals('foo', $foo->getName(), 'Input name should not change');
     }
 
     /**
@@ -284,11 +284,11 @@ class BaseInputFilterTest extends TestCase
         $currentNumberOfFilters = count($inputFilter);
 
         $return = $inputFilter->replace($input, $nameToReplace);
-        $this->assertSame($inputFilter, $return, 'replace() must return it self');
-        $this->assertCount($currentNumberOfFilters, $inputFilter, "Number of filters shouldn't change");
+        self::assertSame($inputFilter, $return, 'replace() must return it self');
+        self::assertCount($currentNumberOfFilters, $inputFilter, "Number of filters shouldn't change");
 
         $returnInput = $inputFilter->get($nameToReplace);
-        $this->assertEquals($expectedInput, $returnInput, 'get() does not match the expected input');
+        self::assertEquals($expectedInput, $returnInput, 'get() does not match the expected input');
     }
 
     /**
@@ -309,21 +309,21 @@ class BaseInputFilterTest extends TestCase
             $inputFilter->add($input, $inputName);
         }
         $return = $inputFilter->setData($data);
-        $this->assertSame($inputFilter, $return, 'setData() must return it self');
+        self::assertSame($inputFilter, $return, 'setData() must return it self');
 
         // ** Check filter state **
-        $this->assertSame($expectedRawValues, $inputFilter->getRawValues(), 'getRawValues() value not match');
+        self::assertSame($expectedRawValues, $inputFilter->getRawValues(), 'getRawValues() value not match');
         foreach ($expectedRawValues as $inputName => $expectedRawValue) {
-            $this->assertSame(
+            self::assertSame(
                 $expectedRawValue,
                 $inputFilter->getRawValue($inputName),
                 'getRawValue() value not match for input ' . $inputName
             );
         }
 
-        $this->assertSame($expectedValues, $inputFilter->getValues(), 'getValues() value not match');
+        self::assertSame($expectedValues, $inputFilter->getValues(), 'getValues() value not match');
         foreach ($expectedValues as $inputName => $expectedValue) {
-            $this->assertSame(
+            self::assertSame(
                 $expectedValue,
                 $inputFilter->getValue($inputName),
                 'getValue() value not match for input ' . $inputName
@@ -332,15 +332,15 @@ class BaseInputFilterTest extends TestCase
 
         // ** Check validation state **
         // phpcs:disable Generic.Files.LineLength.TooLong
-        $this->assertEquals($expectedIsValid, $inputFilter->isValid(), 'isValid() value not match');
-        $this->assertEquals($expectedInvalidInputs, $inputFilter->getInvalidInput(), 'getInvalidInput() value not match');
-        $this->assertEquals($expectedValidInputs, $inputFilter->getValidInput(), 'getValidInput() value not match');
-        $this->assertEquals($expectedMessages, $inputFilter->getMessages(), 'getMessages() value not match');
+        self::assertEquals($expectedIsValid, $inputFilter->isValid(), 'isValid() value not match');
+        self::assertEquals($expectedInvalidInputs, $inputFilter->getInvalidInput(), 'getInvalidInput() value not match');
+        self::assertEquals($expectedValidInputs, $inputFilter->getValidInput(), 'getValidInput() value not match');
+        self::assertEquals($expectedMessages, $inputFilter->getMessages(), 'getMessages() value not match');
         // phpcs:enable Generic.Files.LineLength.TooLong
 
         // ** Check unknown fields **
-        $this->assertFalse($inputFilter->hasUnknown(), 'hasUnknown() value not match');
-        $this->assertEmpty($inputFilter->getUnknown(), 'getUnknown() value not match');
+        self::assertFalse($inputFilter->hasUnknown(), 'hasUnknown() value not match');
+        self::assertEmpty($inputFilter->getUnknown(), 'getUnknown() value not match');
     }
 
     /**
@@ -384,7 +384,7 @@ class BaseInputFilterTest extends TestCase
             ->enableProxyingToOriginalMethods()
             ->setConstructorArgs(['flat'])
             ->getMock();
-        $flatInput->expects($this->once())
+        $flatInput->expects(self::once())
             ->method('setValue')
             ->with('foo');
         // Inputs without value must be reset for to have clean states when use different setData arguments
@@ -393,7 +393,7 @@ class BaseInputFilterTest extends TestCase
             ->enableProxyingToOriginalMethods()
             ->setConstructorArgs(['notSet'])
             ->getMock();
-        $resetInput->expects($this->once())
+        $resetInput->expects(self::once())
             ->method('resetValue');
 
         $filter = $this->inputFilter;
@@ -407,7 +407,7 @@ class BaseInputFilterTest extends TestCase
         $filter->setValidationGroup(['deep' => 'deep-input1']);
         // reset validation group
         $filter->setValidationGroup(InputFilterInterface::VALIDATE_ALL);
-        $this->assertEquals($expectedData, $filter->getValues());
+        self::assertEquals($expectedData, $filter->getValues());
     }
 
     /*
@@ -450,7 +450,7 @@ class BaseInputFilterTest extends TestCase
 
         $filter->setData($data);
 
-        $this->assertTrue(
+        self::assertTrue(
             $filter->isValid($customContext),
             'isValid() value not match. Detail: ' . json_encode($filter->getMessages(), JSON_THROW_ON_ERROR)
         );
@@ -467,7 +467,7 @@ class BaseInputFilterTest extends TestCase
 
         $filter->setData($data);
 
-        $this->assertTrue(
+        self::assertTrue(
             $filter->isValid(),
             'isValid() value not match. Detail: ' . json_encode($filter->getMessages(), JSON_THROW_ON_ERROR)
         );
@@ -491,7 +491,7 @@ class BaseInputFilterTest extends TestCase
 
         $filter->setData($data);
 
-        $this->assertTrue(
+        self::assertTrue(
             $filter->isValid(),
             'isValid() value not match. Detail: ' . json_encode($filter->getMessages(), JSON_THROW_ON_ERROR)
         );
@@ -506,7 +506,7 @@ class BaseInputFilterTest extends TestCase
         $optionalInput = $this->createMock(InputInterface::class);
         $optionalInput->method('getName')
             ->willReturn($optionalInputName);
-        $optionalInput->expects($this->never())
+        $optionalInput->expects(self::never())
             ->method('isValid');
         $data = [];
 
@@ -514,16 +514,16 @@ class BaseInputFilterTest extends TestCase
 
         $filter->setData($data);
 
-        $this->assertTrue(
+        self::assertTrue(
             $filter->isValid(),
             'isValid() value not match. Detail . ' . json_encode($filter->getMessages(), JSON_THROW_ON_ERROR)
         );
-        $this->assertArrayNotHasKey(
+        self::assertArrayNotHasKey(
             $optionalInputName,
             $filter->getValidInput(),
             'Missing optional fields must not appear as valid input neither invalid input'
         );
-        $this->assertArrayNotHasKey(
+        self::assertArrayNotHasKey(
             $optionalInputName,
             $filter->getInvalidInput(),
             'Missing optional fields must not appear as valid input neither invalid input'
@@ -542,8 +542,8 @@ class BaseInputFilterTest extends TestCase
 
         $inputFilter->setData($data);
 
-        $this->assertEquals($getUnknown, $inputFilter->getUnknown(), 'getUnknown() value not match');
-        $this->assertEquals($hasUnknown, $inputFilter->hasUnknown(), 'hasUnknown() value not match');
+        self::assertEquals($getUnknown, $inputFilter->getUnknown(), 'getUnknown() value not match');
+        self::assertEquals($hasUnknown, $inputFilter->hasUnknown(), 'hasUnknown() value not match');
     }
 
     public function testGetInputs(): void
@@ -558,9 +558,9 @@ class BaseInputFilterTest extends TestCase
 
         $filters = $filter->getInputs();
 
-        $this->assertCount(2, $filters);
-        $this->assertEquals('foo', $filters['foo']->getName());
-        $this->assertEquals('bar', $filters['bar']->getName());
+        self::assertCount(2, $filters);
+        self::assertEquals('foo', $filters['foo']->getName());
+        self::assertEquals('bar', $filters['bar']->getName());
     }
 
     public function testAddingExistingInputWillMergeIntoExisting(): void
@@ -575,7 +575,7 @@ class BaseInputFilterTest extends TestCase
         $foo2->setRequired(false);
         $filter->add($foo2);
 
-        $this->assertFalse($filter->get('foo')->isRequired());
+        self::assertFalse($filter->get('foo')->isRequired());
     }
 
     public function testMerge(): void
@@ -590,7 +590,7 @@ class BaseInputFilterTest extends TestCase
 
         $inputFilter->merge($originInputFilter);
 
-        $this->assertEquals(
+        self::assertEquals(
             [
                 'foo',
                 'bar',
@@ -932,11 +932,11 @@ class BaseInputFilterTest extends TestCase
         $inputFilter->method('getValues')
             ->willReturn($getValues);
         if (($isValid === false) || ($isValid === true)) {
-            $inputFilter->expects($this->once())
+            $inputFilter->expects(self::once())
                 ->method('isValid')
                 ->willReturn($isValid);
         } else {
-            $inputFilter->expects($this->never())
+            $inputFilter->expects(self::never())
                 ->method('isValid');
         }
         $inputFilter->method('getMessages')
@@ -979,12 +979,12 @@ class BaseInputFilterTest extends TestCase
         $input->method('breakOnFailure')
             ->willReturn($breakOnFailure);
         if (($isValid === false) || ($isValid === true)) {
-            $input->expects($this->any())
+            $input->expects(self::any())
                 ->method('isValid')
                 ->with($context)
                 ->willReturn($isValid);
         } else {
-            $input->expects($this->never())
+            $input->expects(self::never())
                 ->method('isValid')
                 ->with($context);
         }

--- a/test/CollectionInputFilterTest.php
+++ b/test/CollectionInputFilterTest.php
@@ -31,8 +31,7 @@ use const JSON_THROW_ON_ERROR;
  */
 class CollectionInputFilterTest extends TestCase
 {
-    /** @var CollectionInputFilter */
-    protected $inputFilter;
+    private CollectionInputFilter $inputFilter;
 
     protected function setUp(): void
     {
@@ -47,7 +46,7 @@ class CollectionInputFilterTest extends TestCase
         $this->expectExceptionMessage(
             'expects an instance of Laminas\InputFilter\BaseInputFilter; received "stdClass"'
         );
-        /** @noinspection PhpParamsInspection */
+        /** @psalm-suppress InvalidArgument */
         $inputFilter->setInputFilter(new stdClass());
     }
 
@@ -59,12 +58,12 @@ class CollectionInputFilterTest extends TestCase
     {
         $this->inputFilter->setInputFilter($inputFilter);
 
-        $this->assertInstanceOf($expectedType, $this->inputFilter->getInputFilter(), 'getInputFilter() type not match');
+        self::assertInstanceOf($expectedType, $this->inputFilter->getInputFilter(), 'getInputFilter() type not match');
     }
 
     public function testGetDefaultInputFilter(): void
     {
-        $this->assertInstanceOf(BaseInputFilter::class, $this->inputFilter->getInputFilter());
+        self::assertInstanceOf(BaseInputFilter::class, $this->inputFilter->getInputFilter());
     }
 
     /**
@@ -73,7 +72,7 @@ class CollectionInputFilterTest extends TestCase
     public function testSetRequired(bool $value): void
     {
         $this->inputFilter->setIsRequired($value);
-        $this->assertEquals($value, $this->inputFilter->getIsRequired());
+        self::assertEquals($value, $this->inputFilter->getIsRequired());
     }
 
     /**
@@ -88,7 +87,7 @@ class CollectionInputFilterTest extends TestCase
             $this->inputFilter->setData($data);
         }
 
-        $this->assertEquals($expectedCount, $this->inputFilter->getCount(), 'getCount() value not match');
+        self::assertEquals($expectedCount, $this->inputFilter->getCount(), 'getCount() value not match');
     }
 
     public function testGetCountReturnsRightCountOnConsecutiveCallsWithDifferentData(): void
@@ -103,9 +102,9 @@ class CollectionInputFilterTest extends TestCase
         ];
 
         $this->inputFilter->setData($collectionData1);
-        $this->assertEquals(2, $this->inputFilter->getCount());
+        self::assertEquals(2, $this->inputFilter->getCount());
         $this->inputFilter->setData($collectionData2);
-        $this->assertEquals(1, $this->inputFilter->getCount());
+        self::assertEquals(1, $this->inputFilter->getCount());
     }
 
     /**
@@ -128,14 +127,14 @@ class CollectionInputFilterTest extends TestCase
         }
         $this->inputFilter->setIsRequired($required);
 
-        $this->assertEquals(
+        self::assertEquals(
             $expectedValid,
             $this->inputFilter->isValid(),
             'isValid() value not match. Detail . ' . json_encode($this->inputFilter->getMessages(), JSON_THROW_ON_ERROR)
         );
-        $this->assertEquals($expectedRaw, $this->inputFilter->getRawValues(), 'getRawValues() value not match');
-        $this->assertEquals($expectedValues, $this->inputFilter->getValues(), 'getValues() value not match');
-        $this->assertEquals($expectedMessages, $this->inputFilter->getMessages(), 'getMessages() value not match');
+        self::assertEquals($expectedRaw, $this->inputFilter->getRawValues(), 'getRawValues() value not match');
+        self::assertEquals($expectedValues, $this->inputFilter->getValues(), 'getValues() value not match');
+        self::assertEquals($expectedMessages, $this->inputFilter->getMessages(), 'getMessages() value not match');
     }
 
     /**
@@ -212,7 +211,7 @@ class CollectionInputFilterTest extends TestCase
         $colRaw          = [$dataRaw];
         $colFiltered     = [$dataFiltered];
         $baseInputFilter = $this->createBaseInputFilterMock(true, $dataRaw, $dataFiltered);
-        $baseInputFilter->expects($this->once())
+        $baseInputFilter->expects(self::once())
             ->method('setValidationGroup')
             ->with($validationGroup);
 
@@ -220,13 +219,13 @@ class CollectionInputFilterTest extends TestCase
         $this->inputFilter->setData($colRaw);
         $this->inputFilter->setValidationGroup($colValidationGroup);
 
-        $this->assertTrue(
+        self::assertTrue(
             $this->inputFilter->isValid(),
             'isValid() value not match. Detail . ' . json_encode($this->inputFilter->getMessages(), JSON_THROW_ON_ERROR)
         );
-        $this->assertEquals($colRaw, $this->inputFilter->getRawValues(), 'getRawValues() value not match');
-        $this->assertEquals($colFiltered, $this->inputFilter->getValues(), 'getValues() value not match');
-        $this->assertEquals([], $this->inputFilter->getMessages(), 'getMessages() value not match');
+        self::assertEquals($colRaw, $this->inputFilter->getRawValues(), 'getRawValues() value not match');
+        self::assertEquals($colFiltered, $this->inputFilter->getValues(), 'getValues() value not match');
+        self::assertEquals([], $this->inputFilter->getMessages(), 'getMessages() value not match');
     }
 
     /** @psalm-return array<string, array{0: null|int, 1: bool}> */
@@ -304,7 +303,7 @@ class CollectionInputFilterTest extends TestCase
         ];
 
         $mainInputFilter->setData($data);
-        $this->assertSame($expectedIsValid, $mainInputFilter->isValid());
+        self::assertSame($expectedIsValid, $mainInputFilter->isValid());
     }
 
     /**
@@ -377,7 +376,7 @@ class CollectionInputFilterTest extends TestCase
      * @param mixed[] $getRawValues
      * @param mixed[] $getValues
      * @param string[] $getMessages
-     * @return MockObject|BaseInputFilter
+     * @return MockObject&BaseInputFilter
      */
     protected function createBaseInputFilterMock(
         $isValid = null,
@@ -385,18 +384,18 @@ class CollectionInputFilterTest extends TestCase
         $getValues = [],
         $getMessages = []
     ) {
-        /** @var BaseInputFilter|MockObject $inputFilter */
+        /** @var BaseInputFilter&MockObject $inputFilter */
         $inputFilter = $this->createMock(BaseInputFilter::class);
         $inputFilter->method('getRawValues')
             ->willReturn($getRawValues);
         $inputFilter->method('getValues')
             ->willReturn($getValues);
         if (($isValid === false) || ($isValid === true)) {
-            $inputFilter->expects($this->once())
+            $inputFilter->expects(self::once())
                 ->method('isValid')
                 ->willReturn($isValid);
         } else {
-            $inputFilter->expects($this->never())
+            $inputFilter->expects(self::never())
                 ->method('isValid');
         }
         $inputFilter->method('getMessages')
@@ -429,8 +428,8 @@ class CollectionInputFilterTest extends TestCase
 
         $unknown = $collectionInputFilter->getUnknown();
 
-        $this->assertFalse($collectionInputFilter->hasUnknown());
-        $this->assertCount(0, $unknown);
+        self::assertFalse($collectionInputFilter->hasUnknown());
+        self::assertCount(0, $unknown);
     }
 
     public function testGetUnknownFieldIsUnknown(): void
@@ -450,8 +449,8 @@ class CollectionInputFilterTest extends TestCase
 
         $unknown = $collectionInputFilter->getUnknown();
 
-        $this->assertTrue($collectionInputFilter->hasUnknown());
-        $this->assertEquals([['baz' => 'hey'], ['tor' => 'ver']], $unknown);
+        self::assertTrue($collectionInputFilter->hasUnknown());
+        self::assertEquals([['baz' => 'hey'], ['tor' => 'ver']], $unknown);
     }
 
     /** @psalm-return array<string, array{0: array}> */
@@ -561,17 +560,17 @@ class CollectionInputFilterTest extends TestCase
         $messages = $collectionInputFilter->getMessages();
 
         // @codingStandardsIgnoreStart
-        $this->assertFalse($isValid);
-        $this->assertCount(2, $messages);
+        self::assertFalse($isValid);
+        self::assertCount(2, $messages);
 
-        $this->assertArrayHasKey('phone', $messages[0]);
-        $this->assertCount(1, $messages[0]['phone']);
-        $this->assertContains('Value is required and can\'t be empty', $messages[0]['phone']);
+        self::assertArrayHasKey('phone', $messages[0]);
+        self::assertCount(1, $messages[0]['phone']);
+        self::assertContains('Value is required and can\'t be empty', $messages[0]['phone']);
 
-        $this->assertArrayHasKey('phone', $messages[1]);
-        $this->assertCount(1, $messages[1]['phone']);
-        $this->assertNotContains('Value is required and can\'t be empty', $messages[1]['phone']);
-        $this->assertContains('The input must contain only digits', $messages[1]['phone']);
+        self::assertArrayHasKey('phone', $messages[1]);
+        self::assertCount(1, $messages[1]['phone']);
+        self::assertNotContains('Value is required and can\'t be empty', $messages[1]['phone']);
+        self::assertContains('The input must contain only digits', $messages[1]['phone']);
         // @codingStandardsIgnoreEnd
     }
 
@@ -611,17 +610,17 @@ class CollectionInputFilterTest extends TestCase
         $isValid  = $collectionInputFilter->isValid();
         $messages = $collectionInputFilter->getMessages();
 
-        $this->assertFalse($isValid);
-        $this->assertCount(2, $messages);
+        self::assertFalse($isValid);
+        self::assertCount(2, $messages);
 
-        $this->assertArrayHasKey('phone', $messages[0]);
-        $this->assertCount(1, $messages[0]['phone']);
-        $this->assertContains('CUSTOM ERROR MESSAGE', $messages[0]['phone']);
-        $this->assertNotContains('Value is required and can\'t be empty', $messages[0]['phone']);
+        self::assertArrayHasKey('phone', $messages[0]);
+        self::assertCount(1, $messages[0]['phone']);
+        self::assertContains('CUSTOM ERROR MESSAGE', $messages[0]['phone']);
+        self::assertNotContains('Value is required and can\'t be empty', $messages[0]['phone']);
 
-        $this->assertArrayHasKey('phone', $messages[1]);
-        $this->assertCount(1, $messages[1]['phone']);
-        $this->assertContains('CUSTOM ERROR MESSAGE', $messages[1]['phone']);
+        self::assertArrayHasKey('phone', $messages[1]);
+        self::assertCount(1, $messages[1]['phone']);
+        self::assertContains('CUSTOM ERROR MESSAGE', $messages[1]['phone']);
     }
 
     public function testDuplicatedErrorMessages(): void
@@ -703,8 +702,8 @@ class CollectionInputFilterTest extends TestCase
                 ],
             ]
         );
-        $this->assertFalse($inputFilter->isValid());
-        $this->assertEquals([
+        self::assertFalse($inputFilter->isValid());
+        self::assertEquals([
             'element' => [
                 'type1' => [
                     [
@@ -754,14 +753,14 @@ class CollectionInputFilterTest extends TestCase
 
     public function testLazyLoadsANotEmptyValidatorWhenNoneProvided(): void
     {
-        $this->assertInstanceOf(NotEmpty::class, $this->inputFilter->getNotEmptyValidator());
+        self::assertInstanceOf(NotEmpty::class, $this->inputFilter->getNotEmptyValidator());
     }
 
     public function testAllowsComposingANotEmptyValidator(): void
     {
         $notEmptyValidator = new NotEmpty();
         $this->inputFilter->setNotEmptyValidator($notEmptyValidator);
-        $this->assertSame($notEmptyValidator, $this->inputFilter->getNotEmptyValidator());
+        self::assertSame($notEmptyValidator, $this->inputFilter->getNotEmptyValidator());
     }
 
     public function testUsesMessageFromComposedNotEmptyValidatorWhenRequiredButCollectionIsEmpty(): void
@@ -775,9 +774,9 @@ class CollectionInputFilterTest extends TestCase
 
         $this->inputFilter->setData([]);
 
-        $this->assertFalse($this->inputFilter->isValid());
+        self::assertFalse($this->inputFilter->isValid());
 
-        $this->assertEquals([
+        self::assertEquals([
             [NotEmpty::IS_EMPTY => $message],
         ], $this->inputFilter->getMessages());
     }
@@ -800,7 +799,6 @@ class CollectionInputFilterTest extends TestCase
             ],
         ];
 
-        /** @var BaseInputFilter $baseInputFilter */
         $baseInputFilter = (new BaseInputFilter())
             ->add(new Input(), 'bar');
 
@@ -833,9 +831,8 @@ class CollectionInputFilterTest extends TestCase
      */
     public function testValidationContext(array $data, ?array $customContext, ?array $expectedContext): void
     {
-        /** @var MockObject|BaseInputFilter $baseInputFilter */
         $baseInputFilter = $this->createMock(BaseInputFilter::class);
-        $baseInputFilter->expects($this->exactly(count($data)))
+        $baseInputFilter->expects(self::exactly(count($data)))
             ->method('isValid')
             ->with($expectedContext)
             ->willReturn(true);
@@ -843,7 +840,7 @@ class CollectionInputFilterTest extends TestCase
         $collectionInputFilter = (new CollectionInputFilter())->setInputFilter($baseInputFilter);
         $collectionInputFilter->setData($data);
 
-        $this->assertTrue(
+        self::assertTrue(
             $collectionInputFilter->isValid($customContext),
             'isValid() value not match. Detail: ' . json_encode(
                 $collectionInputFilter->getMessages(),

--- a/test/ConfigProviderTest.php
+++ b/test/ConfigProviderTest.php
@@ -18,15 +18,15 @@ final class ConfigProviderTest extends TestCase
 
         $expected = [
             'aliases'   => [
-                'InputFilterManager'                              => InputFilterPluginManager::class,
-                \Zend\InputFilter\InputFilterPluginManager::class => InputFilterPluginManager::class,
+                'InputFilterManager'                        => InputFilterPluginManager::class,
+                'Zend\InputFilter\InputFilterPluginManager' => InputFilterPluginManager::class,
             ],
             'factories' => [
                 InputFilterPluginManager::class => InputFilterPluginManagerFactory::class,
             ],
         ];
 
-        $this->assertEquals($expected, $provider->getDependencyConfig());
+        self::assertEquals($expected, $provider->getDependencyConfig());
     }
 
     public function testProvidesExpectedInputFilterConfiguration(): void
@@ -39,7 +39,7 @@ final class ConfigProviderTest extends TestCase
             ],
         ];
 
-        $this->assertEquals($expected, $provider->getInputFilterConfig());
+        self::assertEquals($expected, $provider->getInputFilterConfig());
     }
 
     public function testInvocationProvidesDependencyConfiguration(): void
@@ -50,6 +50,6 @@ final class ConfigProviderTest extends TestCase
             'dependencies'  => $provider->getDependencyConfig(),
             'input_filters' => $provider->getInputFilterConfig(),
         ];
-        $this->assertEquals($expected, $provider());
+        self::assertEquals($expected, $provider());
     }
 }

--- a/test/FactoryTest.php
+++ b/test/FactoryTest.php
@@ -23,7 +23,6 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 
-use function count;
 use function sprintf;
 
 /**
@@ -37,7 +36,7 @@ class FactoryTest extends TestCase
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('expects an array or Traversable; received "string"');
-        /** @noinspection PhpParamsInspection */
+        /** @psalm-suppress InvalidArgument */
         $factory->createInput('invalid_value');
     }
 
@@ -45,7 +44,7 @@ class FactoryTest extends TestCase
     {
         $type          = 'foo';
         $pluginManager = $this->createMock(InputFilterPluginManager::class);
-        $pluginManager->expects($this->atLeastOnce())
+        $pluginManager->expects(self::atLeastOnce())
             ->method('has')
             ->with($type)
             ->willReturn(false);
@@ -68,7 +67,7 @@ class FactoryTest extends TestCase
         $factory       = new Factory();
         /** @psalm-suppress MixedArgumentTypeCoercion */
         $factory->setInputFilterManager($pluginManager);
-        $this->assertSame($pluginManager, $factory->getInputFilterManager());
+        self::assertSame($pluginManager, $factory->getInputFilterManager());
     }
 
     public function testGetInputFilterManagerWhenYouConstructFactoryWithIt(): void
@@ -76,7 +75,7 @@ class FactoryTest extends TestCase
         $pluginManager = $this->createMock(InputFilterPluginManager::class);
         /** @psalm-suppress MixedArgumentTypeCoercion */
         $factory = new Factory($pluginManager);
-        $this->assertSame($pluginManager, $factory->getInputFilterManager());
+        self::assertSame($pluginManager, $factory->getInputFilterManager());
     }
 
     public function testCreateInputWithTypeAsAnInvalidPluginInstanceThrowException(): void
@@ -245,20 +244,20 @@ class FactoryTest extends TestCase
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('expects an array or Traversable; received "string"');
-        /** @noinspection PhpParamsInspection */
+        /** @psalm-suppress InvalidArgument */
         $factory->createInputFilter('invalid_value');
     }
 
     public function testFactoryComposesFilterChainByDefault(): void
     {
         $factory = $this->createDefaultFactory();
-        $this->assertInstanceOf(Filter\FilterChain::class, $factory->getDefaultFilterChain());
+        self::assertInstanceOf(Filter\FilterChain::class, $factory->getDefaultFilterChain());
     }
 
     public function testFactoryComposesValidatorChainByDefault(): void
     {
         $factory = $this->createDefaultFactory();
-        $this->assertInstanceOf(Validator\ValidatorChain::class, $factory->getDefaultValidatorChain());
+        self::assertInstanceOf(Validator\ValidatorChain::class, $factory->getDefaultValidatorChain());
     }
 
     public function testFactoryAllowsInjectingFilterChain(): void
@@ -266,7 +265,7 @@ class FactoryTest extends TestCase
         $factory     = $this->createDefaultFactory();
         $filterChain = new Filter\FilterChain();
         $factory->setDefaultFilterChain($filterChain);
-        $this->assertSame($filterChain, $factory->getDefaultFilterChain());
+        self::assertSame($filterChain, $factory->getDefaultFilterChain());
     }
 
     public function testFactoryAllowsInjectingValidatorChain(): void
@@ -274,7 +273,7 @@ class FactoryTest extends TestCase
         $factory        = $this->createDefaultFactory();
         $validatorChain = new Validator\ValidatorChain();
         $factory->setDefaultValidatorChain($validatorChain);
-        $this->assertSame($validatorChain, $factory->getDefaultValidatorChain());
+        self::assertSame($validatorChain, $factory->getDefaultValidatorChain());
     }
 
     public function testFactoryUsesComposedFilterChainWhenCreatingNewInputObjects(): void
@@ -289,10 +288,10 @@ class FactoryTest extends TestCase
         $input = $factory->createInput([
             'name' => 'foo',
         ]);
-        $this->assertInstanceOf(InputInterface::class, $input);
+        self::assertInstanceOf(InputInterface::class, $input);
         $inputFilterChain = $input->getFilterChain();
-        $this->assertNotSame($filterChain, $inputFilterChain);
-        $this->assertSame($pluginManager, $inputFilterChain->getPluginManager());
+        self::assertNotSame($filterChain, $inputFilterChain);
+        self::assertSame($pluginManager, $inputFilterChain->getPluginManager());
     }
 
     public function testFactoryUsesComposedValidatorChainWhenCreatingNewInputObjects(): void
@@ -306,10 +305,10 @@ class FactoryTest extends TestCase
         $input = $factory->createInput([
             'name' => 'foo',
         ]);
-        $this->assertInstanceOf(InputInterface::class, $input);
+        self::assertInstanceOf(InputInterface::class, $input);
         $inputValidatorChain = $input->getValidatorChain();
-        $this->assertNotSame($validatorChain, $inputValidatorChain);
-        $this->assertSame($validatorPlugins, $inputValidatorChain->getPluginManager());
+        self::assertNotSame($validatorChain, $inputValidatorChain);
+        self::assertSame($validatorPlugins, $inputValidatorChain->getPluginManager());
     }
 
     public function testFactoryInjectsComposedFilterAndValidatorChainsIntoInputObjectsWhenCreatingNewInputFilterObjects(): void // phpcs:ignore
@@ -330,14 +329,14 @@ class FactoryTest extends TestCase
                 'name' => 'foo',
             ],
         ]);
-        $this->assertInstanceOf(InputFilterInterface::class, $inputFilter);
-        $this->assertEquals(1, count($inputFilter));
+        self::assertInstanceOf(InputFilterInterface::class, $inputFilter);
+        self::assertCount(1, $inputFilter);
         $input = $inputFilter->get('foo');
-        $this->assertInstanceOf(InputInterface::class, $input);
+        self::assertInstanceOf(InputInterface::class, $input);
         $inputFilterChain    = $input->getFilterChain();
         $inputValidatorChain = $input->getValidatorChain();
-        $this->assertSame($filterPlugins, $inputFilterChain->getPluginManager());
-        $this->assertSame($validatorPlugins, $inputValidatorChain->getPluginManager());
+        self::assertSame($filterPlugins, $inputFilterChain->getPluginManager());
+        self::assertSame($validatorPlugins, $inputValidatorChain->getPluginManager());
     }
 
     public function testFactoryWillCreateInputWithSuggestedFilters(): void
@@ -359,24 +358,24 @@ class FactoryTest extends TestCase
                 ],
             ],
         ]);
-        $this->assertInstanceOf(InputInterface::class, $input);
-        $this->assertEquals('foo', $input->getName());
+        self::assertInstanceOf(InputInterface::class, $input);
+        self::assertEquals('foo', $input->getName());
         $chain = $input->getFilterChain();
         $index = 0;
         foreach ($chain as $filter) {
             switch ($index) {
                 case 0:
-                    $this->assertInstanceOf(Filter\StringTrim::class, $filter);
+                    self::assertInstanceOf(Filter\StringTrim::class, $filter);
                     break;
                 case 1:
-                    $this->assertSame($htmlEntities, $filter);
+                    self::assertSame($htmlEntities, $filter);
                     break;
                 case 2:
-                    $this->assertInstanceOf(Filter\StringToLower::class, $filter);
-                    $this->assertEquals('ISO-8859-1', $filter->getEncoding());
+                    self::assertInstanceOf(Filter\StringToLower::class, $filter);
+                    self::assertEquals('ISO-8859-1', $filter->getEncoding());
                     break;
                 default:
-                    $this->fail('Found more filters than expected');
+                    self::fail('Found more filters than expected');
             }
             $index++;
         }
@@ -402,31 +401,31 @@ class FactoryTest extends TestCase
                 ],
             ],
         ]);
-        $this->assertInstanceOf(InputInterface::class, $input);
-        $this->assertEquals('foo', $input->getName());
+        self::assertInstanceOf(InputInterface::class, $input);
+        self::assertEquals('foo', $input->getName());
         $chain = $input->getValidatorChain();
         $index = 0;
         foreach ($chain->getValidators() as $validator) {
             $validator = $validator['instance'];
             switch ($index) {
                 case 0:
-                    $this->assertInstanceOf(Validator\NotEmpty::class, $validator);
+                    self::assertInstanceOf(Validator\NotEmpty::class, $validator);
                     break;
                 case 1:
-                    $this->assertSame($digits, $validator);
+                    self::assertSame($digits, $validator);
                     break;
                 case 2:
-                    $this->assertInstanceOf(Validator\StringLength::class, $validator);
-                    $this->assertEquals(3, $validator->getMin());
-                    $this->assertEquals(5, $validator->getMax());
+                    self::assertInstanceOf(Validator\StringLength::class, $validator);
+                    self::assertEquals(3, $validator->getMin());
+                    self::assertEquals(5, $validator->getMax());
                     break;
                 default:
-                    $this->fail('Found more validators than expected');
+                    self::fail('Found more validators than expected');
             }
             $index++;
         }
         // Assure that previous foreach has been run
-        $this->assertEquals(3, $index);
+        self::assertEquals(3, $index);
     }
 
     public function testFactoryWillCreateInputWithSuggestedRequiredFlagAndAlternativeAllowEmptyFlag(): void
@@ -437,9 +436,9 @@ class FactoryTest extends TestCase
             'required'    => false,
             'allow_empty' => false,
         ]);
-        $this->assertInstanceOf(InputInterface::class, $input);
-        $this->assertFalse($input->isRequired());
-        $this->assertFalse($input->allowEmpty());
+        self::assertInstanceOf(InputInterface::class, $input);
+        self::assertFalse($input->isRequired());
+        self::assertFalse($input->allowEmpty());
     }
 
     public function testFactoryWillCreateInputWithSuggestedAllowEmptyFlagAndImpliesRequiredFlag(): void
@@ -449,9 +448,9 @@ class FactoryTest extends TestCase
             'name'        => 'foo',
             'allow_empty' => true,
         ]);
-        $this->assertInstanceOf(InputInterface::class, $input);
-        $this->assertTrue($input->allowEmpty());
-        $this->assertFalse($input->isRequired());
+        self::assertInstanceOf(InputInterface::class, $input);
+        self::assertTrue($input->allowEmpty());
+        self::assertFalse($input->isRequired());
     }
 
     public function testFactoryWillCreateInputWithSuggestedName(): void
@@ -460,8 +459,8 @@ class FactoryTest extends TestCase
         $input   = $factory->createInput([
             'name' => 'foo',
         ]);
-        $this->assertInstanceOf(InputInterface::class, $input);
-        $this->assertEquals('foo', $input->getName());
+        self::assertInstanceOf(InputInterface::class, $input);
+        self::assertEquals('foo', $input->getName());
     }
 
     public function testFactoryWillCreateInputWithContinueIfEmptyFlag(): void
@@ -471,8 +470,8 @@ class FactoryTest extends TestCase
             'name'              => 'foo',
             'continue_if_empty' => true,
         ]);
-        $this->assertInstanceOf(InputInterface::class, $input);
-        $this->assertTrue($input->continueIfEmpty());
+        self::assertInstanceOf(InputInterface::class, $input);
+        self::assertTrue($input->continueIfEmpty());
     }
 
     public function testFactoryAcceptsInputInterface(): void
@@ -484,9 +483,9 @@ class FactoryTest extends TestCase
             'foo' => $input,
         ]);
 
-        $this->assertInstanceOf(InputFilterInterface::class, $inputFilter);
-        $this->assertTrue($inputFilter->has('foo'));
-        $this->assertEquals($input, $inputFilter->get('foo'));
+        self::assertInstanceOf(InputFilterInterface::class, $inputFilter);
+        self::assertTrue($inputFilter->has('foo'));
+        self::assertEquals($input, $inputFilter->get('foo'));
     }
 
     public function testFactoryAcceptsInputFilterInterface(): void
@@ -498,9 +497,9 @@ class FactoryTest extends TestCase
             'foo' => $input,
         ]);
 
-        $this->assertInstanceOf(InputFilterInterface::class, $inputFilter);
-        $this->assertTrue($inputFilter->has('foo'));
-        $this->assertEquals($input, $inputFilter->get('foo'));
+        self::assertInstanceOf(InputFilterInterface::class, $inputFilter);
+        self::assertTrue($inputFilter->has('foo'));
+        self::assertEquals($input, $inputFilter->get('foo'));
     }
 
     public function testFactoryWillCreateInputFilterAndAllInputObjectsFromGivenConfiguration(): void
@@ -579,42 +578,42 @@ class FactoryTest extends TestCase
                 'continue_if_empty' => true,
             ],
         ]);
-        $this->assertInstanceOf(InputFilter::class, $inputFilter);
-        $this->assertEquals(5, count($inputFilter));
+        self::assertInstanceOf(InputFilter::class, $inputFilter);
+        self::assertCount(5, $inputFilter);
 
         foreach (['foo', 'bar', 'baz', 'bat', 'zomg'] as $name) {
             $input = $inputFilter->get($name);
 
             switch ($name) {
                 case 'foo':
-                    $this->assertInstanceOf(Input::class, $input);
-                    $this->assertFalse($input->isRequired());
-                    $this->assertEquals(2, count($input->getValidatorChain()));
+                    self::assertInstanceOf(Input::class, $input);
+                    self::assertFalse($input->isRequired());
+                    self::assertCount(2, $input->getValidatorChain());
                     break;
                 case 'bar':
-                    $this->assertInstanceOf(Input::class, $input);
-                    $this->assertTrue($input->allowEmpty());
-                    $this->assertEquals(2, count($input->getFilterChain()));
+                    self::assertInstanceOf(Input::class, $input);
+                    self::assertTrue($input->allowEmpty());
+                    self::assertCount(2, $input->getFilterChain());
                     break;
                 case 'baz':
-                    $this->assertInstanceOf(InputFilter::class, $input);
-                    $this->assertEquals(2, count($input));
+                    self::assertInstanceOf(InputFilter::class, $input);
+                    self::assertCount(2, $input);
                     $foo = $input->get('foo');
-                    $this->assertInstanceOf(Input::class, $foo);
-                    $this->assertFalse($foo->isRequired());
-                    $this->assertEquals(2, count($foo->getValidatorChain()));
+                    self::assertInstanceOf(Input::class, $foo);
+                    self::assertFalse($foo->isRequired());
+                    self::assertCount(2, $foo->getValidatorChain());
                     $bar = $input->get('bar');
-                    $this->assertInstanceOf(Input::class, $bar);
-                    $this->assertTrue($bar->allowEmpty());
-                    $this->assertEquals(2, count($bar->getFilterChain()));
+                    self::assertInstanceOf(Input::class, $bar);
+                    self::assertTrue($bar->allowEmpty());
+                    self::assertCount(2, $bar->getFilterChain());
                     break;
                 case 'bat':
-                    $this->assertInstanceOf(CustomInput::class, $input);
-                    $this->assertEquals('bat', $input->getName());
+                    self::assertInstanceOf(CustomInput::class, $input);
+                    self::assertEquals('bat', $input->getName());
                     break;
                 case 'zomg':
-                    $this->assertInstanceOf(Input::class, $input);
-                    $this->assertTrue($input->continueIfEmpty());
+                    self::assertInstanceOf(Input::class, $input);
+                    self::assertTrue($input->continueIfEmpty());
             }
         }
     }
@@ -626,8 +625,8 @@ class FactoryTest extends TestCase
             ['name' => 'foo'],
         ]);
 
-        $this->assertTrue($inputFilter->has('foo'));
-        $this->assertInstanceOf(Input::class, $inputFilter->get('foo'));
+        self::assertTrue($inputFilter->has('foo'));
+        self::assertInstanceOf(Input::class, $inputFilter->get('foo'));
     }
 
     public function testFactoryAllowsPassingValidatorChainsInInputSpec(): void
@@ -638,9 +637,9 @@ class FactoryTest extends TestCase
             'name'       => 'foo',
             'validators' => $chain,
         ]);
-        $this->assertInstanceOf(InputInterface::class, $input);
+        self::assertInstanceOf(InputInterface::class, $input);
         $test = $input->getValidatorChain();
-        $this->assertSame($chain, $test);
+        self::assertSame($chain, $test);
     }
 
     public function testFactoryAllowsPassingFilterChainsInInputSpec(): void
@@ -651,9 +650,9 @@ class FactoryTest extends TestCase
             'name'    => 'foo',
             'filters' => $chain,
         ]);
-        $this->assertInstanceOf(InputInterface::class, $input);
+        self::assertInstanceOf(InputInterface::class, $input);
         $test = $input->getFilterChain();
-        $this->assertSame($chain, $test);
+        self::assertSame($chain, $test);
     }
 
     public function testFactoryAcceptsCollectionInputFilter(): void
@@ -668,10 +667,10 @@ class FactoryTest extends TestCase
             'count'       => 3,
         ]);
 
-        $this->assertInstanceOf(CollectionInputFilter::class, $inputFilter);
-        $this->assertInstanceOf(InputFilter::class, $inputFilter->getInputFilter());
-        $this->assertTrue($inputFilter->getIsRequired());
-        $this->assertEquals(3, $inputFilter->getCount());
+        self::assertInstanceOf(CollectionInputFilter::class, $inputFilter);
+        self::assertInstanceOf(InputFilter::class, $inputFilter->getInputFilter());
+        self::assertTrue($inputFilter->getIsRequired());
+        self::assertEquals(3, $inputFilter->getCount());
     }
 
     public function testFactoryWillCreateInputWithErrorMessage(): void
@@ -681,7 +680,8 @@ class FactoryTest extends TestCase
             'name'          => 'foo',
             'error_message' => 'My custom error message',
         ]);
-        $this->assertEquals('My custom error message', $input->getErrorMessage());
+        self::assertInstanceOf(InputInterface::class, $input);
+        self::assertEquals('My custom error message', $input->getErrorMessage());
     }
 
     public function testFactoryWillNotGetPrioritySetting(): void
@@ -704,9 +704,10 @@ class FactoryTest extends TestCase
                 ],
             ],
         ]);
+        self::assertInstanceOf(InputInterface::class, $input);
 
         // We should have 3 filters
-        $this->assertEquals(3, $input->getFilterChain()->count());
+        self::assertEquals(3, $input->getFilterChain()->count());
 
         // Filters should pop in the following order:
         // string_to_upper (1001), string_to_lower (1000), string_trim (999)
@@ -714,19 +715,19 @@ class FactoryTest extends TestCase
         foreach ($input->getFilterChain()->getFilters() as $filter) {
             switch ($index) {
                 case 0:
-                    $this->assertInstanceOf(Filter\StringToUpper::class, $filter);
+                    self::assertInstanceOf(Filter\StringToUpper::class, $filter);
                     break;
                 case 1:
-                    $this->assertInstanceOf(Filter\StringToLower::class, $filter);
+                    self::assertInstanceOf(Filter\StringToLower::class, $filter);
                     break;
                 case 2:
-                    $this->assertInstanceOf(Filter\StringTrim::class, $filter);
+                    self::assertInstanceOf(Filter\StringTrim::class, $filter);
                     break;
             }
             $index++;
         }
 
-        $this->assertSame(3, $index);
+        self::assertSame(3, $index);
     }
 
     public function testFactoryValidatorsPriority(): void
@@ -742,8 +743,8 @@ class FactoryTest extends TestCase
                     'name'     => 'Callback',
                     'priority' => Validator\ValidatorChain::DEFAULT_PRIORITY - 1, // 0
                     'options'  => [
-                        'callback' => static function () use (&$order) {
-                            static::assertSame(2, $order);
+                        'callback' => static function () use (&$order): bool {
+                            self::assertSame(2, $order);
                             ++$order;
 
                             return true;
@@ -755,7 +756,7 @@ class FactoryTest extends TestCase
                     'priority' => Validator\ValidatorChain::DEFAULT_PRIORITY + 1, // 2
                     'options'  => [
                         'callback' => static function () use (&$order) {
-                            static::assertSame(0, $order);
+                            self::assertSame(0, $order);
                             ++$order;
 
                             return true;
@@ -765,8 +766,8 @@ class FactoryTest extends TestCase
                 [
                     'name'    => 'Callback', // default priority 1
                     'options' => [
-                        'callback' => static function () use (&$order) {
-                            static::assertSame(1, $order);
+                        'callback' => static function () use (&$order): bool {
+                            self::assertSame(1, $order);
                             ++$order;
 
                             return true;
@@ -775,9 +776,10 @@ class FactoryTest extends TestCase
                 ],
             ],
         ]);
+        self::assertInstanceOf(InputInterface::class, $input);
 
         // We should have 3 validators
-        $this->assertEquals(3, $input->getValidatorChain()->count());
+        self::assertEquals(3, $input->getValidatorChain()->count());
 
         $input->setValue(['foo' => false]);
         self::assertTrue($input->isValid());
@@ -795,8 +797,8 @@ class FactoryTest extends TestCase
             ]
         );
 
-        $this->assertInstanceOf(InputFilter::class, $inputFilter);
-        $this->assertTrue($inputFilter->has('type'));
+        self::assertInstanceOf(InputFilter::class, $inputFilter);
+        self::assertTrue($inputFilter->has('type'));
     }
 
     public function testCustomFactoryInCollection(): void
@@ -807,7 +809,7 @@ class FactoryTest extends TestCase
             'type'         => 'collection',
             'input_filter' => new InputFilter(),
         ]);
-        $this->assertInstanceOf(TestAsset\CustomFactory::class, $inputFilter->getFactory());
+        self::assertInstanceOf(TestAsset\CustomFactory::class, $inputFilter->getFactory());
     }
 
     public function testCanSetInputErrorMessage(): void
@@ -818,7 +820,8 @@ class FactoryTest extends TestCase
             'type'          => Input::class,
             'error_message' => 'Custom error message',
         ]);
-        $this->assertEquals('Custom error message', $input->getErrorMessage());
+        self::assertInstanceOf(InputInterface::class, $input);
+        self::assertEquals('Custom error message', $input->getErrorMessage());
     }
 
     public function testSetInputFilterManagerWithServiceManager(): void
@@ -840,7 +843,7 @@ class FactoryTest extends TestCase
         $smMock             = $this->createMock(ContainerInterface::class);
         $inputFilterManager = new InputFilterPluginManager($smMock);
         $factory            = new Factory($inputFilterManager);
-        $this->assertSame($inputFilterManager, $factory->getInputFilterManager());
+        self::assertSame($inputFilterManager, $factory->getInputFilterManager());
     }
 
     public function testSetInputFilterManagerOnConstruct(): void
@@ -848,7 +851,7 @@ class FactoryTest extends TestCase
         $smMock             = $this->createMock(ContainerInterface::class);
         $inputFilterManager = new InputFilterPluginManager($smMock);
         $factory            = new Factory($inputFilterManager);
-        $this->assertSame($inputFilterManager, $factory->getInputFilterManager());
+        self::assertSame($inputFilterManager, $factory->getInputFilterManager());
     }
 
     /**
@@ -858,9 +861,9 @@ class FactoryTest extends TestCase
     {
         $factory = $this->createDefaultFactory();
 
-        $this->assertTrue($factory->createInput(['break_on_failure' => true])->breakOnFailure());
+        self::assertTrue($factory->createInput(['break_on_failure' => true])->breakOnFailure());
 
-        $this->assertFalse($factory->createInput(['break_on_failure' => false])->breakOnFailure());
+        self::assertFalse($factory->createInput(['break_on_failure' => false])->breakOnFailure());
     }
 
     public function testCanCreateInputFilterWithNullInputs(): void
@@ -877,42 +880,37 @@ class FactoryTest extends TestCase
             ],
         ]);
 
-        $this->assertInstanceOf(InputFilter::class, $inputFilter);
-        $this->assertEquals(2, count($inputFilter));
-        $this->assertTrue($inputFilter->has('foo'));
-        $this->assertFalse($inputFilter->has('bar'));
-        $this->assertTrue($inputFilter->has('baz'));
+        self::assertInstanceOf(InputFilter::class, $inputFilter);
+        self::assertCount(2, $inputFilter);
+        self::assertTrue($inputFilter->has('foo'));
+        self::assertFalse($inputFilter->has('bar'));
+        self::assertTrue($inputFilter->has('baz'));
     }
 
     public function testCanCreateInputFromProvider(): void
     {
-        /** @var InputProviderInterface|MockObject $provider */
-        $provider = $this->getMockBuilder(InputProviderInterface::class)
-            ->setMethods(['getInputSpecification'])
-            ->getMock();
+        /** @var InputProviderInterface&MockObject $provider */
+        $provider = $this->createMock(InputProviderInterface::class);
 
         $provider
-            ->expects($this->any())
+            ->expects(self::any())
             ->method('getInputSpecification')
-            ->will($this->returnValue(['name' => 'foo']));
+            ->willReturn(['name' => 'foo']);
 
         $factory = $this->createDefaultFactory();
         $input   = $factory->createInput($provider);
 
-        $this->assertInstanceOf(InputInterface::class, $input);
+        self::assertInstanceOf(InputInterface::class, $input);
     }
 
     public function testCanCreateInputFilterFromProvider(): void
     {
-        /** @var InputFilterProviderInterface|MockObject $provider */
-        $provider = $this->getMockBuilder(InputFilterProviderInterface::class)
-            ->setMethods(['getInputFilterSpecification'])
-            ->getMock();
-
+        /** @var InputFilterProviderInterface&MockObject $provider */
+        $provider = $this->createMock(InputFilterProviderInterface::class);
         $provider
-            ->expects($this->any())
+            ->expects(self::any())
             ->method('getInputFilterSpecification')
-            ->will($this->returnValue([
+            ->willReturn([
                 'foo' => [
                     'name'     => 'foo',
                     'required' => false,
@@ -921,12 +919,12 @@ class FactoryTest extends TestCase
                     'name'     => 'baz',
                     'required' => true,
                 ],
-            ]));
+            ]);
 
         $factory     = $this->createDefaultFactory();
         $inputFilter = $factory->createInputFilter($provider);
 
-        $this->assertInstanceOf(InputFilterInterface::class, $inputFilter);
+        self::assertInstanceOf(InputFilterInterface::class, $inputFilter);
     }
 
     public function testSuggestedTypeMayBePluginNameInInputFilterPluginManager(): void
@@ -939,7 +937,9 @@ class FactoryTest extends TestCase
         $input = $factory->createInput([
             'type' => 'bar',
         ]);
-        $this->assertSame('bar', $input->getName());
+
+        self::assertInstanceOf(InputInterface::class, $input);
+        self::assertSame('bar', $input->getName());
     }
 
     public function testInputFromPluginManagerMayBeFurtherConfiguredWithSpec(): void
@@ -947,7 +947,7 @@ class FactoryTest extends TestCase
         $pluginManager = new InputFilterPluginManager(new ServiceManager\ServiceManager());
         $pluginManager->setService('bar', $barInput = new Input('bar'));
         $factory = new Factory($pluginManager);
-        $this->assertTrue($barInput->isRequired());
+        self::assertTrue($barInput->isRequired());
         $factory->setInputFilterManager($pluginManager);
 
         $input = $factory->createInput([
@@ -955,8 +955,9 @@ class FactoryTest extends TestCase
             'required' => false,
         ]);
 
-        $this->assertFalse($input->isRequired());
-        $this->assertSame('bar', $input->getName());
+        self::assertInstanceOf(InputInterface::class, $input);
+        self::assertFalse($input->isRequired());
+        self::assertSame('bar', $input->getName());
     }
 
     public function testCreateInputFilterConfiguredNameWhenSpecIsIntegerIndexed(): void
@@ -969,7 +970,7 @@ class FactoryTest extends TestCase
             ],
         ]);
 
-        $this->assertTrue($inputFilter->has('foo'));
+        self::assertTrue($inputFilter->has('foo'));
     }
 
     public function testCreateInputFilterUsesAssociatedNameMappingOverConfiguredName(): void
@@ -982,8 +983,8 @@ class FactoryTest extends TestCase
             ],
         ]);
 
-        $this->assertTrue($inputFilter->has('foo'));
-        $this->assertFalse($inputFilter->has('bar'));
+        self::assertTrue($inputFilter->has('foo'));
+        self::assertFalse($inputFilter->has('bar'));
     }
 
     public function testCreateInputFilterUsesConfiguredNameForNestedInputFilters(): void
@@ -1011,35 +1012,35 @@ class FactoryTest extends TestCase
             ],
         ]);
 
-        $this->assertInstanceOf(InputFilter::class, $inputFilter);
-        $this->assertEquals(2, count($inputFilter));
+        self::assertInstanceOf(InputFilter::class, $inputFilter);
+        self::assertCount(2, $inputFilter);
 
         $nestedInputFilter = $inputFilter->get('bar');
-        $this->assertInstanceOf(InputFilter::class, $nestedInputFilter);
-        $this->assertEquals(2, count($nestedInputFilter));
-        $this->assertTrue($nestedInputFilter->has('bat'));
-        $this->assertTrue($nestedInputFilter->has('baz'));
+        self::assertInstanceOf(InputFilter::class, $nestedInputFilter);
+        self::assertCount(2, $nestedInputFilter);
+        self::assertTrue($nestedInputFilter->has('bat'));
+        self::assertTrue($nestedInputFilter->has('baz'));
 
         $collection = $inputFilter->get('foo');
-        $this->assertInstanceOf(CollectionInputFilter::class, $collection);
+        self::assertInstanceOf(CollectionInputFilter::class, $collection);
         $collectionInputFilter = $collection->getInputFilter();
-        $this->assertInstanceOf(InputFilter::class, $collectionInputFilter);
-        $this->assertEquals(1, count($collectionInputFilter));
-        $this->assertTrue($collectionInputFilter->has('bat'));
+        self::assertInstanceOf(InputFilter::class, $collectionInputFilter);
+        self::assertCount(1, $collectionInputFilter);
+        self::assertTrue($collectionInputFilter->has('bat'));
     }
 
     public function testClearDefaultFilterChain(): void
     {
         $factory = $this->createDefaultFactory();
         $factory->clearDefaultFilterChain();
-        $this->assertNull($factory->getDefaultFilterChain());
+        self::assertNull($factory->getDefaultFilterChain());
     }
 
     public function testClearDefaultValidatorChain(): void
     {
         $factory = $this->createDefaultFactory();
         $factory->clearDefaultValidatorChain();
-        $this->assertNull($factory->getDefaultValidatorChain());
+        self::assertNull($factory->getDefaultValidatorChain());
     }
 
     public function testWhenCreateInputPullsInputFromThePluginManagerItMustNotOverwriteFilterAndValidatorChains(): void
@@ -1083,12 +1084,12 @@ class FactoryTest extends TestCase
             'count'            => 3,
         ]);
 
-        $this->assertInstanceOf(CollectionInputFilter::class, $inputFilter);
+        self::assertInstanceOf(CollectionInputFilter::class, $inputFilter);
 
         $notEmptyValidator = $inputFilter->getNotEmptyValidator();
         $messageTemplates  = $notEmptyValidator->getMessageTemplates();
-        $this->assertArrayHasKey(Validator\NotEmpty::IS_EMPTY, $messageTemplates);
-        $this->assertSame($message, $messageTemplates[Validator\NotEmpty::IS_EMPTY]);
+        self::assertArrayHasKey(Validator\NotEmpty::IS_EMPTY, $messageTemplates);
+        self::assertSame($message, $messageTemplates[Validator\NotEmpty::IS_EMPTY]);
     }
 
     protected function createDefaultFactory(): Factory
@@ -1104,11 +1105,11 @@ class FactoryTest extends TestCase
         $pluginValue
     ): InputFilterPluginManager {
         $pluginManager = $this->createMock(InputFilterPluginManager::class);
-        $pluginManager->expects($this->atLeastOnce())
+        $pluginManager->expects(self::atLeastOnce())
             ->method('has')
             ->with($pluginName)
             ->willReturn(true);
-        $pluginManager->expects($this->atLeastOnce())
+        $pluginManager->expects(self::atLeastOnce())
             ->method('get')
             ->with($pluginName)
             ->willReturn($pluginValue);

--- a/test/FileInput/HttpServerFileInputDecoratorTest.php
+++ b/test/FileInput/HttpServerFileInputDecoratorTest.php
@@ -10,7 +10,6 @@ use Laminas\Validator;
 use LaminasTest\InputFilter\InputTest;
 use Webmozart\Assert\Assert;
 
-use function count;
 use function json_encode;
 
 use const JSON_THROW_ON_ERROR;
@@ -35,7 +34,7 @@ class HttpServerFileInputDecoratorTest extends InputTest
 
     public function testRetrievingValueFiltersTheValue(): void
     {
-        $this->markTestSkipped('Test are not enabled in FileInputTest');
+        self::markTestSkipped('Test are not enabled in FileInputTest');
     }
 
     public function testRetrievingValueFiltersTheValueOnlyAfterValidating(): void
@@ -46,12 +45,12 @@ class HttpServerFileInputDecoratorTest extends InputTest
         $newValue = ['tmp_name' => 'foo'];
         $this->input->setFilterChain($this->createFilterChainMock([[$value, $newValue]]));
 
-        $this->assertEquals($value, $this->input->getValue());
-        $this->assertTrue(
+        self::assertEquals($value, $this->input->getValue());
+        self::assertTrue(
             $this->input->isValid(),
             'isValid() value not match. Detail . ' . json_encode($this->input->getMessages(), JSON_THROW_ON_ERROR)
         );
-        $this->assertEquals($newValue, $this->input->getValue());
+        self::assertEquals($newValue, $this->input->getValue());
     }
 
     public function testCanFilterArrayOfMultiFileData(): void
@@ -71,12 +70,12 @@ class HttpServerFileInputDecoratorTest extends InputTest
             [$values[2], $newValue],
         ]));
 
-        $this->assertEquals($values, $this->input->getValue());
-        $this->assertTrue(
+        self::assertEquals($values, $this->input->getValue());
+        self::assertTrue(
             $this->input->isValid(),
             'isValid() value not match. Detail . ' . json_encode($this->input->getMessages(), JSON_THROW_ON_ERROR)
         );
-        $this->assertEquals(
+        self::assertEquals(
             $filteredValue,
             $this->input->getValue()
         );
@@ -90,12 +89,12 @@ class HttpServerFileInputDecoratorTest extends InputTest
         $newValue = ['tmp_name' => 'new'];
         $this->input->setFilterChain($this->createFilterChainMock([[$value, $newValue]]));
 
-        $this->assertEquals($value, $this->input->getRawValue());
+        self::assertEquals($value, $this->input->getRawValue());
     }
 
     public function testValidationOperatesOnFilteredValue(): void
     {
-        $this->markTestSkipped('Test is not enabled in FileInputTest');
+        self::markTestSkipped('Test is not enabled in FileInputTest');
     }
 
     public function testValidationOperatesBeforeFiltering(): void
@@ -112,21 +111,21 @@ class HttpServerFileInputDecoratorTest extends InputTest
         $this->input->setFilterChain($this->createFilterChainMock([[$badValue, $filteredValue]]));
         $this->input->setValidatorChain($this->createValidatorChainMock([[$badValue, null, false]]));
 
-        $this->assertFalse($this->input->isValid());
-        $this->assertEquals($badValue, $this->input->getValue());
+        self::assertFalse($this->input->isValid());
+        self::assertEquals($badValue, $this->input->getValue());
     }
 
     public function testAutoPrependUploadValidatorIsOnByDefault(): void
     {
         $input = new FileInput('foo');
-        $this->assertTrue($input->getAutoPrependUploadValidator());
+        self::assertTrue($input->getAutoPrependUploadValidator());
     }
 
     public function testUploadValidatorIsAddedWhenIsValidIsCalled(): void
     {
         $this->input->setAutoPrependUploadValidator(true);
-        $this->assertTrue($this->input->getAutoPrependUploadValidator());
-        $this->assertTrue($this->input->isRequired());
+        self::assertTrue($this->input->getAutoPrependUploadValidator());
+        self::assertTrue($this->input->isRequired());
         $this->input->setValue([
             'tmp_name' => __FILE__,
             'name'     => 'foo',
@@ -134,60 +133,58 @@ class HttpServerFileInputDecoratorTest extends InputTest
             'error'    => 0,
         ]);
         $validatorChain = $this->input->getValidatorChain();
-        $this->assertEquals(0, count($validatorChain->getValidators()));
+        self::assertCount(0, $validatorChain->getValidators());
 
-        $this->assertFalse($this->input->isValid());
+        self::assertFalse($this->input->isValid());
         $validators = $validatorChain->getValidators();
-        $this->assertEquals(1, count($validators));
-        $this->assertInstanceOf(Validator\File\UploadFile::class, $validators[0]['instance']);
+        self::assertCount(1, $validators);
+        self::assertInstanceOf(Validator\File\UploadFile::class, $validators[0]['instance']);
     }
 
     public function testUploadValidatorIsNotAddedWhenIsValidIsCalled(): void
     {
-        $this->assertFalse($this->input->getAutoPrependUploadValidator());
-        $this->assertTrue($this->input->isRequired());
+        self::assertFalse($this->input->getAutoPrependUploadValidator());
+        self::assertTrue($this->input->isRequired());
         $this->input->setValue(['tmp_name' => 'bar']);
         $validatorChain = $this->input->getValidatorChain();
-        $this->assertEquals(0, count($validatorChain->getValidators()));
+        self::assertCount(0, $validatorChain->getValidators());
 
-        $this->assertTrue(
+        self::assertTrue(
             $this->input->isValid(),
             'isValid() value not match. Detail . ' . json_encode($this->input->getMessages(), JSON_THROW_ON_ERROR)
         );
-        $this->assertEquals(0, count($validatorChain->getValidators()));
+        self::assertCount(0, $validatorChain->getValidators());
     }
 
     public function testRequiredUploadValidatorValidatorNotAddedWhenOneExists(): void
     {
         $this->input->setAutoPrependUploadValidator(true);
-        $this->assertTrue($this->input->getAutoPrependUploadValidator());
-        $this->assertTrue($this->input->isRequired());
+        self::assertTrue($this->input->getAutoPrependUploadValidator());
+        self::assertTrue($this->input->isRequired());
         $this->input->setValue(['tmp_name' => 'bar']);
 
-        $uploadMock = $this->getMockBuilder(Validator\File\UploadFile::class)
-            ->setMethods(['isValid'])
-            ->getMock();
-        $uploadMock->expects($this->exactly(1))
+        $uploadMock = $this->createMock(Validator\File\UploadFile::class);
+        $uploadMock->expects(self::exactly(1))
                      ->method('isValid')
-                     ->will($this->returnValue(true));
+                     ->willReturn(true);
 
         $validatorChain = $this->input->getValidatorChain();
         $validatorChain->prependValidator($uploadMock);
-        $this->assertTrue(
+        self::assertTrue(
             $this->input->isValid(),
             'isValid() value not match. Detail . ' . json_encode($this->input->getMessages(), JSON_THROW_ON_ERROR)
         );
 
         $validators = $validatorChain->getValidators();
-        $this->assertEquals(1, count($validators));
-        $this->assertEquals($uploadMock, $validators[0]['instance']);
+        self::assertCount(1, $validators);
+        self::assertEquals($uploadMock, $validators[0]['instance']);
     }
 
     public function testValidationsRunWithoutFileArrayDueToAjaxPost(): void
     {
         $this->input->setAutoPrependUploadValidator(true);
-        $this->assertTrue($this->input->getAutoPrependUploadValidator());
-        $this->assertTrue($this->input->isRequired());
+        self::assertTrue($this->input->getAutoPrependUploadValidator());
+        self::assertTrue($this->input->isRequired());
         $this->input->setValue('');
 
         $expectedNormalizedValue = [
@@ -198,14 +195,14 @@ class HttpServerFileInputDecoratorTest extends InputTest
             'error'    => UPLOAD_ERR_NO_FILE,
         ];
         $this->input->setValidatorChain($this->createValidatorChainMock([[$expectedNormalizedValue, null, false]]));
-        $this->assertFalse($this->input->isValid());
+        self::assertFalse($this->input->isValid());
     }
 
     public function testValidationsRunWithoutFileArrayIsSend(): void
     {
         $this->input->setAutoPrependUploadValidator(true);
-        $this->assertTrue($this->input->getAutoPrependUploadValidator());
-        $this->assertTrue($this->input->isRequired());
+        self::assertTrue($this->input->getAutoPrependUploadValidator());
+        self::assertTrue($this->input->isRequired());
         $this->input->setValue([]);
         $expectedNormalizedValue = [
             'tmp_name' => '',
@@ -215,19 +212,19 @@ class HttpServerFileInputDecoratorTest extends InputTest
             'error'    => UPLOAD_ERR_NO_FILE,
         ];
         $this->input->setValidatorChain($this->createValidatorChainMock([[$expectedNormalizedValue, null, false]]));
-        $this->assertFalse($this->input->isValid());
+        self::assertFalse($this->input->isValid());
     }
 
     /** @param mixed $value */
     public function testNotEmptyValidatorAddedWhenIsValidIsCalled($value = null): void
     {
-        $this->markTestSkipped('Test is not enabled in FileInputTest');
+        self::markTestSkipped('Test is not enabled in FileInputTest');
     }
 
     /** @param mixed $value */
     public function testRequiredNotEmptyValidatorNotAddedWhenOneExists($value = null): void
     {
-        $this->markTestSkipped('Test is not enabled in FileInputTest');
+        self::markTestSkipped('Test is not enabled in FileInputTest');
     }
 
     /**
@@ -242,7 +239,7 @@ class HttpServerFileInputDecoratorTest extends InputTest
         ?bool $isValid = null,
         $expectedValue = null
     ): void {
-        $this->markTestSkipped('Input::setFallbackValue is not implemented on FileInput');
+        self::markTestSkipped('Input::setFallbackValue is not implemented on FileInput');
     }
 
     /** @param null|string|string[] $fallbackValue */
@@ -250,13 +247,13 @@ class HttpServerFileInputDecoratorTest extends InputTest
         ?bool $required = null,
         $fallbackValue = null
     ): void {
-        $this->markTestSkipped('Input::setFallbackValue is not implemented on FileInput');
+        self::markTestSkipped('Input::setFallbackValue is not implemented on FileInput');
     }
 
     public function testIsEmptyFileNotArray(): void
     {
         $rawValue = 'file';
-        $this->assertTrue($this->input->isEmptyFile($rawValue));
+        self::assertTrue($this->input->isEmptyFile($rawValue));
     }
 
     public function testIsEmptyFileUploadNoFile(): void
@@ -265,7 +262,7 @@ class HttpServerFileInputDecoratorTest extends InputTest
             'tmp_name' => '',
             'error'    => UPLOAD_ERR_NO_FILE,
         ];
-        $this->assertTrue($this->input->isEmptyFile($rawValue));
+        self::assertTrue($this->input->isEmptyFile($rawValue));
     }
 
     public function testIsEmptyFileOk(): void
@@ -274,7 +271,7 @@ class HttpServerFileInputDecoratorTest extends InputTest
             'tmp_name' => 'name',
             'error'    => UPLOAD_ERR_OK,
         ];
-        $this->assertFalse($this->input->isEmptyFile($rawValue));
+        self::assertFalse($this->input->isEmptyFile($rawValue));
     }
 
     public function testIsEmptyMultiFileUploadNoFile(): void
@@ -285,7 +282,7 @@ class HttpServerFileInputDecoratorTest extends InputTest
                 'error'    => UPLOAD_ERR_NO_FILE,
             ],
         ];
-        $this->assertTrue($this->input->isEmptyFile($rawValue));
+        self::assertTrue($this->input->isEmptyFile($rawValue));
     }
 
     public function testIsEmptyFileMultiFileOk(): void
@@ -300,7 +297,7 @@ class HttpServerFileInputDecoratorTest extends InputTest
                 'error'    => UPLOAD_ERR_OK,
             ],
         ];
-        $this->assertFalse($this->input->isEmptyFile($rawValue));
+        self::assertFalse($this->input->isEmptyFile($rawValue));
     }
 
     public function testDefaultInjectedUploadValidatorRespectsRelease2Convention(): void
@@ -311,7 +308,7 @@ class HttpServerFileInputDecoratorTest extends InputTest
         $pluginManager->setInvokableClass('fileuploadfile', TestAsset\FileUploadMock::class);
         $input->setValue('');
 
-        $this->assertTrue($input->isValid());
+        self::assertTrue($input->isValid());
     }
 
     /**
@@ -326,9 +323,9 @@ class HttpServerFileInputDecoratorTest extends InputTest
         $target->setAutoPrependUploadValidator(false);
 
         $return = $target->merge($source);
-        $this->assertSame($target, $return, 'merge() must return it self');
+        self::assertSame($target, $return, 'merge() must return it self');
 
-        $this->assertEquals(
+        self::assertEquals(
             true,
             $target->getAutoPrependUploadValidator(),
             'getAutoPrependUploadValidator() value not match'

--- a/test/FileInput/PsrFileInputDecoratorTest.php
+++ b/test/FileInput/PsrFileInputDecoratorTest.php
@@ -11,7 +11,6 @@ use Laminas\Validator;
 use LaminasTest\InputFilter\InputTest;
 use Psr\Http\Message\UploadedFileInterface;
 
-use function count;
 use function in_array;
 use function json_encode;
 
@@ -38,7 +37,7 @@ class PsrFileInputDecoratorTest extends InputTest
 
     public function testRetrievingValueFiltersTheValue(): void
     {
-        $this->markTestSkipped('Test is not enabled in PsrFileInputTest');
+        self::markTestSkipped('Test is not enabled in PsrFileInputTest');
     }
 
     public function testRetrievingValueFiltersTheValueOnlyAfterValidating(): void
@@ -59,12 +58,12 @@ class PsrFileInputDecoratorTest extends InputTest
             ],
         ]));
 
-        $this->assertEquals($upload, $this->input->getValue());
-        $this->assertTrue(
+        self::assertEquals($upload, $this->input->getValue());
+        self::assertTrue(
             $this->input->isValid(),
             'isValid() value not match. Detail . ' . json_encode($this->input->getMessages(), JSON_THROW_ON_ERROR)
         );
-        $this->assertEquals($filteredUpload, $this->input->getValue());
+        self::assertEquals($filteredUpload, $this->input->getValue());
     }
 
     public function testCanFilterArrayOfMultiFileData(): void
@@ -90,12 +89,12 @@ class PsrFileInputDecoratorTest extends InputTest
             [$values[2], $filteredValues[2]],
         ]));
 
-        $this->assertEquals($values, $this->input->getValue());
-        $this->assertTrue(
+        self::assertEquals($values, $this->input->getValue());
+        self::assertTrue(
             $this->input->isValid(),
             'isValid() value not match. Detail . ' . json_encode($this->input->getMessages(), JSON_THROW_ON_ERROR)
         );
-        $this->assertEquals(
+        self::assertEquals(
             $filteredValues,
             $this->input->getValue()
         );
@@ -111,12 +110,12 @@ class PsrFileInputDecoratorTest extends InputTest
         $filteredValue = $this->createMock(UploadedFileInterface::class);
         $this->input->setFilterChain($this->createFilterChainMock([[$value, $filteredValue]]));
 
-        $this->assertEquals($value, $this->input->getRawValue());
+        self::assertEquals($value, $this->input->getRawValue());
     }
 
     public function testValidationOperatesOnFilteredValue(): void
     {
-        $this->markTestSkipped('Test is not enabled in PsrFileInputTest');
+        self::markTestSkipped('Test is not enabled in PsrFileInputTest');
     }
 
     public function testValidationOperatesBeforeFiltering(): void
@@ -132,21 +131,21 @@ class PsrFileInputDecoratorTest extends InputTest
         $this->input->setFilterChain($this->createFilterChainMock([[$badValue, $filteredValue]]));
         $this->input->setValidatorChain($this->createValidatorChainMock([[$badValue, null, false]]));
 
-        $this->assertFalse($this->input->isValid());
-        $this->assertEquals($badValue, $this->input->getValue());
+        self::assertFalse($this->input->isValid());
+        self::assertEquals($badValue, $this->input->getValue());
     }
 
     public function testAutoPrependUploadValidatorIsOnByDefault(): void
     {
         $input = new FileInput('foo');
-        $this->assertTrue($input->getAutoPrependUploadValidator());
+        self::assertTrue($input->getAutoPrependUploadValidator());
     }
 
     public function testUploadValidatorIsAddedDuringIsValidWhenAutoPrependUploadValidatorIsEnabled(): void
     {
         $this->input->setAutoPrependUploadValidator(true);
-        $this->assertTrue($this->input->getAutoPrependUploadValidator());
-        $this->assertTrue($this->input->isRequired());
+        self::assertTrue($this->input->getAutoPrependUploadValidator());
+        self::assertTrue($this->input->isRequired());
 
         $uploadedFile = $this->createMock(UploadedFileInterface::class);
         $uploadedFile->expects(self::atLeast(1))
@@ -156,18 +155,18 @@ class PsrFileInputDecoratorTest extends InputTest
         $this->input->setValue($uploadedFile);
 
         $validatorChain = $this->input->getValidatorChain();
-        $this->assertCount(0, $validatorChain->getValidators());
+        self::assertCount(0, $validatorChain->getValidators());
 
-        $this->assertFalse($this->input->isValid());
+        self::assertFalse($this->input->isValid());
         $validators = $validatorChain->getValidators();
-        $this->assertCount(1, $validators);
-        $this->assertInstanceOf(Validator\File\UploadFile::class, $validators[0]['instance']);
+        self::assertCount(1, $validators);
+        self::assertInstanceOf(Validator\File\UploadFile::class, $validators[0]['instance']);
     }
 
     public function testUploadValidatorIsNotAddedByDefaultDuringIsValidWhenAutoPrependUploadValidatorIsDisabled(): void
     {
-        $this->assertFalse($this->input->getAutoPrependUploadValidator());
-        $this->assertTrue($this->input->isRequired());
+        self::assertFalse($this->input->getAutoPrependUploadValidator());
+        self::assertTrue($this->input->isRequired());
 
         $uploadedFile = $this->createMock(UploadedFileInterface::class);
         $uploadedFile->expects(self::atLeast(1))
@@ -176,20 +175,20 @@ class PsrFileInputDecoratorTest extends InputTest
 
         $this->input->setValue($uploadedFile);
         $validatorChain = $this->input->getValidatorChain();
-        $this->assertEquals(0, count($validatorChain->getValidators()));
+        self::assertCount(0, $validatorChain->getValidators());
 
-        $this->assertTrue(
+        self::assertTrue(
             $this->input->isValid(),
             'isValid() value not match. Detail . ' . json_encode($this->input->getMessages(), JSON_THROW_ON_ERROR)
         );
-        $this->assertEquals(0, count($validatorChain->getValidators()));
+        self::assertCount(0, $validatorChain->getValidators());
     }
 
     public function testRequiredUploadValidatorValidatorNotAddedWhenOneExists(): void
     {
         $this->input->setAutoPrependUploadValidator(true);
-        $this->assertTrue($this->input->getAutoPrependUploadValidator());
-        $this->assertTrue($this->input->isRequired());
+        self::assertTrue($this->input->getAutoPrependUploadValidator());
+        self::assertTrue($this->input->isRequired());
 
         $upload = $this->createMock(UploadedFileInterface::class);
         $upload->expects(self::atLeast(1))
@@ -206,26 +205,26 @@ class PsrFileInputDecoratorTest extends InputTest
 
         $validatorChain = $this->input->getValidatorChain();
         $validatorChain->prependValidator($validator);
-        $this->assertTrue(
+        self::assertTrue(
             $this->input->isValid(),
             'isValid() value not match. Detail . ' . json_encode($this->input->getMessages(), JSON_THROW_ON_ERROR)
         );
 
         $validators = $validatorChain->getValidators();
-        $this->assertEquals(1, count($validators));
-        $this->assertEquals($validator, $validators[0]['instance']);
+        self::assertCount(1, $validators);
+        self::assertEquals($validator, $validators[0]['instance']);
     }
 
     /** @param mixed $value */
     public function testNotEmptyValidatorAddedWhenIsValidIsCalled($value = null): void
     {
-        $this->markTestSkipped('Test is not enabled in PsrFileInputTest');
+        self::markTestSkipped('Test is not enabled in PsrFileInputTest');
     }
 
     /** @param mixed $value */
     public function testRequiredNotEmptyValidatorNotAddedWhenOneExists($value = null): void
     {
-        $this->markTestSkipped('Test is not enabled in PsrFileInputTest');
+        self::markTestSkipped('Test is not enabled in PsrFileInputTest');
     }
 
     /**
@@ -240,7 +239,7 @@ class PsrFileInputDecoratorTest extends InputTest
         ?bool $isValid = null,
         $expectedValue = null
     ): void {
-        $this->markTestSkipped('Input::setFallbackValue is not implemented on PsrFileInput');
+        self::markTestSkipped('Input::setFallbackValue is not implemented on PsrFileInput');
     }
 
     /** @param null|string|string[] $fallbackValue */
@@ -248,7 +247,7 @@ class PsrFileInputDecoratorTest extends InputTest
         ?bool $required = null,
         $fallbackValue = null
     ): void {
-        $this->markTestSkipped('Input::setFallbackValue is not implemented on PsrFileInput');
+        self::markTestSkipped('Input::setFallbackValue is not implemented on PsrFileInput');
     }
 
     public function testIsEmptyFileUploadNoFile(): void
@@ -257,7 +256,7 @@ class PsrFileInputDecoratorTest extends InputTest
         $upload->expects(self::atLeast(1))
             ->method('getError')
             ->willReturn(UPLOAD_ERR_NO_FILE);
-        $this->assertTrue($this->input->isEmptyFile($upload));
+        self::assertTrue($this->input->isEmptyFile($upload));
     }
 
     public function testIsEmptyFileOk(): void
@@ -266,7 +265,7 @@ class PsrFileInputDecoratorTest extends InputTest
         $upload->expects(self::atLeast(1))
             ->method('getError')
             ->willReturn(UPLOAD_ERR_OK);
-        $this->assertFalse($this->input->isEmptyFile($upload));
+        self::assertFalse($this->input->isEmptyFile($upload));
     }
 
     public function testIsEmptyMultiFileUploadNoFile(): void
@@ -278,7 +277,7 @@ class PsrFileInputDecoratorTest extends InputTest
 
         $rawValue = [$upload];
 
-        $this->assertTrue($this->input->isEmptyFile($rawValue));
+        self::assertTrue($this->input->isEmptyFile($rawValue));
     }
 
     public function testIsEmptyFileMultiFileOk(): void
@@ -292,7 +291,7 @@ class PsrFileInputDecoratorTest extends InputTest
             $rawValue[] = $upload;
         }
 
-        $this->assertFalse($this->input->isEmptyFile($rawValue));
+        self::assertFalse($this->input->isEmptyFile($rawValue));
     }
 
     /**
@@ -307,9 +306,9 @@ class PsrFileInputDecoratorTest extends InputTest
         $target->setAutoPrependUploadValidator(false);
 
         $return = $target->merge($source);
-        $this->assertSame($target, $return, 'merge() must return it self');
+        self::assertSame($target, $return, 'merge() must return it self');
 
-        $this->assertEquals(
+        self::assertEquals(
             true,
             $target->getAutoPrependUploadValidator(),
             'getAutoPrependUploadValidator() value not match'

--- a/test/InputFilterPluginManagerFactoryTest.php
+++ b/test/InputFilterPluginManagerFactoryTest.php
@@ -21,15 +21,15 @@ class InputFilterPluginManagerFactoryTest extends TestCase
         $factory   = new InputFilterPluginManagerFactory();
 
         $filters = $factory($container, InputFilterPluginManagerFactory::class);
-        $this->assertInstanceOf(InputFilterPluginManager::class, $filters);
+        self::assertInstanceOf(InputFilterPluginManager::class, $filters);
 
         $r = new ReflectionObject($filters);
         $p = $r->getProperty('creationContext');
         $p->setAccessible(true);
-        $this->assertSame($container, $p->getValue($filters));
+        self::assertSame($container, $p->getValue($filters));
     }
 
-    /** @psalm-return array<string, array{0: class-string<InputInterface>}> */
+    /** @psalm-return array<string, array{0: class-string}> */
     public function pluginProvider(): array
     {
         return [
@@ -54,7 +54,7 @@ class InputFilterPluginManagerFactoryTest extends TestCase
                 'test' => $plugin,
             ],
         ]);
-        $this->assertSame($plugin, $filters->get('test'));
+        self::assertSame($plugin, $filters->get('test'));
     }
 
     public function testConfiguresInputFilterServicesWhenFound(): void
@@ -84,11 +84,11 @@ class InputFilterPluginManagerFactoryTest extends TestCase
         $factory      = new InputFilterPluginManagerFactory();
         $inputFilters = $factory($container);
 
-        $this->assertInstanceOf(InputFilterPluginManager::class, $inputFilters);
-        $this->assertTrue($inputFilters->has('test'));
-        $this->assertSame($inputFilter, $inputFilters->get('test'));
-        $this->assertTrue($inputFilters->has('test-too'));
-        $this->assertSame($inputFilter, $inputFilters->get('test-too'));
+        self::assertInstanceOf(InputFilterPluginManager::class, $inputFilters);
+        self::assertTrue($inputFilters->has('test'));
+        self::assertSame($inputFilter, $inputFilters->get('test'));
+        self::assertTrue($inputFilters->has('test-too'));
+        self::assertSame($inputFilter, $inputFilters->get('test-too'));
     }
 
     public function testDoesNotConfigureInputFilterServicesWhenServiceListenerPresent(): void
@@ -104,9 +104,9 @@ class InputFilterPluginManagerFactoryTest extends TestCase
         $factory      = new InputFilterPluginManagerFactory();
         $inputFilters = $factory($container);
 
-        $this->assertInstanceOf(InputFilterPluginManager::class, $inputFilters);
-        $this->assertFalse($inputFilters->has('test'));
-        $this->assertFalse($inputFilters->has('test-too'));
+        self::assertInstanceOf(InputFilterPluginManager::class, $inputFilters);
+        self::assertFalse($inputFilters->has('test'));
+        self::assertFalse($inputFilters->has('test-too'));
     }
 
     public function testDoesNotConfigureInputFilterServicesWhenConfigServiceNotPresent(): void
@@ -122,7 +122,7 @@ class InputFilterPluginManagerFactoryTest extends TestCase
         $factory      = new InputFilterPluginManagerFactory();
         $inputFilters = $factory($container);
 
-        $this->assertInstanceOf(InputFilterPluginManager::class, $inputFilters);
+        self::assertInstanceOf(InputFilterPluginManager::class, $inputFilters);
     }
 
     public function testDoesNotConfigureInputFilterServicesWhenConfigServiceDoesNotContainInputFiltersConfig(): void
@@ -141,7 +141,7 @@ class InputFilterPluginManagerFactoryTest extends TestCase
         $factory      = new InputFilterPluginManagerFactory();
         $inputFilters = $factory($container);
 
-        $this->assertInstanceOf(InputFilterPluginManager::class, $inputFilters);
-        $this->assertFalse($inputFilters->has('foo'));
+        self::assertInstanceOf(InputFilterPluginManager::class, $inputFilters);
+        self::assertFalse($inputFilters->has('foo'));
     }
 }

--- a/test/InputFilterTest.php
+++ b/test/InputFilterTest.php
@@ -29,14 +29,14 @@ class InputFilterTest extends BaseInputFilterTest
     public function testLazilyComposesAFactoryByDefault(): void
     {
         $factory = $this->inputFilter->getFactory();
-        $this->assertInstanceOf(Factory::class, $factory);
+        self::assertInstanceOf(Factory::class, $factory);
     }
 
     public function testCanComposeAFactory(): void
     {
         $factory = $this->createFactoryMock();
         $this->inputFilter->setFactory($factory);
-        $this->assertSame($factory, $this->inputFilter->getFactory());
+        self::assertSame($factory, $this->inputFilter->getFactory());
     }
 
     /**
@@ -99,12 +99,14 @@ class InputFilterTest extends BaseInputFilterTest
             ],
         ], 'nested');
 
+        $expect = ['nested' => ['nestedField1' => null]];
+
         // Empty set of data
         $filter1->setData([]);
-        self::assertNull($filter1->getValues()['nested']['nestedField1']);
+        self::assertEquals($expect, $filter1->getValues());
 
         // null provided for nested filter
         $filter1->setData(['nested' => null]);
-        self::assertNull($filter1->getValues()['nested']['nestedField1']);
+        self::assertEquals($expect, $filter1->getValues());
     }
 }

--- a/test/InputTest.php
+++ b/test/InputTest.php
@@ -69,70 +69,70 @@ class InputTest extends TestCase
 
     public function testConstructorRequiresAName(): void
     {
-        $this->assertEquals('foo', $this->input->getName());
+        self::assertEquals('foo', $this->input->getName());
     }
 
     public function testInputHasEmptyFilterChainByDefault(): void
     {
         $filters = $this->input->getFilterChain();
-        $this->assertInstanceOf(FilterChain::class, $filters);
-        $this->assertEquals(0, count($filters));
+        self::assertInstanceOf(FilterChain::class, $filters);
+        self::assertCount(0, $filters);
     }
 
     public function testInputHasEmptyValidatorChainByDefault(): void
     {
         $validators = $this->input->getValidatorChain();
-        $this->assertInstanceOf(ValidatorChain::class, $validators);
-        $this->assertEquals(0, count($validators));
+        self::assertInstanceOf(ValidatorChain::class, $validators);
+        self::assertCount(0, $validators);
     }
 
     public function testCanInjectFilterChain(): void
     {
         $chain = $this->createFilterChainMock();
         $this->input->setFilterChain($chain);
-        $this->assertSame($chain, $this->input->getFilterChain());
+        self::assertSame($chain, $this->input->getFilterChain());
     }
 
     public function testCanInjectValidatorChain(): void
     {
         $chain = $this->createValidatorChainMock();
         $this->input->setValidatorChain($chain);
-        $this->assertSame($chain, $this->input->getValidatorChain());
+        self::assertSame($chain, $this->input->getValidatorChain());
     }
 
     public function testInputIsMarkedAsRequiredByDefault(): void
     {
-        $this->assertTrue($this->input->isRequired());
+        self::assertTrue($this->input->isRequired());
     }
 
     public function testRequiredFlagIsMutable(): void
     {
         $this->input->setRequired(false);
-        $this->assertFalse($this->input->isRequired());
+        self::assertFalse($this->input->isRequired());
     }
 
     public function testInputDoesNotAllowEmptyValuesByDefault(): void
     {
-        $this->assertFalse($this->input->allowEmpty());
+        self::assertFalse($this->input->allowEmpty());
     }
 
     public function testAllowEmptyFlagIsMutable(): void
     {
         $this->input->setAllowEmpty(true);
-        $this->assertTrue($this->input->allowEmpty());
+        self::assertTrue($this->input->allowEmpty());
     }
 
     public function testContinueIfEmptyFlagIsFalseByDefault(): void
     {
         $input = $this->input;
-        $this->assertFalse($input->continueIfEmpty());
+        self::assertFalse($input->continueIfEmpty());
     }
 
     public function testContinueIfEmptyFlagIsMutable(): void
     {
         $input = $this->input;
         $input->setContinueIfEmpty(true);
-        $this->assertTrue($input->continueIfEmpty());
+        self::assertTrue($input->continueIfEmpty());
     }
 
     /**
@@ -144,10 +144,10 @@ class InputTest extends TestCase
         $input = $this->input;
 
         $return = $input->setFallbackValue($fallbackValue);
-        $this->assertSame($input, $return, 'setFallbackValue() must return it self');
+        self::assertSame($input, $return, 'setFallbackValue() must return it self');
 
-        $this->assertEquals($fallbackValue, $input->getFallbackValue(), 'getFallbackValue() value not match');
-        $this->assertTrue($input->hasFallback(), 'hasFallback() value not match');
+        self::assertEquals($fallbackValue, $input->getFallbackValue(), 'getFallbackValue() value not match');
+        self::assertTrue($input->hasFallback(), 'hasFallback() value not match');
     }
 
     /**
@@ -159,8 +159,8 @@ class InputTest extends TestCase
         $input = $this->input;
         $input->setFallbackValue($fallbackValue);
         $input->clearFallbackValue();
-        $this->assertNull($input->getFallbackValue(), 'getFallbackValue() value not match');
-        $this->assertFalse($input->hasFallback(), 'hasFallback() value not match');
+        self::assertNull($input->getFallbackValue(), 'getFallbackValue() value not match');
+        self::assertFalse($input->hasFallback(), 'hasFallback() value not match');
     }
 
     /**
@@ -184,14 +184,14 @@ class InputTest extends TestCase
         $input->setFallbackValue($fallbackValue);
         $input->setValue($originalValue);
 
-        $this->assertTrue(
+        self::assertTrue(
             $input->isValid(),
             'isValid() should be return always true when fallback value is set. Detail: '
             . json_encode($input->getMessages(), JSON_THROW_ON_ERROR)
         );
-        $this->assertEquals([], $input->getMessages(), 'getMessages() should be empty because the input is valid');
-        $this->assertSame($expectedValue, $input->getRawValue(), 'getRawValue() value not match');
-        $this->assertSame($expectedValue, $input->getValue(), 'getValue() value not match');
+        self::assertEquals([], $input->getMessages(), 'getMessages() should be empty because the input is valid');
+        self::assertSame($expectedValue, $input->getRawValue(), 'getRawValue() value not match');
+        self::assertSame($expectedValue, $input->getValue(), 'getValue() value not match');
     }
 
     /**
@@ -209,14 +209,14 @@ class InputTest extends TestCase
         $input->setValidatorChain($this->createValidatorChainMock());
         $input->setFallbackValue($fallbackValue);
 
-        $this->assertTrue(
+        self::assertTrue(
             $input->isValid(),
             'isValid() should be return always true when fallback value is set. Detail: '
             . json_encode($input->getMessages(), JSON_THROW_ON_ERROR)
         );
-        $this->assertEquals([], $input->getMessages(), 'getMessages() should be empty because the input is valid');
-        $this->assertSame($expectedValue, $input->getRawValue(), 'getRawValue() value not match');
-        $this->assertSame($expectedValue, $input->getValue(), 'getValue() value not match');
+        self::assertEquals([], $input->getMessages(), 'getMessages() should be empty because the input is valid');
+        self::assertSame($expectedValue, $input->getRawValue(), 'getRawValue() value not match');
+        self::assertSame($expectedValue, $input->getValue(), 'getValue() value not match');
     }
 
     public function testRequiredWithoutFallbackAndValueNotSetThenFail(): void
@@ -224,7 +224,7 @@ class InputTest extends TestCase
         $input = $this->input;
         $input->setRequired(true);
 
-        $this->assertFalse(
+        self::assertFalse(
             $input->isValid(),
             'isValid() should be return always false when no fallback value, is required, and not data is set.'
         );
@@ -237,11 +237,11 @@ class InputTest extends TestCase
         $input->setRequired(true);
         $input->setErrorMessage('FAILED TO VALIDATE');
 
-        $this->assertFalse(
+        self::assertFalse(
             $input->isValid(),
             'isValid() should be return always false when no fallback value, is required, and not data is set.'
         );
-        $this->assertSame(['FAILED TO VALIDATE'], $input->getMessages());
+        self::assertSame(['FAILED TO VALIDATE'], $input->getMessages());
     }
 
     public function testRequiredWithoutFallbackAndValueNotSetProvidesNotEmptyValidatorIsEmptyErrorMessage(): void
@@ -249,7 +249,7 @@ class InputTest extends TestCase
         $input = $this->input;
         $input->setRequired(true);
 
-        $this->assertFalse(
+        self::assertFalse(
             $input->isValid(),
             'isValid() should always return false when no fallback value is present, '
             . 'the input is required, and no data is set.'
@@ -266,11 +266,8 @@ class InputTest extends TestCase
             NotEmptyValidator::IS_EMPTY => "Custom message",
         ];
 
-        $notEmpty = $this->getMockBuilder(NotEmptyValidator::class)
-            ->setMethods(['getOption'])
-            ->getMock();
-
-        $notEmpty->expects($this->once())
+        $notEmpty = $this->createMock(NotEmptyValidator::class);
+        $notEmpty->expects(self::once())
             ->method('getOption')
             ->with('messageTemplates')
             ->willReturn($customMessage);
@@ -278,12 +275,12 @@ class InputTest extends TestCase
         $input->getValidatorChain()
             ->attach($notEmpty);
 
-        $this->assertFalse(
+        self::assertFalse(
             $input->isValid(),
             'isValid() should always return false when no fallback value is present, '
             . 'the input is required, and no data is set.'
         );
-        $this->assertEquals($customMessage, $input->getMessages());
+        self::assertEquals($customMessage, $input->getMessages());
     }
 
     public function testRequiredWithoutFallbackAndValueNotSetProvidesCustomErrorMessageWhenSet(): void
@@ -292,12 +289,12 @@ class InputTest extends TestCase
         $input->setRequired(true);
         $input->setErrorMessage('FAILED TO VALIDATE');
 
-        $this->assertFalse(
+        self::assertFalse(
             $input->isValid(),
             'isValid() should always return false when no fallback value is present, '
             . 'the input is required, and no data is set.'
         );
-        $this->assertSame(['FAILED TO VALIDATE'], $input->getMessages());
+        self::assertSame(['FAILED TO VALIDATE'], $input->getMessages());
     }
 
     public function testNotRequiredWithoutFallbackAndValueNotSetThenIsValid(): void
@@ -310,12 +307,12 @@ class InputTest extends TestCase
         // Validator should not to be called
         $input->getValidatorChain()
             ->attach($this->createValidatorMock(null, null));
-        $this->assertTrue(
+        self::assertTrue(
             $input->isValid(),
             'isValid() should be return always true when is not required, and no data is set. Detail: '
             . json_encode($input->getMessages(), JSON_THROW_ON_ERROR)
         );
-        $this->assertEquals([], $input->getMessages(), 'getMessages() should be empty because the input is valid');
+        self::assertEquals([], $input->getMessages(), 'getMessages() should be empty because the input is valid');
     }
 
     /**
@@ -330,12 +327,12 @@ class InputTest extends TestCase
         $input->isValid();
         $validators = $input->getValidatorChain()
                                 ->getValidators();
-        $this->assertEmpty($validators);
+        self::assertEmpty($validators);
     }
 
     public function testDefaultGetValue(): void
     {
-        $this->assertNull($this->input->getValue());
+        self::assertNull($this->input->getValue());
     }
 
     public function testValueMayBeInjected(): void
@@ -343,7 +340,7 @@ class InputTest extends TestCase
         $valueRaw = $this->getDummyValue();
 
         $this->input->setValue($valueRaw);
-        $this->assertEquals($valueRaw, $this->input->getValue());
+        self::assertEquals($valueRaw, $this->input->getValue());
     }
 
     public function testRetrievingValueFiltersTheValue(): void
@@ -356,7 +353,7 @@ class InputTest extends TestCase
         $this->input->setFilterChain($filterChain);
         $this->input->setValue($valueRaw);
 
-        $this->assertSame($valueFiltered, $this->input->getValue());
+        self::assertSame($valueFiltered, $this->input->getValue());
     }
 
     public function testCanRetrieveRawValue(): void
@@ -368,7 +365,7 @@ class InputTest extends TestCase
         $this->input->setFilterChain($filterChain);
         $this->input->setValue($valueRaw);
 
-        $this->assertEquals($valueRaw, $this->input->getRawValue());
+        self::assertEquals($valueRaw, $this->input->getRawValue());
     }
 
     public function testValidationOperatesOnFilteredValue(): void
@@ -385,7 +382,7 @@ class InputTest extends TestCase
         $this->input->setValidatorChain($validatorChain);
         $this->input->setValue($valueRaw);
 
-        $this->assertTrue(
+        self::assertTrue(
             $this->input->isValid(),
             'isValid() value not match. Detail . ' . json_encode($this->input->getMessages(), JSON_THROW_ON_ERROR)
         );
@@ -393,13 +390,13 @@ class InputTest extends TestCase
 
     public function testBreakOnFailureFlagIsOffByDefault(): void
     {
-        $this->assertFalse($this->input->breakOnFailure());
+        self::assertFalse($this->input->breakOnFailure());
     }
 
     public function testBreakOnFailureFlagIsMutable(): void
     {
         $this->input->setBreakOnFailure(true);
-        $this->assertTrue($this->input->breakOnFailure());
+        self::assertTrue($this->input->breakOnFailure());
     }
 
     /**
@@ -408,19 +405,19 @@ class InputTest extends TestCase
      */
     public function testNotEmptyValidatorAddedWhenIsValidIsCalled($value): void
     {
-        $this->assertTrue($this->input->isRequired());
+        self::assertTrue($this->input->isRequired());
         $this->input->setValue($value);
         $validatorChain = $this->input->getValidatorChain();
-        $this->assertEquals(0, count($validatorChain->getValidators()));
+        self::assertEquals(0, count($validatorChain->getValidators()));
 
-        $this->assertFalse($this->input->isValid());
+        self::assertFalse($this->input->isValid());
         $messages = $this->input->getMessages();
-        $this->assertArrayHasKey('isEmpty', $messages);
-        $this->assertEquals(1, count($validatorChain->getValidators()));
+        self::assertArrayHasKey('isEmpty', $messages);
+        self::assertEquals(1, count($validatorChain->getValidators()));
 
         // Assert that NotEmpty validator wasn't added again
-        $this->assertFalse($this->input->isValid());
-        $this->assertEquals(1, count($validatorChain->getValidators()));
+        self::assertFalse($this->input->isValid());
+        self::assertEquals(1, count($validatorChain->getValidators()));
     }
 
     /**
@@ -436,11 +433,11 @@ class InputTest extends TestCase
 
         $validatorChain = $this->input->getValidatorChain();
         $validatorChain->prependValidator($notEmptyMock);
-        $this->assertFalse($this->input->isValid());
+        self::assertFalse($this->input->isValid());
 
         $validators = $validatorChain->getValidators();
-        $this->assertEquals(1, count($validators));
-        $this->assertEquals($notEmptyMock, $validators[0]['instance']);
+        self::assertEquals(1, count($validators));
+        self::assertEquals($notEmptyMock, $validators[0]['instance']);
     }
 
     /**
@@ -462,11 +459,11 @@ class InputTest extends TestCase
         $validatorChain->attach($this->createValidatorMock(true));
         $validatorChain->attach($notEmptyMock);
 
-        $this->assertFalse($this->input->isValid());
+        self::assertFalse($this->input->isValid());
 
         $validators = $validatorChain->getValidators();
-        $this->assertEquals(2, count($validators));
-        $this->assertEquals($notEmptyMock, $validators[1]['instance']);
+        self::assertEquals(2, count($validators));
+        self::assertEquals($notEmptyMock, $validators[1]['instance']);
     }
 
     /**
@@ -490,14 +487,14 @@ class InputTest extends TestCase
             ->attach($validator);
         $this->input->setValue($value);
 
-        $this->assertEquals(
+        self::assertEquals(
             $expectedIsValid,
             $this->input->isValid(),
             'isValid() value not match. Detail: ' . json_encode($this->input->getMessages(), JSON_THROW_ON_ERROR)
         );
-        $this->assertEquals($expectedMessages, $this->input->getMessages(), 'getMessages() value not match');
-        $this->assertEquals($value, $this->input->getRawValue(), 'getRawValue() must return the value always');
-        $this->assertEquals($value, $this->input->getValue(), 'getValue() must return the filtered value always');
+        self::assertEquals($expectedMessages, $this->input->getMessages(), 'getMessages() value not match');
+        self::assertEquals($value, $this->input->getRawValue(), 'getRawValue() must return the value always');
+        self::assertEquals($value, $this->input->getValue(), 'getValue() must return the filtered value always');
     }
 
     /**
@@ -507,10 +504,10 @@ class InputTest extends TestCase
     public function testSetValuePutInputInTheDesiredState($value): void
     {
         $input = $this->input;
-        $this->assertFalse($input->hasValue(), 'Input should not have value by default');
+        self::assertFalse($input->hasValue(), 'Input should not have value by default');
 
         $input->setValue($value);
-        $this->assertTrue($input->hasValue(), "hasValue() didn't return true when value was set");
+        self::assertTrue($input->hasValue(), "hasValue() didn't return true when value was set");
     }
 
     /**
@@ -521,14 +518,14 @@ class InputTest extends TestCase
     {
         $input         = $this->input;
         $originalInput = clone $input;
-        $this->assertFalse($input->hasValue(), 'Input should not have value by default');
+        self::assertFalse($input->hasValue(), 'Input should not have value by default');
 
         $input->setValue($value);
-        $this->assertTrue($input->hasValue(), "hasValue() didn't return true when value was set");
+        self::assertTrue($input->hasValue(), "hasValue() didn't return true when value was set");
 
         $return = $input->resetValue();
-        $this->assertSame($input, $return, 'resetValue() must return itself');
-        $this->assertEquals($originalInput, $input, 'Input was not reset to the default value state');
+        self::assertSame($input, $return, 'resetValue() must return itself');
+        self::assertEquals($originalInput, $input, 'Input was not reset to the default value state');
     }
 
     public function testMerge(): void
@@ -563,14 +560,14 @@ class InputTest extends TestCase
         $target->setValidatorChain($targetValidatorChain);
 
         $return = $target->merge($source);
-        $this->assertSame($target, $return, 'merge() must return it self');
+        self::assertSame($target, $return, 'merge() must return it self');
 
-        $this->assertEquals('bazInput', $target->getName(), 'getName() value not match');
-        $this->assertEquals('bazErrorMessage', $target->getErrorMessage(), 'getErrorMessage() value not match');
-        $this->assertTrue($target->breakOnFailure(), 'breakOnFailure() value not match');
-        $this->assertTrue($target->isRequired(), 'isRequired() value not match');
-        $this->assertEquals($sourceRawValue, $target->getRawValue(), 'getRawValue() value not match');
-        $this->assertTrue($target->hasValue(), 'hasValue() value not match');
+        self::assertEquals('bazInput', $target->getName(), 'getName() value not match');
+        self::assertEquals('bazErrorMessage', $target->getErrorMessage(), 'getErrorMessage() value not match');
+        self::assertTrue($target->breakOnFailure(), 'breakOnFailure() value not match');
+        self::assertTrue($target->isRequired(), 'isRequired() value not match');
+        self::assertEquals($sourceRawValue, $target->getRawValue(), 'getRawValue() value not match');
+        self::assertTrue($target->hasValue(), 'hasValue() value not match');
     }
 
     /**
@@ -580,17 +577,17 @@ class InputTest extends TestCase
     {
         $source = new Input();
         $source->setContinueIfEmpty(true);
-        $this->assertFalse($source->hasValue(), 'Source should not have a value');
+        self::assertFalse($source->hasValue(), 'Source should not have a value');
 
         $target = $this->input;
         $target->setContinueIfEmpty(false);
-        $this->assertFalse($target->hasValue(), 'Target should not have a value');
+        self::assertFalse($target->hasValue(), 'Target should not have a value');
 
         $return = $target->merge($source);
-        $this->assertSame($target, $return, 'merge() must return it self');
+        self::assertSame($target, $return, 'merge() must return it self');
 
-        $this->assertTrue($target->continueIfEmpty(), 'continueIfEmpty() value not match');
-        $this->assertFalse($target->hasValue(), 'hasValue() value not match');
+        self::assertTrue($target->continueIfEmpty(), 'continueIfEmpty() value not match');
+        self::assertFalse($target->hasValue(), 'hasValue() value not match');
     }
 
     /**
@@ -604,14 +601,14 @@ class InputTest extends TestCase
 
         $target = $this->input;
         $target->setContinueIfEmpty(false);
-        $this->assertFalse($target->hasValue(), 'Target should not have a value');
+        self::assertFalse($target->hasValue(), 'Target should not have a value');
 
         $return = $target->merge($source);
-        $this->assertSame($target, $return, 'merge() must return it self');
+        self::assertSame($target, $return, 'merge() must return it self');
 
-        $this->assertTrue($target->continueIfEmpty(), 'continueIfEmpty() value not match');
-        $this->assertEquals(['foo'], $target->getRawValue(), 'getRawValue() value not match');
-        $this->assertTrue($target->hasValue(), 'hasValue() value not match');
+        self::assertTrue($target->continueIfEmpty(), 'continueIfEmpty() value not match');
+        self::assertEquals(['foo'], $target->getRawValue(), 'getRawValue() value not match');
+        self::assertTrue($target->hasValue(), 'hasValue() value not match');
     }
 
     /**
@@ -621,18 +618,18 @@ class InputTest extends TestCase
     {
         $source = new Input();
         $source->setContinueIfEmpty(true);
-        $this->assertFalse($source->hasValue(), 'Source should not have a value');
+        self::assertFalse($source->hasValue(), 'Source should not have a value');
 
         $target = $this->input;
         $target->setContinueIfEmpty(false);
         $target->setValue(['foo']);
 
         $return = $target->merge($source);
-        $this->assertSame($target, $return, 'merge() must return it self');
+        self::assertSame($target, $return, 'merge() must return it self');
 
-        $this->assertTrue($target->continueIfEmpty(), 'continueIfEmpty() value not match');
-        $this->assertEquals(['foo'], $target->getRawValue(), 'getRawValue() value not match');
-        $this->assertTrue($target->hasValue(), 'hasValue() value not match');
+        self::assertTrue($target->continueIfEmpty(), 'continueIfEmpty() value not match');
+        self::assertEquals(['foo'], $target->getRawValue(), 'getRawValue() value not match');
+        self::assertTrue($target->hasValue(), 'hasValue() value not match');
     }
 
     public function testNotEmptyMessageIsTranslated(): void
@@ -643,15 +640,15 @@ class InputTest extends TestCase
         $notEmpty = new NotEmptyValidator();
 
         $translatedMessage = 'some translation';
-        $translator->expects($this->atLeastOnce())
+        $translator->expects(self::atLeastOnce())
             ->method('translate')
             ->with($notEmpty->getMessageTemplates()[NotEmptyValidator::IS_EMPTY])
             ->willReturn($translatedMessage);
 
-        $this->assertFalse($this->input->isValid());
+        self::assertFalse($this->input->isValid());
         $messages = $this->input->getMessages();
-        $this->assertArrayHasKey('isEmpty', $messages);
-        $this->assertSame($translatedMessage, $messages['isEmpty']);
+        self::assertArrayHasKey('isEmpty', $messages);
+        self::assertSame($translatedMessage, $messages['isEmpty']);
     }
 
     /**
@@ -821,8 +818,8 @@ class InputTest extends TestCase
 
     /**
      * @psalm-return array<string, array{
-     *     raw: bool|int|float|string|list<string>|object,
-     *     filtered: bool|int|float|string|list<string>|object
+     *     raw: mixed,
+     *     filtered: mixed,
      * }>
      */
     public function mixedValueProvider(): array
@@ -917,10 +914,10 @@ class InputTest extends TestCase
         $validatorChain = $this->createMock(ValidatorChain::class);
 
         if (empty($valueMap)) {
-            $validatorChain->expects($this->never())
+            $validatorChain->expects(self::never())
                 ->method('isValid');
         } else {
-            $validatorChain->expects($this->atLeastOnce())
+            $validatorChain->expects(self::atLeastOnce())
                 ->method('isValid')
                 ->willReturnMap($valueMap);
         }
@@ -944,11 +941,11 @@ class InputTest extends TestCase
         $validator = $this->createMock(ValidatorInterface::class);
 
         if (($isValid === false) || ($isValid === true)) {
-            $isValidMethod = $validator->expects($this->once())
+            $isValidMethod = $validator->expects(self::once())
                 ->method('isValid')
                 ->willReturn($isValid);
         } else {
-            $isValidMethod = $validator->expects($this->never())
+            $isValidMethod = $validator->expects(self::never())
                 ->method('isValid');
         }
         if ($value !== 'not-set') {

--- a/test/ModuleTest.php
+++ b/test/ModuleTest.php
@@ -24,19 +24,19 @@ class ModuleTest extends TestCase
         $config = $this->module->getConfig();
 
         // Service manager
-        $this->assertArrayHasKey('service_manager', $config);
+        self::assertArrayHasKey('service_manager', $config);
 
         // Input filters
-        $this->assertArrayHasKey('input_filters', $config);
+        self::assertArrayHasKey('input_filters', $config);
     }
 
     public function testServiceManagerConfigShouldContainInputFilterManager(): void
     {
         $config = $this->module->getConfig();
 
-        $this->assertArrayHasKey(
+        self::assertArrayHasKey(
             InputFilterPluginManager::class,
-            $config['service_manager']['factories']
+            $config['service_manager']['factories'] ?? []
         );
     }
 
@@ -44,9 +44,9 @@ class ModuleTest extends TestCase
     {
         $config = $this->module->getConfig();
 
-        $this->assertArrayHasKey(
+        self::assertArrayHasKey(
             'InputFilterManager',
-            $config['service_manager']['aliases']
+            $config['service_manager']['aliases'] ?? []
         );
     }
 
@@ -54,9 +54,9 @@ class ModuleTest extends TestCase
     {
         $config = $this->module->getConfig();
 
-        $this->assertContains(
+        self::assertContains(
             InputFilterAbstractServiceFactory::class,
-            $config['input_filters']['abstract_factories']
+            $config['input_filters']['abstract_factories'] ?? []
         );
     }
 
@@ -93,6 +93,7 @@ class ModuleTest extends TestCase
             ->method('getEvent')
             ->willReturn($event);
 
+        /** @psalm-suppress InvalidArgument Prevents dev dependency on the Module manager component */
         $this->module->init($moduleManager);
     }
 }

--- a/test/OptionalInputFilterTest.php
+++ b/test/OptionalInputFilterTest.php
@@ -19,7 +19,7 @@ class OptionalInputFilterTest extends TestCase
 {
     public function testValidatesSuccessfullyWhenSetDataIsNeverCalled(): void
     {
-        $this->assertTrue($this->getNestedCarInputFilter()->get('car')->isValid());
+        self::assertTrue($this->getNestedCarInputFilter()->get('car')->isValid());
     }
 
     public function testValidatesSuccessfullyWhenValidNonEmptyDataSetProvided(): void
@@ -34,8 +34,8 @@ class OptionalInputFilterTest extends TestCase
         $inputFilter = $this->getNestedCarInputFilter();
         $inputFilter->setData($data);
 
-        $this->assertTrue($inputFilter->isValid());
-        $this->assertEquals($data, $inputFilter->getValues());
+        self::assertTrue($inputFilter->isValid());
+        self::assertEquals($data, $inputFilter->getValues());
     }
 
     public function testValidatesSuccessfullyWhenEmptyDataSetProvided(): void
@@ -47,8 +47,8 @@ class OptionalInputFilterTest extends TestCase
         $inputFilter = $this->getNestedCarInputFilter();
         $inputFilter->setData($data);
 
-        $this->assertTrue($inputFilter->isValid());
-        $this->assertEquals($data, $inputFilter->getValues());
+        self::assertTrue($inputFilter->isValid());
+        self::assertEquals($data, $inputFilter->getValues());
     }
 
     public function testValidatesSuccessfullyWhenNoDataProvided(): void
@@ -58,8 +58,8 @@ class OptionalInputFilterTest extends TestCase
         $inputFilter = $this->getNestedCarInputFilter();
         $inputFilter->setData($data);
 
-        $this->assertTrue($inputFilter->isValid());
-        $this->assertEquals(['car' => null], $inputFilter->getValues());
+        self::assertTrue($inputFilter->isValid());
+        self::assertEquals(['car' => null], $inputFilter->getValues());
     }
 
     public function testValidationFailureWhenInvalidDataSetIsProvided(): void
@@ -71,7 +71,7 @@ class OptionalInputFilterTest extends TestCase
             ],
         ]);
 
-        $this->assertFalse($inputFilter->isValid());
+        self::assertFalse($inputFilter->isValid());
         $this->assertGetValuesThrows($inputFilter);
     }
 
@@ -84,8 +84,8 @@ class OptionalInputFilterTest extends TestCase
         $inputFilter = $this->getNestedCarInputFilter();
         $inputFilter->setData($data);
 
-        $this->assertTrue($inputFilter->isValid());
-        $this->assertEquals($data, $inputFilter->getValues());
+        self::assertTrue($inputFilter->isValid());
+        self::assertEquals($data, $inputFilter->getValues());
     }
 
     /**
@@ -98,23 +98,23 @@ class OptionalInputFilterTest extends TestCase
         $optionalInputFilter->add(new Input('brand'));
 
         $optionalInputFilter->setData(['model' => 'Golf']);
-        $this->assertFalse($optionalInputFilter->isValid());
+        self::assertFalse($optionalInputFilter->isValid());
 
         $optionalInputFilter->setData(new ArrayIterator([]));
-        $this->assertTrue($optionalInputFilter->isValid());
+        self::assertTrue($optionalInputFilter->isValid());
 
         $optionalInputFilter->setData([]);
-        $this->assertTrue($optionalInputFilter->isValid());
+        self::assertTrue($optionalInputFilter->isValid());
     }
 
     protected function assertGetValuesThrows(InputFilterInterface $inputFilter): void
     {
         try {
             $inputFilter->getValues();
-            $this->assertTrue(false);
+            self::fail('No exception was thrown');
         // TODO: issue #143 narrow which exception should be thrown
         } catch (Exception $exception) {
-            $this->assertTrue(true);
+            self::assertTrue(true);
         }
     }
 

--- a/test/TestAsset/FooAbstractFactory.php
+++ b/test/TestAsset/FooAbstractFactory.php
@@ -1,32 +1,27 @@
-<?php // phpcs:disable
+<?php
+
+declare(strict_types=1);
 
 namespace LaminasTest\InputFilter\TestAsset;
 
-use Laminas\ServiceManager\AbstractFactoryInterface;
-use Laminas\ServiceManager\ServiceLocatorInterface;
+use Laminas\ServiceManager\Factory\AbstractFactoryInterface;
 use Psr\Container\ContainerInterface;
 
 class FooAbstractFactory implements AbstractFactoryInterface
 {
-    public function __invoke(ContainerInterface $container, $name, ?array $options = null)
+    /** @param string $requestedName */
+    public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null): Foo
     {
         return new Foo();
     }
 
-    public function canCreate(ContainerInterface $container, $name)
+    /** @param string $requestedName */
+    public function canCreate(ContainerInterface $container, $requestedName): bool
     {
-        if ($name == 'foo') {
+        if ($requestedName === 'foo') {
             return true;
         }
-    }
 
-    public function canCreateServiceWithName(ServiceLocatorInterface $container, $name, $requestedName)
-    {
-        return $this->canCreate($container, $requestedName ?: $name);
-    }
-
-    public function createServiceWithName(ServiceLocatorInterface $container, $name, $requestedName)
-    {
-        return $this($container, $requestedName ?: $name);
+        return false;
     }
 }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes
| QA            | yes

### Description

General type improvements to reduce the size of the baseline and standardise phpunit assertions.
