### PR TITLE
Removes deprecation messages which lead to irritation because there are no alternative paths for implementation

### DIFF
--- a/src/EmptyContextInterface.php
+++ b/src/EmptyContextInterface.php
@@ -4,22 +4,15 @@ declare(strict_types=1);
 
 namespace Laminas\InputFilter;
 
-/**
- * @deprecated 2.4.8 Add Laminas\Validator\NotEmpty validator to the ValidatorChain.
- */
 interface EmptyContextInterface
 {
     /**
-     * @deprecated 2.4.8 Add Laminas\Validator\NotEmpty validator to the ValidatorChain and set this to `true`.
-     *
      * @param bool $continueIfEmpty
      * @return self
      */
     public function setContinueIfEmpty($continueIfEmpty);
 
     /**
-     * @deprecated 2.4.8 Add Laminas\Validator\NotEmpty validator to the ValidatorChain. Should always return `true`.
-     *
      * @return bool
      */
     public function continueIfEmpty();

--- a/src/FileInput.php
+++ b/src/FileInput.php
@@ -154,8 +154,6 @@ class FileInput extends Input
     }
 
     /**
-     * @deprecated 2.4.8 See note on parent class. Removal does not affect this class.
-     *
      * No-op, NotEmpty validator does not apply for FileInputs.
      * See also: BaseInputFilter::isValid()
      *

--- a/src/Input.php
+++ b/src/Input.php
@@ -17,18 +17,10 @@ class Input implements
     InputInterface,
     EmptyContextInterface
 {
-    /**
-     * @deprecated 2.4.8 Add Laminas\Validator\NotEmpty validator to the ValidatorChain.
-     *
-     * @var bool
-     */
+    /** @var bool */
     protected $allowEmpty = false;
 
-    /**
-     * @deprecated 2.4.8 Add Laminas\Validator\NotEmpty validator to the ValidatorChain.
-     *
-     * @var bool
-     */
+    /** @var bool */
     protected $continueIfEmpty = false;
 
     /** @var bool */
@@ -43,11 +35,7 @@ class Input implements
     /** @var null|string */
     protected $name;
 
-    /**
-     * @deprecated 2.4.8 Add Laminas\Validator\NotEmpty validator to the ValidatorChain.
-     *
-     * @var bool
-     */
+    /** @var bool */
     protected $notEmptyValidator = false;
 
     /** @var bool */
@@ -79,8 +67,6 @@ class Input implements
     }
 
     /**
-     * @deprecated 2.4.8 Add Laminas\Validator\NotEmpty validator to the ValidatorChain and set this to `true`.
-     *
      * @param  bool $allowEmpty
      * @return $this
      */
@@ -101,8 +87,6 @@ class Input implements
     }
 
     /**
-     * @deprecated 2.4.8 Add Laminas\Validator\NotEmpty validator to the ValidatorChain and set this to `true`.
-     *
      * @param bool $continueIfEmpty
      * @return $this
      */
@@ -208,8 +192,6 @@ class Input implements
     }
 
     /**
-     * @deprecated 2.4.8 Add Laminas\Validator\NotEmpty validator to the ValidatorChain.
-     *
      * @return bool
      */
     public function allowEmpty()
@@ -226,8 +208,6 @@ class Input implements
     }
 
     /**
-     * @deprecated 2.4.8 Add Laminas\Validator\NotEmpty validator to the ValidatorChain. Should always return `true`.
-     *
      * @return bool
      */
     public function continueIfEmpty()
@@ -440,8 +420,6 @@ class Input implements
     }
 
     /**
-     * @deprecated 2.4.8 Add Laminas\Validator\NotEmpty validator to the ValidatorChain.
-     *
      * @return void
      */
     protected function injectNotEmptyValidator()

--- a/src/InputInterface.php
+++ b/src/InputInterface.php
@@ -10,8 +10,6 @@ use Laminas\Validator\ValidatorChain;
 interface InputInterface
 {
     /**
-     * @deprecated 2.4.8 Add Laminas\Validator\NotEmpty validator to the ValidatorChain and set this to `true`.
-     *
      * @param bool $allowEmpty
      * @return $this
      */
@@ -63,8 +61,6 @@ interface InputInterface
     public function merge(InputInterface $input);
 
     /**
-     * @deprecated 2.4.8 Add Laminas\Validator\NotEmpty validator to the ValidatorChain.
-     *
      * @return bool
      */
     public function allowEmpty();


### PR DESCRIPTION
The current deprecations of methods and properties cannot be resolved or bypassed by other options or workarounds. The `isValid` method of the `Input` class uses and needs these deprecated methods and properties:

https://github.com/laminas/laminas-inputfilter/blob/2e9a2f2b867eb423338a9948ae0027ec4e556378/src/Input.php#L370-L405

https://github.com/laminas/laminas-inputfilter/blob/2e9a2f2b867eb423338a9948ae0027ec4e556378/src/Input.php#L20-L32

https://github.com/laminas/laminas-inputfilter/blob/2e9a2f2b867eb423338a9948ae0027ec4e556378/src/Input.php#L46-L51

An alternative solution or way was never provided and in its current state, it would not work. Therefore the deprecation was too early and all discussions and developments in this direction have never been completed or are very old.

See:

- #10 
- #7
- #34 

As long as we do not have an alternative solution, the current deprecation messages are confusing.