### PR TITLE
Use `@psalm-return` annotations together with `@return` to improve compatibility with PHPStan static analysis

### DIFF
--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -28,7 +28,8 @@ class ConfigProvider
     /**
      * Return dependency mappings for this component.
      *
-     * @return ServiceManagerConfigurationType
+     * @psalm-return ServiceManagerConfigurationType
+     * @return array
      */
     public function getDependencyConfig()
     {

--- a/src/InputFilterProviderInterface.php
+++ b/src/InputFilterProviderInterface.php
@@ -14,7 +14,8 @@ interface InputFilterProviderInterface
      * Should return an array specification compatible with
      * {@link Factory::createInputFilter()}.
      *
-     * @return InputFilterSpecification|CollectionSpecification
+     * @psalm-return InputFilterSpecification|CollectionSpecification
+     * @return array
      */
     public function getInputFilterSpecification();
 }

--- a/src/InputProviderInterface.php
+++ b/src/InputProviderInterface.php
@@ -13,7 +13,8 @@ interface InputProviderInterface
      * Should return an array specification compatible with
      * {@link Factory::createInput()}.
      *
-     * @return InputSpecification
+     * @psalm-return InputSpecification
+     * @return array
      */
     public function getInputSpecification();
 }


### PR DESCRIPTION
The result of the discussion in https://github.com/laminas/laminas-inputfilter/pull/84