### PR TITLE
Hotfix/return psalm types

### DIFF
--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -17,7 +17,7 @@ class ConfigProvider
      *     input_filters: ServiceManagerConfigurationType,
      * }
      */
-    public function __invoke()
+    public function __invoke(): array
     {
         return [
             'dependencies'  => $this->getDependencyConfig(),
@@ -28,9 +28,10 @@ class ConfigProvider
     /**
      * Return dependency mappings for this component.
      *
-     * @return ServiceManagerConfigurationType
+     * @psalm-return ServiceManagerConfigurationType
+     * @return array
      */
-    public function getDependencyConfig()
+    public function getDependencyConfig(): array
     {
         return [
             'aliases'   => [
@@ -48,9 +49,10 @@ class ConfigProvider
     /**
      * Get input filter configuration
      *
-     * @return ServiceManagerConfigurationType
+     * @psalm-return ServiceManagerConfigurationType
+     * @return array
      */
-    public function getInputFilterConfig()
+    public function getInputFilterConfig(): array
     {
         return [
             'abstract_factories' => [

--- a/src/InputFilterProviderInterface.php
+++ b/src/InputFilterProviderInterface.php
@@ -14,7 +14,8 @@ interface InputFilterProviderInterface
      * Should return an array specification compatible with
      * {@link Factory::createInputFilter()}.
      *
-     * @return InputFilterSpecification|CollectionSpecification
+     * @psalm-return InputFilterSpecification|CollectionSpecification
+     * @return array
      */
     public function getInputFilterSpecification();
 }

--- a/src/InputFilterProviderInterface.php
+++ b/src/InputFilterProviderInterface.php
@@ -17,5 +17,5 @@ interface InputFilterProviderInterface
      * @psalm-return InputFilterSpecification|CollectionSpecification
      * @return array
      */
-    public function getInputFilterSpecification();
+    public function getInputFilterSpecification(): array;
 }

--- a/src/InputProviderInterface.php
+++ b/src/InputProviderInterface.php
@@ -13,7 +13,8 @@ interface InputProviderInterface
      * Should return an array specification compatible with
      * {@link Factory::createInput()}.
      *
-     * @return InputSpecification
+     * @psalm-return InputSpecification
+     * @return array
      */
     public function getInputSpecification();
 }

--- a/src/InputProviderInterface.php
+++ b/src/InputProviderInterface.php
@@ -16,5 +16,5 @@ interface InputProviderInterface
      * @psalm-return InputSpecification
      * @return array
      */
-    public function getInputSpecification();
+    public function getInputSpecification(): array;
 }


### PR DESCRIPTION
`@return` annotation specifying psalm types produces false errors for other static analysis tools, particularly for PHPStan. Therefore, returning psalm types specified with `@psalm-return` and native PHP types provided for `@return` annotation.