### PR TITLE
Use typed properties for ValidatorChain & FilterChain in Input

### DIFF
--- a/src/Input.php
+++ b/src/Input.php
@@ -37,8 +37,8 @@ class Input implements
     /** @var string|null */
     protected $errorMessage;
 
-    /** @var null|FilterChain */
-    protected $filterChain;
+    /** @var FilterChain */
+    protected FilterChain $filterChain;
 
     /** @var null|string */
     protected $name;
@@ -53,8 +53,8 @@ class Input implements
     /** @var bool */
     protected $required = true;
 
-    /** @var null|ValidatorChain */
-    protected $validatorChain;
+    /** @var ValidatorChain */
+    protected ValidatorChain $validatorChain;
 
     /** @var mixed */
     protected $value;
@@ -248,7 +248,7 @@ class Input implements
      */
     public function getFilterChain()
     {
-        if (! $this->filterChain) {
+        if (!isset($this->filterChain)) {
             $this->filterChain = new FilterChain();
         }
         return $this->filterChain;
@@ -283,7 +283,7 @@ class Input implements
      */
     public function getValidatorChain()
     {
-        if (! $this->validatorChain) {
+        if (!isset($this->validatorChain)) {
             $this->validatorChain = new ValidatorChain();
         }
         return $this->validatorChain;


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | yes
| New Feature   | no
| RFC           | no
| QA            | no

### Description

This PR will add property types for base `Input` class for `$validatorChain` and `$filterChain` properties. As those could be accessed in derived classes directly and not via their appropriate getters/setters this is breaking.
The purpose of this PR is to remove confusion for phpstan (not sure about psalm) as it will detect a `nullable` property as technically it is `null` as long it isn't set or initialized via `getValidatorChain()`/`getFilterChain()`.
