### PR TITLE
Remove support for PHP 8.0, Upgrade PHPUnit to 10.1.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 /.phpcs-cache
-/.phpunit.result.cache
+/.phpunit.cache
 /.psalm-cache/
 /docs/html/
 /laminas-mkdoc-theme.tgz

--- a/.laminas-ci.json
+++ b/.laminas-ci.json
@@ -1,5 +1,2 @@
 {
-    "ignore_php_platform_requirements": {
-        "8.1": true
-    }
 }

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
     "require-dev": {
         "ext-json": "*",
         "laminas/laminas-coding-standard": "~2.5.0",
-        "phpunit/phpunit": "^9.6.8",
+        "phpunit/phpunit": "^10.1.3",
         "psalm/plugin-phpunit": "^0.18.4",
         "psr/http-message": "^1.1",
         "vimeo/psalm": "^5.12",

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "config": {
         "sort-packages": true,
         "platform": {
-            "php": "8.0.99"
+            "php": "8.1.99"
         },
         "allow-plugins": {
             "dealerdirect/phpcodesniffer-composer-installer": true
@@ -31,7 +31,7 @@
         }
     },
     "require": {
-        "php": "~8.0.0 || ~8.1.0 || ~8.2.0",
+        "php": "~8.1.0 || ~8.2.0",
         "laminas/laminas-filter": "^2.13",
         "laminas/laminas-servicemanager": "^3.16.0",
         "laminas/laminas-stdlib": "^3.0",
@@ -40,10 +40,10 @@
     "require-dev": {
         "ext-json": "*",
         "laminas/laminas-coding-standard": "~2.5.0",
-        "phpunit/phpunit": "^9.5.27",
+        "phpunit/phpunit": "^9.6.8",
         "psalm/plugin-phpunit": "^0.18.4",
-        "psr/http-message": "^1.0.1",
-        "vimeo/psalm": "^5.4",
+        "psr/http-message": "^1.1",
+        "vimeo/psalm": "^5.12",
         "webmozart/assert": "^1.11"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     "require": {
         "php": "~8.1.0 || ~8.2.0",
         "laminas/laminas-filter": "^2.13",
-        "laminas/laminas-servicemanager": "^3.16.0",
+        "laminas/laminas-servicemanager": "^3.21.0",
         "laminas/laminas-stdlib": "^3.0",
         "laminas/laminas-validator": "^2.15"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c36fc55a44a41caa344c9975e9359b42",
+    "content-hash": "447843ff01110bb9e5ecf0559177355d",
     "packages": [
         {
             "name": "laminas/laminas-filter",

--- a/composer.lock
+++ b/composer.lock
@@ -4,27 +4,27 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "72041ce1d54e09a0ebb6ee2286b47084",
+    "content-hash": "c36fc55a44a41caa344c9975e9359b42",
     "packages": [
         {
             "name": "laminas/laminas-filter",
-            "version": "2.31.0",
+            "version": "2.32.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-filter.git",
-                "reference": "548a6597d357b0b0b139cc7bffea4dfbc50eb5a8"
+                "reference": "2b7e6b2b26a92412c38336ee3089251164edf141"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-filter/zipball/548a6597d357b0b0b139cc7bffea4dfbc50eb5a8",
-                "reference": "548a6597d357b0b0b139cc7bffea4dfbc50eb5a8",
+                "url": "https://api.github.com/repos/laminas/laminas-filter/zipball/2b7e6b2b26a92412c38336ee3089251164edf141",
+                "reference": "2b7e6b2b26a92412c38336ee3089251164edf141",
                 "shasum": ""
             },
             "require": {
                 "ext-mbstring": "*",
-                "laminas/laminas-servicemanager": "^3.14.0",
+                "laminas/laminas-servicemanager": "^3.21.0",
                 "laminas/laminas-stdlib": "^3.13.0",
-                "php": "~8.0.0 || ~8.1.0 || ~8.2.0"
+                "php": "~8.1.0 || ~8.2.0"
             },
             "conflict": {
                 "laminas/laminas-validator": "<2.10.1",
@@ -32,13 +32,13 @@
             },
             "require-dev": {
                 "laminas/laminas-coding-standard": "~2.5.0",
-                "laminas/laminas-crypt": "^3.9",
+                "laminas/laminas-crypt": "^3.10",
                 "laminas/laminas-uri": "^2.10",
                 "pear/archive_tar": "^1.4.14",
-                "phpunit/phpunit": "^9.5.27",
+                "phpunit/phpunit": "^10.1.3",
                 "psalm/plugin-phpunit": "^0.18.4",
-                "psr/http-factory": "^1.0.1",
-                "vimeo/psalm": "^5.3"
+                "psr/http-factory": "^1.0.2",
+                "vimeo/psalm": "^5.11"
             },
             "suggest": {
                 "laminas/laminas-crypt": "Laminas\\Crypt component, for encryption filters",
@@ -82,30 +82,30 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2023-01-12T06:17:48+00:00"
+            "time": "2023-05-16T23:25:05+00:00"
         },
         {
             "name": "laminas/laminas-servicemanager",
-            "version": "3.20.0",
+            "version": "3.21.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-servicemanager.git",
-                "reference": "bc2c2cbe2dd90db8b9d16b0618f542692b76ab59"
+                "reference": "625f2aa3bc6dd02688b2da5155b3a69870812bda"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-servicemanager/zipball/bc2c2cbe2dd90db8b9d16b0618f542692b76ab59",
-                "reference": "bc2c2cbe2dd90db8b9d16b0618f542692b76ab59",
+                "url": "https://api.github.com/repos/laminas/laminas-servicemanager/zipball/625f2aa3bc6dd02688b2da5155b3a69870812bda",
+                "reference": "625f2aa3bc6dd02688b2da5155b3a69870812bda",
                 "shasum": ""
             },
             "require": {
-                "laminas/laminas-stdlib": "^3.2.1",
-                "php": "~8.0.0 || ~8.1.0 || ~8.2.0",
+                "laminas/laminas-stdlib": "^3.17",
+                "php": "~8.1.0 || ~8.2.0",
                 "psr/container": "^1.0"
             },
             "conflict": {
                 "ext-psr": "*",
-                "laminas/laminas-code": "<3.3.1",
+                "laminas/laminas-code": "<4.10.0",
                 "zendframework/zend-code": "<3.3.1",
                 "zendframework/zend-servicemanager": "*"
             },
@@ -117,18 +117,19 @@
             },
             "require-dev": {
                 "composer/package-versions-deprecated": "^1.11.99.5",
-                "laminas/laminas-coding-standard": "~2.4.0",
+                "friendsofphp/proxy-manager-lts": "^1.0.14",
+                "laminas/laminas-code": "^4.10.0",
+                "laminas/laminas-coding-standard": "~2.5.0",
                 "laminas/laminas-container-config-test": "^0.8",
                 "laminas/laminas-dependency-plugin": "^2.2",
-                "mikey179/vfsstream": "^1.6.11@alpha",
-                "ocramius/proxy-manager": "^2.14.1",
-                "phpbench/phpbench": "^1.2.7",
-                "phpunit/phpunit": "^9.5.26",
-                "psalm/plugin-phpunit": "^0.18.0",
-                "vimeo/psalm": "^5.0.0"
+                "mikey179/vfsstream": "^1.6.11",
+                "phpbench/phpbench": "^1.2.9",
+                "phpunit/phpunit": "^10.0.17",
+                "psalm/plugin-phpunit": "^0.18.4",
+                "vimeo/psalm": "^5.8.0"
             },
             "suggest": {
-                "ocramius/proxy-manager": "ProxyManager ^2.1.1 to handle lazy initialization of services"
+                "friendsofphp/proxy-manager-lts": "ProxyManager ^2.1.1 to handle lazy initialization of services"
             },
             "bin": [
                 "bin/generate-deps-for-config-factory",
@@ -172,34 +173,34 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2022-12-01T17:03:38+00:00"
+            "time": "2023-05-14T12:24:54+00:00"
         },
         {
             "name": "laminas/laminas-stdlib",
-            "version": "3.16.1",
+            "version": "3.17.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-stdlib.git",
-                "reference": "f4f773641807c7ccee59b758bfe4ac4ba33ecb17"
+                "reference": "dd35c868075bad80b6718959740913e178eb4274"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-stdlib/zipball/f4f773641807c7ccee59b758bfe4ac4ba33ecb17",
-                "reference": "f4f773641807c7ccee59b758bfe4ac4ba33ecb17",
+                "url": "https://api.github.com/repos/laminas/laminas-stdlib/zipball/dd35c868075bad80b6718959740913e178eb4274",
+                "reference": "dd35c868075bad80b6718959740913e178eb4274",
                 "shasum": ""
             },
             "require": {
-                "php": "~8.0.0 || ~8.1.0 || ~8.2.0"
+                "php": "~8.1.0 || ~8.2.0"
             },
             "conflict": {
                 "zendframework/zend-stdlib": "*"
             },
             "require-dev": {
-                "laminas/laminas-coding-standard": "^2.4.0",
-                "phpbench/phpbench": "^1.2.7",
-                "phpunit/phpunit": "^9.5.26",
-                "psalm/plugin-phpunit": "^0.18.0",
-                "vimeo/psalm": "^5.0.0"
+                "laminas/laminas-coding-standard": "^2.5",
+                "phpbench/phpbench": "^1.2.9",
+                "phpunit/phpunit": "^10.0.16",
+                "psalm/plugin-phpunit": "^0.18.4",
+                "vimeo/psalm": "^5.8"
             },
             "type": "library",
             "autoload": {
@@ -231,44 +232,44 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2022-12-03T18:48:01+00:00"
+            "time": "2023-03-20T13:51:37+00:00"
         },
         {
             "name": "laminas/laminas-validator",
-            "version": "2.29.0",
+            "version": "2.31.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-validator.git",
-                "reference": "e40ee8d86cc1907083e273bfd6ed8b6dde2d9850"
+                "reference": "7dc274aa5afd5e23be0dbea13363e3d66ba5808b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-validator/zipball/e40ee8d86cc1907083e273bfd6ed8b6dde2d9850",
-                "reference": "e40ee8d86cc1907083e273bfd6ed8b6dde2d9850",
+                "url": "https://api.github.com/repos/laminas/laminas-validator/zipball/7dc274aa5afd5e23be0dbea13363e3d66ba5808b",
+                "reference": "7dc274aa5afd5e23be0dbea13363e3d66ba5808b",
                 "shasum": ""
             },
             "require": {
-                "laminas/laminas-servicemanager": "^3.12.0",
+                "laminas/laminas-servicemanager": "^3.21.0",
                 "laminas/laminas-stdlib": "^3.13",
-                "php": "~8.0.0 || ~8.1.0 || ~8.2.0",
-                "psr/http-message": "^1.0.1"
+                "php": "~8.1.0 || ~8.2.0",
+                "psr/http-message": "^1.0.1 || ^2.0.0"
             },
             "conflict": {
                 "zendframework/zend-validator": "*"
             },
             "require-dev": {
-                "laminas/laminas-coding-standard": "^2.4.0",
-                "laminas/laminas-db": "^2.16",
-                "laminas/laminas-filter": "^2.28.1",
+                "laminas/laminas-coding-standard": "^2.5",
+                "laminas/laminas-db": "^2.18",
+                "laminas/laminas-filter": "^2.32",
                 "laminas/laminas-http": "^2.18",
-                "laminas/laminas-i18n": "^2.19",
-                "laminas/laminas-session": "^2.15",
+                "laminas/laminas-i18n": "^2.23",
+                "laminas/laminas-session": "^2.16",
                 "laminas/laminas-uri": "^2.10.0",
-                "phpunit/phpunit": "^9.5.26",
-                "psalm/plugin-phpunit": "^0.18.3",
-                "psr/http-client": "^1.0.1",
-                "psr/http-factory": "^1.0.1",
-                "vimeo/psalm": "^5.0"
+                "phpunit/phpunit": "^10.1.3",
+                "psalm/plugin-phpunit": "^0.18.4",
+                "psr/http-client": "^1.0.2",
+                "psr/http-factory": "^1.0.2",
+                "vimeo/psalm": "^5.11"
             },
             "suggest": {
                 "laminas/laminas-db": "Laminas\\Db component, required by the (No)RecordExists validator",
@@ -316,7 +317,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2022-12-13T22:53:38+00:00"
+            "time": "2023-05-19T09:42:26+00:00"
         },
         {
             "name": "psr/container",
@@ -368,25 +369,25 @@
         },
         {
             "name": "psr/http-message",
-            "version": "1.0.1",
+            "version": "1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/http-message.git",
-                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363"
+                "reference": "cb6ce4845ce34a8ad9e68117c10ee90a29919eba"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/http-message/zipball/f6561bf28d520154e4b0ec72be95418abe6d9363",
-                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363",
+                "url": "https://api.github.com/repos/php-fig/http-message/zipball/cb6ce4845ce34a8ad9e68117c10ee90a29919eba",
+                "reference": "cb6ce4845ce34a8ad9e68117c10ee90a29919eba",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.0"
+                "php": "^7.2 || ^8.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "1.1.x-dev"
                 }
             },
             "autoload": {
@@ -415,9 +416,9 @@
                 "response"
             ],
             "support": {
-                "source": "https://github.com/php-fig/http-message/tree/master"
+                "source": "https://github.com/php-fig/http-message/tree/1.1"
             },
-            "time": "2016-08-06T14:39:51+00:00"
+            "time": "2023-04-04T09:50:52+00:00"
         }
     ],
     "packages-dev": [
@@ -992,30 +993,30 @@
         },
         {
             "name": "doctrine/instantiator",
-            "version": "1.5.0",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "0a0fa9780f5d4e507415a065172d26a98d02047b"
+                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/0a0fa9780f5d4e507415a065172d26a98d02047b",
-                "reference": "0a0fa9780f5d4e507415a065172d26a98d02047b",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
+                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1 || ^8.0"
+                "php": "^8.1"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^9 || ^11",
+                "doctrine/coding-standard": "^11",
                 "ext-pdo": "*",
                 "ext-phar": "*",
-                "phpbench/phpbench": "^0.16 || ^1",
-                "phpstan/phpstan": "^1.4",
-                "phpstan/phpstan-phpunit": "^1",
-                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
-                "vimeo/psalm": "^4.30 || ^5.4"
+                "phpbench/phpbench": "^1.2",
+                "phpstan/phpstan": "^1.9.4",
+                "phpstan/phpstan-phpunit": "^1.3",
+                "phpunit/phpunit": "^9.5.27",
+                "vimeo/psalm": "^5.4"
             },
             "type": "library",
             "autoload": {
@@ -1042,7 +1043,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/instantiator/issues",
-                "source": "https://github.com/doctrine/instantiator/tree/1.5.0"
+                "source": "https://github.com/doctrine/instantiator/tree/2.0.0"
             },
             "funding": [
                 {
@@ -1058,7 +1059,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-12-30T00:15:36+00:00"
+            "time": "2022-12-30T00:23:10+00:00"
         },
         {
             "name": "felixfbecker/advanced-json-rpc",
@@ -1163,16 +1164,16 @@
         },
         {
             "name": "fidry/cpu-core-counter",
-            "version": "0.4.1",
+            "version": "0.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/theofidry/cpu-core-counter.git",
-                "reference": "79261cc280aded96d098e1b0e0ba0c4881b432c2"
+                "reference": "b58e5a3933e541dc286cc91fc4f3898bbc6f1623"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/theofidry/cpu-core-counter/zipball/79261cc280aded96d098e1b0e0ba0c4881b432c2",
-                "reference": "79261cc280aded96d098e1b0e0ba0c4881b432c2",
+                "url": "https://api.github.com/repos/theofidry/cpu-core-counter/zipball/b58e5a3933e541dc286cc91fc4f3898bbc6f1623",
+                "reference": "b58e5a3933e541dc286cc91fc4f3898bbc6f1623",
                 "shasum": ""
             },
             "require": {
@@ -1212,7 +1213,7 @@
             ],
             "support": {
                 "issues": "https://github.com/theofidry/cpu-core-counter/issues",
-                "source": "https://github.com/theofidry/cpu-core-counter/tree/0.4.1"
+                "source": "https://github.com/theofidry/cpu-core-counter/tree/0.5.1"
             },
             "funding": [
                 {
@@ -1220,7 +1221,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-12-16T22:01:02+00:00"
+            "time": "2022-12-24T12:35:10+00:00"
         },
         {
             "name": "laminas/laminas-coding-standard",
@@ -1280,16 +1281,16 @@
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.11.0",
+            "version": "1.11.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "14daed4296fae74d9e3201d2c4925d1acb7aa614"
+                "reference": "7284c22080590fb39f2ffa3e9057f10a4ddd0e0c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/14daed4296fae74d9e3201d2c4925d1acb7aa614",
-                "reference": "14daed4296fae74d9e3201d2c4925d1acb7aa614",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/7284c22080590fb39f2ffa3e9057f10a4ddd0e0c",
+                "reference": "7284c22080590fb39f2ffa3e9057f10a4ddd0e0c",
                 "shasum": ""
             },
             "require": {
@@ -1327,7 +1328,7 @@
             ],
             "support": {
                 "issues": "https://github.com/myclabs/DeepCopy/issues",
-                "source": "https://github.com/myclabs/DeepCopy/tree/1.11.0"
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.11.1"
             },
             "funding": [
                 {
@@ -1335,20 +1336,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-03-03T13:19:32+00:00"
+            "time": "2023-03-08T13:26:56+00:00"
         },
         {
             "name": "netresearch/jsonmapper",
-            "version": "v4.1.0",
+            "version": "v4.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cweiske/jsonmapper.git",
-                "reference": "cfa81ea1d35294d64adb9c68aa4cb9e92400e53f"
+                "reference": "f60565f8c0566a31acf06884cdaa591867ecc956"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cweiske/jsonmapper/zipball/cfa81ea1d35294d64adb9c68aa4cb9e92400e53f",
-                "reference": "cfa81ea1d35294d64adb9c68aa4cb9e92400e53f",
+                "url": "https://api.github.com/repos/cweiske/jsonmapper/zipball/f60565f8c0566a31acf06884cdaa591867ecc956",
+                "reference": "f60565f8c0566a31acf06884cdaa591867ecc956",
                 "shasum": ""
             },
             "require": {
@@ -1384,22 +1385,22 @@
             "support": {
                 "email": "cweiske@cweiske.de",
                 "issues": "https://github.com/cweiske/jsonmapper/issues",
-                "source": "https://github.com/cweiske/jsonmapper/tree/v4.1.0"
+                "source": "https://github.com/cweiske/jsonmapper/tree/v4.2.0"
             },
-            "time": "2022-12-08T20:46:14+00:00"
+            "time": "2023-04-09T17:37:40+00:00"
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.15.3",
+            "version": "v4.15.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "570e980a201d8ed0236b0a62ddf2c9cbb2034039"
+                "reference": "11e2663a5bc9db5d714eedb4277ee300403b4a9e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/570e980a201d8ed0236b0a62ddf2c9cbb2034039",
-                "reference": "570e980a201d8ed0236b0a62ddf2c9cbb2034039",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/11e2663a5bc9db5d714eedb4277ee300403b4a9e",
+                "reference": "11e2663a5bc9db5d714eedb4277ee300403b4a9e",
                 "shasum": ""
             },
             "require": {
@@ -1440,9 +1441,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.15.3"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v4.15.5"
             },
-            "time": "2023-01-16T22:05:37+00:00"
+            "time": "2023-05-19T20:20:00+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -1766,23 +1767,23 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "9.2.24",
+            "version": "9.2.26",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "2cf940ebc6355a9d430462811b5aaa308b174bed"
+                "reference": "443bc6912c9bd5b409254a40f4b0f4ced7c80ea1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/2cf940ebc6355a9d430462811b5aaa308b174bed",
-                "reference": "2cf940ebc6355a9d430462811b5aaa308b174bed",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/443bc6912c9bd5b409254a40f4b0f4ced7c80ea1",
+                "reference": "443bc6912c9bd5b409254a40f4b0f4ced7c80ea1",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-libxml": "*",
                 "ext-xmlwriter": "*",
-                "nikic/php-parser": "^4.14",
+                "nikic/php-parser": "^4.15",
                 "php": ">=7.3",
                 "phpunit/php-file-iterator": "^3.0.3",
                 "phpunit/php-text-template": "^2.0.2",
@@ -1797,8 +1798,8 @@
                 "phpunit/phpunit": "^9.3"
             },
             "suggest": {
-                "ext-pcov": "*",
-                "ext-xdebug": "*"
+                "ext-pcov": "PHP extension that provides line coverage",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
             },
             "type": "library",
             "extra": {
@@ -1831,7 +1832,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.24"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.26"
             },
             "funding": [
                 {
@@ -1839,7 +1840,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-01-26T08:26:55+00:00"
+            "time": "2023-03-06T12:58:08+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -2084,16 +2085,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.5.28",
+            "version": "9.6.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "954ca3113a03bf780d22f07bf055d883ee04b65e"
+                "reference": "17d621b3aff84d0c8b62539e269e87d8d5baa76e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/954ca3113a03bf780d22f07bf055d883ee04b65e",
-                "reference": "954ca3113a03bf780d22f07bf055d883ee04b65e",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/17d621b3aff84d0c8b62539e269e87d8d5baa76e",
+                "reference": "17d621b3aff84d0c8b62539e269e87d8d5baa76e",
                 "shasum": ""
             },
             "require": {
@@ -2126,8 +2127,8 @@
                 "sebastian/version": "^3.0.2"
             },
             "suggest": {
-                "ext-soap": "*",
-                "ext-xdebug": "*"
+                "ext-soap": "To be able to generate mocks based on WSDL files",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
             },
             "bin": [
                 "phpunit"
@@ -2135,7 +2136,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "9.5-dev"
+                    "dev-master": "9.6-dev"
                 }
             },
             "autoload": {
@@ -2166,7 +2167,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.28"
+                "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.8"
             },
             "funding": [
                 {
@@ -2182,7 +2184,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-14T12:32:24+00:00"
+            "time": "2023-05-11T05:14:45+00:00"
         },
         {
             "name": "psalm/plugin-phpunit",
@@ -2594,16 +2596,16 @@
         },
         {
             "name": "sebastian/diff",
-            "version": "4.0.4",
+            "version": "4.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "3461e3fccc7cfdfc2720be910d3bd73c69be590d"
+                "reference": "74be17022044ebaaecfdf0c5cd504fc9cd5a7131"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/3461e3fccc7cfdfc2720be910d3bd73c69be590d",
-                "reference": "3461e3fccc7cfdfc2720be910d3bd73c69be590d",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/74be17022044ebaaecfdf0c5cd504fc9cd5a7131",
+                "reference": "74be17022044ebaaecfdf0c5cd504fc9cd5a7131",
                 "shasum": ""
             },
             "require": {
@@ -2648,7 +2650,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/diff/issues",
-                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.4"
+                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.5"
             },
             "funding": [
                 {
@@ -2656,20 +2658,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:10:38+00:00"
+            "time": "2023-05-07T05:35:17+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "5.1.4",
+            "version": "5.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "1b5dff7bb151a4db11d49d90e5408e4e938270f7"
+                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/1b5dff7bb151a4db11d49d90e5408e4e938270f7",
-                "reference": "1b5dff7bb151a4db11d49d90e5408e4e938270f7",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
+                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
                 "shasum": ""
             },
             "require": {
@@ -2711,7 +2713,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/environment/issues",
-                "source": "https://github.com/sebastianbergmann/environment/tree/5.1.4"
+                "source": "https://github.com/sebastianbergmann/environment/tree/5.1.5"
             },
             "funding": [
                 {
@@ -2719,7 +2721,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-04-03T09:37:03+00:00"
+            "time": "2023-02-03T06:03:51+00:00"
         },
         {
             "name": "sebastian/exporter",
@@ -3033,16 +3035,16 @@
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "4.0.4",
+            "version": "4.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "cd9d8cf3c5804de4341c283ed787f099f5506172"
+                "reference": "e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/cd9d8cf3c5804de4341c283ed787f099f5506172",
-                "reference": "cd9d8cf3c5804de4341c283ed787f099f5506172",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1",
+                "reference": "e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1",
                 "shasum": ""
             },
             "require": {
@@ -3081,10 +3083,10 @@
                 }
             ],
             "description": "Provides functionality to recursively process PHP variables",
-            "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
+            "homepage": "https://github.com/sebastianbergmann/recursion-context",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
-                "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.4"
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.5"
             },
             "funding": [
                 {
@@ -3092,7 +3094,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:17:30+00:00"
+            "time": "2023-02-03T06:07:39+00:00"
         },
         {
             "name": "sebastian/resource-operations",
@@ -3151,16 +3153,16 @@
         },
         {
             "name": "sebastian/type",
-            "version": "3.2.0",
+            "version": "3.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/type.git",
-                "reference": "fb3fe09c5f0bae6bc27ef3ce933a1e0ed9464b6e"
+                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/fb3fe09c5f0bae6bc27ef3ce933a1e0ed9464b6e",
-                "reference": "fb3fe09c5f0bae6bc27ef3ce933a1e0ed9464b6e",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
+                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
                 "shasum": ""
             },
             "require": {
@@ -3195,7 +3197,7 @@
             "homepage": "https://github.com/sebastianbergmann/type",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/type/issues",
-                "source": "https://github.com/sebastianbergmann/type/tree/3.2.0"
+                "source": "https://github.com/sebastianbergmann/type/tree/3.2.1"
             },
             "funding": [
                 {
@@ -3203,7 +3205,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-09-12T14:47:03+00:00"
+            "time": "2023-02-03T06:13:03+00:00"
         },
         {
             "name": "sebastian/version",
@@ -3321,26 +3323,25 @@
         },
         {
             "name": "spatie/array-to-xml",
-            "version": "2.17.1",
+            "version": "3.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spatie/array-to-xml.git",
-                "reference": "5cbec9c6ab17e320c58a259f0cebe88bde4a7c46"
+                "reference": "e210b98957987c755372465be105d32113f339a4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spatie/array-to-xml/zipball/5cbec9c6ab17e320c58a259f0cebe88bde4a7c46",
-                "reference": "5cbec9c6ab17e320c58a259f0cebe88bde4a7c46",
+                "url": "https://api.github.com/repos/spatie/array-to-xml/zipball/e210b98957987c755372465be105d32113f339a4",
+                "reference": "e210b98957987c755372465be105d32113f339a4",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
-                "php": "^7.4|^8.0"
+                "php": "^8.0"
             },
             "require-dev": {
                 "mockery/mockery": "^1.2",
                 "pestphp/pest": "^1.21",
-                "phpunit/phpunit": "^9.0",
                 "spatie/pest-plugin-snapshots": "^1.1"
             },
             "type": "library",
@@ -3369,7 +3370,7 @@
                 "xml"
             ],
             "support": {
-                "source": "https://github.com/spatie/array-to-xml/tree/2.17.1"
+                "source": "https://github.com/spatie/array-to-xml/tree/3.1.6"
             },
             "funding": [
                 {
@@ -3381,20 +3382,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-12-26T08:22:07+00:00"
+            "time": "2023-05-11T14:04:07+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.7.1",
+            "version": "3.7.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "1359e176e9307e906dc3d890bcc9603ff6d90619"
+                "reference": "ed8e00df0a83aa96acf703f8c2979ff33341f879"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/1359e176e9307e906dc3d890bcc9603ff6d90619",
-                "reference": "1359e176e9307e906dc3d890bcc9603ff6d90619",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/ed8e00df0a83aa96acf703f8c2979ff33341f879",
+                "reference": "ed8e00df0a83aa96acf703f8c2979ff33341f879",
                 "shasum": ""
             },
             "require": {
@@ -3430,31 +3431,33 @@
             "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
             "keywords": [
                 "phpcs",
-                "standards"
+                "standards",
+                "static analysis"
             ],
             "support": {
                 "issues": "https://github.com/squizlabs/PHP_CodeSniffer/issues",
                 "source": "https://github.com/squizlabs/PHP_CodeSniffer",
                 "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
             },
-            "time": "2022-06-18T07:21:10+00:00"
+            "time": "2023-02-22T23:07:41+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v6.0.19",
+            "version": "v6.2.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "c3ebc83d031b71c39da318ca8b7a07ecc67507ed"
+                "reference": "12288d9f4500f84a4d02254d4aa968b15488476f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/c3ebc83d031b71c39da318ca8b7a07ecc67507ed",
-                "reference": "c3ebc83d031b71c39da318ca8b7a07ecc67507ed",
+                "url": "https://api.github.com/repos/symfony/console/zipball/12288d9f4500f84a4d02254d4aa968b15488476f",
+                "reference": "12288d9f4500f84a4d02254d4aa968b15488476f",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0.2",
+                "php": ">=8.1",
+                "symfony/deprecation-contracts": "^2.1|^3",
                 "symfony/polyfill-mbstring": "~1.0",
                 "symfony/service-contracts": "^1.1|^2|^3",
                 "symfony/string": "^5.4|^6.0"
@@ -3511,12 +3514,12 @@
             "homepage": "https://symfony.com",
             "keywords": [
                 "cli",
-                "command line",
+                "command-line",
                 "console",
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v6.0.19"
+                "source": "https://github.com/symfony/console/tree/v6.2.10"
             },
             "funding": [
                 {
@@ -3532,29 +3535,29 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-01T08:36:10+00:00"
+            "time": "2023-04-28T13:37:43+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v3.0.2",
+            "version": "v3.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "26954b3d62a6c5fd0ea8a2a00c0353a14978d05c"
+                "reference": "e2d1534420bd723d0ef5aec58a22c5fe60ce6f5e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/26954b3d62a6c5fd0ea8a2a00c0353a14978d05c",
-                "reference": "26954b3d62a6c5fd0ea8a2a00c0353a14978d05c",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/e2d1534420bd723d0ef5aec58a22c5fe60ce6f5e",
+                "reference": "e2d1534420bd723d0ef5aec58a22c5fe60ce6f5e",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0.2"
+                "php": ">=8.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "3.0-dev"
+                    "dev-main": "3.3-dev"
                 },
                 "thanks": {
                     "name": "symfony/contracts",
@@ -3583,7 +3586,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.0.2"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.2.1"
             },
             "funding": [
                 {
@@ -3599,24 +3602,24 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-01-02T09:55:41+00:00"
+            "time": "2023-03-01T10:25:55+00:00"
         },
         {
             "name": "symfony/filesystem",
-            "version": "v6.0.19",
+            "version": "v6.2.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "3d49eec03fda1f0fc19b7349fbbe55ebc1004214"
+                "reference": "fd588debf7d1bc16a2c84b4b3b71145d9946b894"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/3d49eec03fda1f0fc19b7349fbbe55ebc1004214",
-                "reference": "3d49eec03fda1f0fc19b7349fbbe55ebc1004214",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/fd588debf7d1bc16a2c84b4b3b71145d9946b894",
+                "reference": "fd588debf7d1bc16a2c84b4b3b71145d9946b894",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0.2",
+                "php": ">=8.1",
                 "symfony/polyfill-ctype": "~1.8",
                 "symfony/polyfill-mbstring": "~1.8"
             },
@@ -3646,7 +3649,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v6.0.19"
+                "source": "https://github.com/symfony/filesystem/tree/v6.2.10"
             },
             "funding": [
                 {
@@ -3662,7 +3665,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-20T17:44:14+00:00"
+            "time": "2023-04-18T13:46:08+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -4079,20 +4082,20 @@
         },
         {
             "name": "symfony/string",
-            "version": "v6.0.19",
+            "version": "v6.2.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "d9e72497367c23e08bf94176d2be45b00a9d232a"
+                "reference": "193e83bbd6617d6b2151c37fff10fa7168ebddef"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/d9e72497367c23e08bf94176d2be45b00a9d232a",
-                "reference": "d9e72497367c23e08bf94176d2be45b00a9d232a",
+                "url": "https://api.github.com/repos/symfony/string/zipball/193e83bbd6617d6b2151c37fff10fa7168ebddef",
+                "reference": "193e83bbd6617d6b2151c37fff10fa7168ebddef",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0.2",
+                "php": ">=8.1",
                 "symfony/polyfill-ctype": "~1.8",
                 "symfony/polyfill-intl-grapheme": "~1.0",
                 "symfony/polyfill-intl-normalizer": "~1.0",
@@ -4104,6 +4107,7 @@
             "require-dev": {
                 "symfony/error-handler": "^5.4|^6.0",
                 "symfony/http-client": "^5.4|^6.0",
+                "symfony/intl": "^6.2",
                 "symfony/translation-contracts": "^2.0|^3.0",
                 "symfony/var-exporter": "^5.4|^6.0"
             },
@@ -4144,7 +4148,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v6.0.19"
+                "source": "https://github.com/symfony/string/tree/v6.2.8"
             },
             "funding": [
                 {
@@ -4160,7 +4164,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-01T08:36:10+00:00"
+            "time": "2023-03-20T16:06:02+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -4214,22 +4218,22 @@
         },
         {
             "name": "vimeo/psalm",
-            "version": "5.6.0",
+            "version": "5.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vimeo/psalm.git",
-                "reference": "e784128902dfe01d489c4123d69918a9f3c1eac5"
+                "reference": "f90118cdeacd0088e7215e64c0c99ceca819e176"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vimeo/psalm/zipball/e784128902dfe01d489c4123d69918a9f3c1eac5",
-                "reference": "e784128902dfe01d489c4123d69918a9f3c1eac5",
+                "url": "https://api.github.com/repos/vimeo/psalm/zipball/f90118cdeacd0088e7215e64c0c99ceca819e176",
+                "reference": "f90118cdeacd0088e7215e64c0c99ceca819e176",
                 "shasum": ""
             },
             "require": {
                 "amphp/amp": "^2.4.2",
                 "amphp/byte-stream": "^1.5",
-                "composer/package-versions-deprecated": "^1.10.0",
+                "composer-runtime-api": "^2",
                 "composer/semver": "^1.4 || ^2.0 || ^3.0",
                 "composer/xdebug-handler": "^2.0 || ^3.0",
                 "dnoegel/php-xdg-base-dir": "^0.1.1",
@@ -4242,12 +4246,12 @@
                 "ext-tokenizer": "*",
                 "felixfbecker/advanced-json-rpc": "^3.1",
                 "felixfbecker/language-server-protocol": "^1.5.2",
-                "fidry/cpu-core-counter": "^0.4.0",
+                "fidry/cpu-core-counter": "^0.4.1 || ^0.5.1",
                 "netresearch/jsonmapper": "^1.0 || ^2.0 || ^3.0 || ^4.0",
-                "nikic/php-parser": "^4.13",
+                "nikic/php-parser": "^4.14",
                 "php": "^7.4 || ~8.0.0 || ~8.1.0 || ~8.2.0",
                 "sebastian/diff": "^4.0 || ^5.0",
-                "spatie/array-to-xml": "^2.17.0",
+                "spatie/array-to-xml": "^2.17.0 || ^3.0",
                 "symfony/console": "^4.1.6 || ^5.0 || ^6.0",
                 "symfony/filesystem": "^5.4 || ^6.0"
             },
@@ -4255,14 +4259,15 @@
                 "psalm/psalm": "self.version"
             },
             "require-dev": {
+                "amphp/phpunit-util": "^2.0",
                 "bamarni/composer-bin-plugin": "^1.4",
-                "brianium/paratest": "^6.0",
+                "brianium/paratest": "^6.9",
                 "ext-curl": "*",
                 "mockery/mockery": "^1.5",
                 "nunomaduro/mock-final-classes": "^1.1",
                 "php-parallel-lint/php-parallel-lint": "^1.2",
                 "phpstan/phpdoc-parser": "^1.6",
-                "phpunit/phpunit": "^9.5",
+                "phpunit/phpunit": "^9.6",
                 "psalm/plugin-mockery": "^1.1",
                 "psalm/plugin-phpunit": "^0.18",
                 "slevomat/coding-standard": "^8.4",
@@ -4308,34 +4313,35 @@
             "keywords": [
                 "code",
                 "inspection",
-                "php"
+                "php",
+                "static analysis"
             ],
             "support": {
                 "issues": "https://github.com/vimeo/psalm/issues",
-                "source": "https://github.com/vimeo/psalm/tree/5.6.0"
+                "source": "https://github.com/vimeo/psalm/tree/5.12.0"
             },
-            "time": "2023-01-23T20:32:47+00:00"
+            "time": "2023-05-22T21:19:03+00:00"
         },
         {
             "name": "webimpress/coding-standard",
-            "version": "1.2.4",
+            "version": "1.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webimpress/coding-standard.git",
-                "reference": "cd0c4b0b97440c337c1f7da17b524674ca2f9ca9"
+                "reference": "b26557e2386711ecb74f22718f4b4bde5ddbc899"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webimpress/coding-standard/zipball/cd0c4b0b97440c337c1f7da17b524674ca2f9ca9",
-                "reference": "cd0c4b0b97440c337c1f7da17b524674ca2f9ca9",
+                "url": "https://api.github.com/repos/webimpress/coding-standard/zipball/b26557e2386711ecb74f22718f4b4bde5ddbc899",
+                "reference": "b26557e2386711ecb74f22718f4b4bde5ddbc899",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.3 || ^8.0",
-                "squizlabs/php_codesniffer": "^3.6.2"
+                "squizlabs/php_codesniffer": "^3.7.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.5.13"
+                "phpunit/phpunit": "^9.6.4"
             },
             "type": "phpcodesniffer-standard",
             "extra": {
@@ -4361,7 +4367,7 @@
             ],
             "support": {
                 "issues": "https://github.com/webimpress/coding-standard/issues",
-                "source": "https://github.com/webimpress/coding-standard/tree/1.2.4"
+                "source": "https://github.com/webimpress/coding-standard/tree/1.3.1"
             },
             "funding": [
                 {
@@ -4369,7 +4375,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-02-15T19:52:12+00:00"
+            "time": "2023-03-09T15:05:18+00:00"
         },
         {
             "name": "webmozart/assert",
@@ -4436,13 +4442,13 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "~8.0.0 || ~8.1.0 || ~8.2.0"
+        "php": "~8.1.0 || ~8.2.0"
     },
     "platform-dev": {
         "ext-json": "*"
     },
     "platform-overrides": {
-        "php": "8.0.99"
+        "php": "8.1.99"
     },
     "plugin-api-version": "2.3.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "447843ff01110bb9e5ecf0559177355d",
+    "content-hash": "60141e5d535d2def634187e798a266b4",
     "packages": [
         {
             "name": "laminas/laminas-filter",
@@ -992,76 +992,6 @@
             "time": "2019-12-04T15:06:13+00:00"
         },
         {
-            "name": "doctrine/instantiator",
-            "version": "2.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
-                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^8.1"
-            },
-            "require-dev": {
-                "doctrine/coding-standard": "^11",
-                "ext-pdo": "*",
-                "ext-phar": "*",
-                "phpbench/phpbench": "^1.2",
-                "phpstan/phpstan": "^1.9.4",
-                "phpstan/phpstan-phpunit": "^1.3",
-                "phpunit/phpunit": "^9.5.27",
-                "vimeo/psalm": "^5.4"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Doctrine\\Instantiator\\": "src/Doctrine/Instantiator/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Marco Pivetta",
-                    "email": "ocramius@gmail.com",
-                    "homepage": "https://ocramius.github.io/"
-                }
-            ],
-            "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
-            "homepage": "https://www.doctrine-project.org/projects/instantiator.html",
-            "keywords": [
-                "constructor",
-                "instantiate"
-            ],
-            "support": {
-                "issues": "https://github.com/doctrine/instantiator/issues",
-                "source": "https://github.com/doctrine/instantiator/tree/2.0.0"
-            },
-            "funding": [
-                {
-                    "url": "https://www.doctrine-project.org/sponsorship.html",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://www.patreon.com/phpdoctrine",
-                    "type": "patreon"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Finstantiator",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2022-12-30T00:23:10+00:00"
-        },
-        {
             "name": "felixfbecker/advanced-json-rpc",
             "version": "v3.2.1",
             "source": {
@@ -1767,16 +1697,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "9.2.26",
+            "version": "10.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "443bc6912c9bd5b409254a40f4b0f4ced7c80ea1"
+                "reference": "db1497ec8dd382e82c962f7abbe0320e4882ee4e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/443bc6912c9bd5b409254a40f4b0f4ced7c80ea1",
-                "reference": "443bc6912c9bd5b409254a40f4b0f4ced7c80ea1",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/db1497ec8dd382e82c962f7abbe0320e4882ee4e",
+                "reference": "db1497ec8dd382e82c962f7abbe0320e4882ee4e",
                 "shasum": ""
             },
             "require": {
@@ -1784,18 +1714,18 @@
                 "ext-libxml": "*",
                 "ext-xmlwriter": "*",
                 "nikic/php-parser": "^4.15",
-                "php": ">=7.3",
-                "phpunit/php-file-iterator": "^3.0.3",
-                "phpunit/php-text-template": "^2.0.2",
-                "sebastian/code-unit-reverse-lookup": "^2.0.2",
-                "sebastian/complexity": "^2.0",
-                "sebastian/environment": "^5.1.2",
-                "sebastian/lines-of-code": "^1.0.3",
-                "sebastian/version": "^3.0.1",
+                "php": ">=8.1",
+                "phpunit/php-file-iterator": "^4.0",
+                "phpunit/php-text-template": "^3.0",
+                "sebastian/code-unit-reverse-lookup": "^3.0",
+                "sebastian/complexity": "^3.0",
+                "sebastian/environment": "^6.0",
+                "sebastian/lines-of-code": "^2.0",
+                "sebastian/version": "^4.0",
                 "theseer/tokenizer": "^1.2.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.1"
             },
             "suggest": {
                 "ext-pcov": "PHP extension that provides line coverage",
@@ -1804,7 +1734,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "9.2-dev"
+                    "dev-main": "10.1-dev"
                 }
             },
             "autoload": {
@@ -1832,7 +1762,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.26"
+                "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/10.1.2"
             },
             "funding": [
                 {
@@ -1840,32 +1771,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-03-06T12:58:08+00:00"
+            "time": "2023-05-22T09:04:27+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "3.0.6",
+            "version": "4.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf"
+                "reference": "5647d65443818959172645e7ed999217360654b6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
-                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/5647d65443818959172645e7ed999217360654b6",
+                "reference": "5647d65443818959172645e7ed999217360654b6",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-main": "4.0-dev"
                 }
             },
             "autoload": {
@@ -1892,7 +1823,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
-                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/3.0.6"
+                "security": "https://github.com/sebastianbergmann/php-file-iterator/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/4.0.2"
             },
             "funding": [
                 {
@@ -1900,28 +1832,28 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-12-02T12:48:52+00:00"
+            "time": "2023-05-07T09:13:23+00:00"
         },
         {
             "name": "phpunit/php-invoker",
-            "version": "3.1.1",
+            "version": "4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-invoker.git",
-                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67"
+                "reference": "f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
-                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7",
+                "reference": "f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
                 "ext-pcntl": "*",
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "suggest": {
                 "ext-pcntl": "*"
@@ -1929,7 +1861,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1-dev"
+                    "dev-main": "4.0-dev"
                 }
             },
             "autoload": {
@@ -1955,7 +1887,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
-                "source": "https://github.com/sebastianbergmann/php-invoker/tree/3.1.1"
+                "source": "https://github.com/sebastianbergmann/php-invoker/tree/4.0.0"
             },
             "funding": [
                 {
@@ -1963,32 +1895,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T05:58:55+00:00"
+            "time": "2023-02-03T06:56:09+00:00"
         },
         {
             "name": "phpunit/php-text-template",
-            "version": "2.0.4",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-text-template.git",
-                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28"
+                "reference": "9f3d3709577a527025f55bcf0f7ab8052c8bb37d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
-                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/9f3d3709577a527025f55bcf0f7ab8052c8bb37d",
+                "reference": "9f3d3709577a527025f55bcf0f7ab8052c8bb37d",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-main": "3.0-dev"
                 }
             },
             "autoload": {
@@ -2014,7 +1946,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
-                "source": "https://github.com/sebastianbergmann/php-text-template/tree/2.0.4"
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/3.0.0"
             },
             "funding": [
                 {
@@ -2022,32 +1954,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T05:33:50+00:00"
+            "time": "2023-02-03T06:56:46+00:00"
         },
         {
             "name": "phpunit/php-timer",
-            "version": "5.0.3",
+            "version": "6.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2"
+                "reference": "e2a2d67966e740530f4a3343fe2e030ffdc1161d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
-                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/e2a2d67966e740530f4a3343fe2e030ffdc1161d",
+                "reference": "e2a2d67966e740530f4a3343fe2e030ffdc1161d",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.0-dev"
+                    "dev-main": "6.0-dev"
                 }
             },
             "autoload": {
@@ -2073,7 +2005,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-timer/issues",
-                "source": "https://github.com/sebastianbergmann/php-timer/tree/5.0.3"
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/6.0.0"
             },
             "funding": [
                 {
@@ -2081,24 +2013,23 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:16:10+00:00"
+            "time": "2023-02-03T06:57:52+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.6.8",
+            "version": "10.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "17d621b3aff84d0c8b62539e269e87d8d5baa76e"
+                "reference": "2379ebafc1737e71cdc84f402acb6b7f04198b9d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/17d621b3aff84d0c8b62539e269e87d8d5baa76e",
-                "reference": "17d621b3aff84d0c8b62539e269e87d8d5baa76e",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/2379ebafc1737e71cdc84f402acb6b7f04198b9d",
+                "reference": "2379ebafc1737e71cdc84f402acb6b7f04198b9d",
                 "shasum": ""
             },
             "require": {
-                "doctrine/instantiator": "^1.3.1 || ^2",
                 "ext-dom": "*",
                 "ext-json": "*",
                 "ext-libxml": "*",
@@ -2108,27 +2039,26 @@
                 "myclabs/deep-copy": "^1.10.1",
                 "phar-io/manifest": "^2.0.3",
                 "phar-io/version": "^3.0.2",
-                "php": ">=7.3",
-                "phpunit/php-code-coverage": "^9.2.13",
-                "phpunit/php-file-iterator": "^3.0.5",
-                "phpunit/php-invoker": "^3.1.1",
-                "phpunit/php-text-template": "^2.0.3",
-                "phpunit/php-timer": "^5.0.2",
-                "sebastian/cli-parser": "^1.0.1",
-                "sebastian/code-unit": "^1.0.6",
-                "sebastian/comparator": "^4.0.8",
-                "sebastian/diff": "^4.0.3",
-                "sebastian/environment": "^5.1.3",
-                "sebastian/exporter": "^4.0.5",
-                "sebastian/global-state": "^5.0.1",
-                "sebastian/object-enumerator": "^4.0.3",
-                "sebastian/resource-operations": "^3.0.3",
-                "sebastian/type": "^3.2",
-                "sebastian/version": "^3.0.2"
+                "php": ">=8.1",
+                "phpunit/php-code-coverage": "^10.1.1",
+                "phpunit/php-file-iterator": "^4.0",
+                "phpunit/php-invoker": "^4.0",
+                "phpunit/php-text-template": "^3.0",
+                "phpunit/php-timer": "^6.0",
+                "sebastian/cli-parser": "^2.0",
+                "sebastian/code-unit": "^2.0",
+                "sebastian/comparator": "^5.0",
+                "sebastian/diff": "^5.0",
+                "sebastian/environment": "^6.0",
+                "sebastian/exporter": "^5.0",
+                "sebastian/global-state": "^6.0",
+                "sebastian/object-enumerator": "^5.0",
+                "sebastian/recursion-context": "^5.0",
+                "sebastian/type": "^4.0",
+                "sebastian/version": "^4.0"
             },
             "suggest": {
-                "ext-soap": "To be able to generate mocks based on WSDL files",
-                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
+                "ext-soap": "To be able to generate mocks based on WSDL files"
             },
             "bin": [
                 "phpunit"
@@ -2136,7 +2066,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "9.6-dev"
+                    "dev-main": "10.1-dev"
                 }
             },
             "autoload": {
@@ -2168,7 +2098,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.8"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.1.3"
             },
             "funding": [
                 {
@@ -2184,7 +2114,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-05-11T05:14:45+00:00"
+            "time": "2023-05-11T05:16:22+00:00"
         },
         {
             "name": "psalm/plugin-phpunit",
@@ -2298,28 +2228,28 @@
         },
         {
             "name": "sebastian/cli-parser",
-            "version": "1.0.1",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/cli-parser.git",
-                "reference": "442e7c7e687e42adc03470c7b668bc4b2402c0b2"
+                "reference": "efdc130dbbbb8ef0b545a994fd811725c5282cae"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/442e7c7e687e42adc03470c7b668bc4b2402c0b2",
-                "reference": "442e7c7e687e42adc03470c7b668bc4b2402c0b2",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/efdc130dbbbb8ef0b545a994fd811725c5282cae",
+                "reference": "efdc130dbbbb8ef0b545a994fd811725c5282cae",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-main": "2.0-dev"
                 }
             },
             "autoload": {
@@ -2342,7 +2272,7 @@
             "homepage": "https://github.com/sebastianbergmann/cli-parser",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
-                "source": "https://github.com/sebastianbergmann/cli-parser/tree/1.0.1"
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/2.0.0"
             },
             "funding": [
                 {
@@ -2350,32 +2280,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T06:08:49+00:00"
+            "time": "2023-02-03T06:58:15+00:00"
         },
         {
             "name": "sebastian/code-unit",
-            "version": "1.0.8",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/code-unit.git",
-                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120"
+                "reference": "a81fee9eef0b7a76af11d121767abc44c104e503"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/1fc9f64c0927627ef78ba436c9b17d967e68e120",
-                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/a81fee9eef0b7a76af11d121767abc44c104e503",
+                "reference": "a81fee9eef0b7a76af11d121767abc44c104e503",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-main": "2.0-dev"
                 }
             },
             "autoload": {
@@ -2398,7 +2328,7 @@
             "homepage": "https://github.com/sebastianbergmann/code-unit",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/code-unit/issues",
-                "source": "https://github.com/sebastianbergmann/code-unit/tree/1.0.8"
+                "source": "https://github.com/sebastianbergmann/code-unit/tree/2.0.0"
             },
             "funding": [
                 {
@@ -2406,32 +2336,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:08:54+00:00"
+            "time": "2023-02-03T06:58:43+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
-            "version": "2.0.3",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
-                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5"
+                "reference": "5e3a687f7d8ae33fb362c5c0743794bbb2420a1d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
-                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/5e3a687f7d8ae33fb362c5c0743794bbb2420a1d",
+                "reference": "5e3a687f7d8ae33fb362c5c0743794bbb2420a1d",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-main": "3.0-dev"
                 }
             },
             "autoload": {
@@ -2453,7 +2383,7 @@
             "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
-                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/2.0.3"
+                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/3.0.0"
             },
             "funding": [
                 {
@@ -2461,34 +2391,36 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T05:30:19+00:00"
+            "time": "2023-02-03T06:59:15+00:00"
         },
         {
             "name": "sebastian/comparator",
-            "version": "4.0.8",
+            "version": "5.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "fa0f136dd2334583309d32b62544682ee972b51a"
+                "reference": "72f01e6586e0caf6af81297897bd112eb7e9627c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/fa0f136dd2334583309d32b62544682ee972b51a",
-                "reference": "fa0f136dd2334583309d32b62544682ee972b51a",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/72f01e6586e0caf6af81297897bd112eb7e9627c",
+                "reference": "72f01e6586e0caf6af81297897bd112eb7e9627c",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3",
-                "sebastian/diff": "^4.0",
-                "sebastian/exporter": "^4.0"
+                "ext-dom": "*",
+                "ext-mbstring": "*",
+                "php": ">=8.1",
+                "sebastian/diff": "^5.0",
+                "sebastian/exporter": "^5.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -2527,7 +2459,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/comparator/issues",
-                "source": "https://github.com/sebastianbergmann/comparator/tree/4.0.8"
+                "source": "https://github.com/sebastianbergmann/comparator/tree/5.0.0"
             },
             "funding": [
                 {
@@ -2535,33 +2467,33 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-09-14T12:41:17+00:00"
+            "time": "2023-02-03T07:07:16+00:00"
         },
         {
             "name": "sebastian/complexity",
-            "version": "2.0.2",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/complexity.git",
-                "reference": "739b35e53379900cc9ac327b2147867b8b6efd88"
+                "reference": "e67d240970c9dc7ea7b2123a6d520e334dd61dc6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/739b35e53379900cc9ac327b2147867b8b6efd88",
-                "reference": "739b35e53379900cc9ac327b2147867b8b6efd88",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/e67d240970c9dc7ea7b2123a6d520e334dd61dc6",
+                "reference": "e67d240970c9dc7ea7b2123a6d520e334dd61dc6",
                 "shasum": ""
             },
             "require": {
-                "nikic/php-parser": "^4.7",
-                "php": ">=7.3"
+                "nikic/php-parser": "^4.10",
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-main": "3.0-dev"
                 }
             },
             "autoload": {
@@ -2584,7 +2516,7 @@
             "homepage": "https://github.com/sebastianbergmann/complexity",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/complexity/issues",
-                "source": "https://github.com/sebastianbergmann/complexity/tree/2.0.2"
+                "source": "https://github.com/sebastianbergmann/complexity/tree/3.0.0"
             },
             "funding": [
                 {
@@ -2592,33 +2524,33 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T15:52:27+00:00"
+            "time": "2023-02-03T06:59:47+00:00"
         },
         {
             "name": "sebastian/diff",
-            "version": "4.0.5",
+            "version": "5.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "74be17022044ebaaecfdf0c5cd504fc9cd5a7131"
+                "reference": "912dc2fbe3e3c1e7873313cc801b100b6c68c87b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/74be17022044ebaaecfdf0c5cd504fc9cd5a7131",
-                "reference": "74be17022044ebaaecfdf0c5cd504fc9cd5a7131",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/912dc2fbe3e3c1e7873313cc801b100b6c68c87b",
+                "reference": "912dc2fbe3e3c1e7873313cc801b100b6c68c87b",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3",
+                "phpunit/phpunit": "^10.0",
                 "symfony/process": "^4.2 || ^5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -2650,7 +2582,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/diff/issues",
-                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.5"
+                "security": "https://github.com/sebastianbergmann/diff/security/policy",
+                "source": "https://github.com/sebastianbergmann/diff/tree/5.0.3"
             },
             "funding": [
                 {
@@ -2658,27 +2591,27 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-05-07T05:35:17+00:00"
+            "time": "2023-05-01T07:48:21+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "5.1.5",
+            "version": "6.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed"
+                "reference": "43c751b41d74f96cbbd4e07b7aec9675651e2951"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
-                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/43c751b41d74f96cbbd4e07b7aec9675651e2951",
+                "reference": "43c751b41d74f96cbbd4e07b7aec9675651e2951",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "suggest": {
                 "ext-posix": "*"
@@ -2686,7 +2619,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.1-dev"
+                    "dev-main": "6.0-dev"
                 }
             },
             "autoload": {
@@ -2705,7 +2638,7 @@
                 }
             ],
             "description": "Provides functionality to handle HHVM/PHP environments",
-            "homepage": "http://www.github.com/sebastianbergmann/environment",
+            "homepage": "https://github.com/sebastianbergmann/environment",
             "keywords": [
                 "Xdebug",
                 "environment",
@@ -2713,7 +2646,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/environment/issues",
-                "source": "https://github.com/sebastianbergmann/environment/tree/5.1.5"
+                "security": "https://github.com/sebastianbergmann/environment/security/policy",
+                "source": "https://github.com/sebastianbergmann/environment/tree/6.0.1"
             },
             "funding": [
                 {
@@ -2721,34 +2655,34 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T06:03:51+00:00"
+            "time": "2023-04-11T05:39:26+00:00"
         },
         {
             "name": "sebastian/exporter",
-            "version": "4.0.5",
+            "version": "5.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "ac230ed27f0f98f597c8a2b6eb7ac563af5e5b9d"
+                "reference": "f3ec4bf931c0b31e5b413f5b4fc970a7d03338c0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/ac230ed27f0f98f597c8a2b6eb7ac563af5e5b9d",
-                "reference": "ac230ed27f0f98f597c8a2b6eb7ac563af5e5b9d",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/f3ec4bf931c0b31e5b413f5b4fc970a7d03338c0",
+                "reference": "f3ec4bf931c0b31e5b413f5b4fc970a7d03338c0",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3",
-                "sebastian/recursion-context": "^4.0"
+                "ext-mbstring": "*",
+                "php": ">=8.1",
+                "sebastian/recursion-context": "^5.0"
             },
             "require-dev": {
-                "ext-mbstring": "*",
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -2790,7 +2724,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/exporter/issues",
-                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.5"
+                "source": "https://github.com/sebastianbergmann/exporter/tree/5.0.0"
             },
             "funding": [
                 {
@@ -2798,38 +2732,35 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-09-14T06:03:37+00:00"
+            "time": "2023-02-03T07:06:49+00:00"
         },
         {
             "name": "sebastian/global-state",
-            "version": "5.0.5",
+            "version": "6.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "0ca8db5a5fc9c8646244e629625ac486fa286bf2"
+                "reference": "aab257c712de87b90194febd52e4d184551c2d44"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/0ca8db5a5fc9c8646244e629625ac486fa286bf2",
-                "reference": "0ca8db5a5fc9c8646244e629625ac486fa286bf2",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/aab257c712de87b90194febd52e4d184551c2d44",
+                "reference": "aab257c712de87b90194febd52e4d184551c2d44",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3",
-                "sebastian/object-reflector": "^2.0",
-                "sebastian/recursion-context": "^4.0"
+                "php": ">=8.1",
+                "sebastian/object-reflector": "^3.0",
+                "sebastian/recursion-context": "^5.0"
             },
             "require-dev": {
                 "ext-dom": "*",
-                "phpunit/phpunit": "^9.3"
-            },
-            "suggest": {
-                "ext-uopz": "*"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.0-dev"
+                    "dev-main": "6.0-dev"
                 }
             },
             "autoload": {
@@ -2854,7 +2785,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/global-state/issues",
-                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.5"
+                "source": "https://github.com/sebastianbergmann/global-state/tree/6.0.0"
             },
             "funding": [
                 {
@@ -2862,33 +2793,33 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-02-14T08:28:10+00:00"
+            "time": "2023-02-03T07:07:38+00:00"
         },
         {
             "name": "sebastian/lines-of-code",
-            "version": "1.0.3",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/lines-of-code.git",
-                "reference": "c1c2e997aa3146983ed888ad08b15470a2e22ecc"
+                "reference": "17c4d940ecafb3d15d2cf916f4108f664e28b130"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/c1c2e997aa3146983ed888ad08b15470a2e22ecc",
-                "reference": "c1c2e997aa3146983ed888ad08b15470a2e22ecc",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/17c4d940ecafb3d15d2cf916f4108f664e28b130",
+                "reference": "17c4d940ecafb3d15d2cf916f4108f664e28b130",
                 "shasum": ""
             },
             "require": {
-                "nikic/php-parser": "^4.6",
-                "php": ">=7.3"
+                "nikic/php-parser": "^4.10",
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-main": "2.0-dev"
                 }
             },
             "autoload": {
@@ -2911,7 +2842,7 @@
             "homepage": "https://github.com/sebastianbergmann/lines-of-code",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
-                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/1.0.3"
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/2.0.0"
             },
             "funding": [
                 {
@@ -2919,34 +2850,34 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-11-28T06:42:11+00:00"
+            "time": "2023-02-03T07:08:02+00:00"
         },
         {
             "name": "sebastian/object-enumerator",
-            "version": "4.0.4",
+            "version": "5.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-enumerator.git",
-                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71"
+                "reference": "202d0e344a580d7f7d04b3fafce6933e59dae906"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/5c9eeac41b290a3712d88851518825ad78f45c71",
-                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/202d0e344a580d7f7d04b3fafce6933e59dae906",
+                "reference": "202d0e344a580d7f7d04b3fafce6933e59dae906",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3",
-                "sebastian/object-reflector": "^2.0",
-                "sebastian/recursion-context": "^4.0"
+                "php": ">=8.1",
+                "sebastian/object-reflector": "^3.0",
+                "sebastian/recursion-context": "^5.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -2968,7 +2899,7 @@
             "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
-                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/4.0.4"
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/5.0.0"
             },
             "funding": [
                 {
@@ -2976,32 +2907,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:12:34+00:00"
+            "time": "2023-02-03T07:08:32+00:00"
         },
         {
             "name": "sebastian/object-reflector",
-            "version": "2.0.4",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-reflector.git",
-                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7"
+                "reference": "24ed13d98130f0e7122df55d06c5c4942a577957"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
-                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/24ed13d98130f0e7122df55d06c5c4942a577957",
+                "reference": "24ed13d98130f0e7122df55d06c5c4942a577957",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-main": "3.0-dev"
                 }
             },
             "autoload": {
@@ -3023,7 +2954,7 @@
             "homepage": "https://github.com/sebastianbergmann/object-reflector/",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
-                "source": "https://github.com/sebastianbergmann/object-reflector/tree/2.0.4"
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/3.0.0"
             },
             "funding": [
                 {
@@ -3031,32 +2962,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:14:26+00:00"
+            "time": "2023-02-03T07:06:18+00:00"
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "4.0.5",
+            "version": "5.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1"
+                "reference": "05909fb5bc7df4c52992396d0116aed689f93712"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1",
-                "reference": "e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/05909fb5bc7df4c52992396d0116aed689f93712",
+                "reference": "05909fb5bc7df4c52992396d0116aed689f93712",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -3086,7 +3017,7 @@
             "homepage": "https://github.com/sebastianbergmann/recursion-context",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
-                "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.5"
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/5.0.0"
             },
             "funding": [
                 {
@@ -3094,87 +3025,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T06:07:39+00:00"
-        },
-        {
-            "name": "sebastian/resource-operations",
-            "version": "3.0.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/resource-operations.git",
-                "reference": "0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8",
-                "reference": "0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                }
-            ],
-            "description": "Provides a list of PHP built-in functions that operate on resources",
-            "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/resource-operations/issues",
-                "source": "https://github.com/sebastianbergmann/resource-operations/tree/3.0.3"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2020-09-28T06:45:17+00:00"
+            "time": "2023-02-03T07:05:40+00:00"
         },
         {
             "name": "sebastian/type",
-            "version": "3.2.1",
+            "version": "4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/type.git",
-                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7"
+                "reference": "462699a16464c3944eefc02ebdd77882bd3925bf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
-                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/462699a16464c3944eefc02ebdd77882bd3925bf",
+                "reference": "462699a16464c3944eefc02ebdd77882bd3925bf",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.5"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.2-dev"
+                    "dev-main": "4.0-dev"
                 }
             },
             "autoload": {
@@ -3197,7 +3073,7 @@
             "homepage": "https://github.com/sebastianbergmann/type",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/type/issues",
-                "source": "https://github.com/sebastianbergmann/type/tree/3.2.1"
+                "source": "https://github.com/sebastianbergmann/type/tree/4.0.0"
             },
             "funding": [
                 {
@@ -3205,29 +3081,29 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T06:13:03+00:00"
+            "time": "2023-02-03T07:10:45+00:00"
         },
         {
             "name": "sebastian/version",
-            "version": "3.0.2",
+            "version": "4.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/version.git",
-                "reference": "c6c1022351a901512170118436c764e473f6de8c"
+                "reference": "c51fa83a5d8f43f1402e3f32a005e6262244ef17"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c6c1022351a901512170118436c764e473f6de8c",
-                "reference": "c6c1022351a901512170118436c764e473f6de8c",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c51fa83a5d8f43f1402e3f32a005e6262244ef17",
+                "reference": "c51fa83a5d8f43f1402e3f32a005e6262244ef17",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-main": "4.0-dev"
                 }
             },
             "autoload": {
@@ -3250,7 +3126,7 @@
             "homepage": "https://github.com/sebastianbergmann/version",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/version/issues",
-                "source": "https://github.com/sebastianbergmann/version/tree/3.0.2"
+                "source": "https://github.com/sebastianbergmann/version/tree/4.0.1"
             },
             "funding": [
                 {
@@ -3258,7 +3134,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T06:39:44+00:00"
+            "time": "2023-02-07T11:34:05+00:00"
         },
         {
             "name": "slevomat/coding-standard",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -3,17 +3,26 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
     bootstrap="vendor/autoload.php"
-    convertDeprecationsToExceptions="true"
-    colors="true">
-    <coverage processUncoveredFiles="true">
-        <include>
-            <directory suffix=".php">src</directory>
-        </include>
-    </coverage>
-
+    colors="true"
+    cacheDirectory=".phpunit.cache"
+    displayDetailsOnIncompleteTests="true"
+    displayDetailsOnSkippedTests="true"
+    displayDetailsOnTestsThatTriggerDeprecations="true"
+    displayDetailsOnTestsThatTriggerErrors="true"
+    displayDetailsOnTestsThatTriggerNotices="true"
+    displayDetailsOnTestsThatTriggerWarnings="true"
+    failOnWarning="true"
+    failOnDeprecation="true"
+    failOnNotice="true"
+>
     <testsuites>
         <testsuite name="laminas-inputfilter Test Suite">
             <directory>./test</directory>
         </testsuite>
     </testsuites>
+    <source>
+        <include>
+            <directory suffix=".php">src</directory>
+        </include>
+    </source>
 </phpunit>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -285,6 +285,11 @@
       <code>setInputFilter</code>
     </PossiblyUnusedMethod>
   </file>
+  <file src="src/InputFilterAwareTrait.php">
+    <InvalidNullableReturnType>
+      <code>InputFilterInterface</code>
+    </InvalidNullableReturnType>
+  </file>
   <file src="src/InputFilterInterface.php">
     <PossiblyUnusedReturnValue>
       <code>InputFilterInterface</code>
@@ -432,12 +437,16 @@
     </RedundantCondition>
   </file>
   <file src="test/BaseInputFilterTest.php">
+    <DeprecatedMethod>
+      <code>enableProxyingToOriginalMethods</code>
+      <code>enableProxyingToOriginalMethods</code>
+    </DeprecatedMethod>
     <InvalidArgument>
       <code><![CDATA[['nested' => ['nested-input1', 'nested-input2']]]]></code>
     </InvalidArgument>
-    <InvalidDocblock>
-      <code>public function addMethodArgumentsProvider(): array</code>
-    </InvalidDocblock>
+    <LessSpecificReturnStatement>
+      <code>$dataSets</code>
+    </LessSpecificReturnStatement>
     <MissingClosureParamType>
       <code>$inputTypeData</code>
       <code>$inputTypeData</code>
@@ -453,6 +462,7 @@
       <code>$set[6]</code>
     </MixedArgument>
     <MixedArgumentTypeCoercion>
+      <code>$getMessages</code>
       <code>$msg</code>
       <code>$msg</code>
       <code>$name</code>
@@ -480,14 +490,6 @@
       <code>$tmpTemplate[2]</code>
       <code>$tmpTemplate[3]</code>
     </MixedAssignment>
-    <MixedInferredReturnType>
-      <code><![CDATA[<string, array{
-     *     0: InputInterface,
-     *     1: null|string,
-     *     2: null|string,
-     *     3: MockObject&InputInterface
-     * }>]]></code>
-    </MixedInferredReturnType>
     <MixedReturnTypeCoercion>
       <code>$dataSets</code>
       <code><![CDATA[array<string, array{
@@ -501,6 +503,14 @@
      *     7: string[]
      * }>]]></code>
     </MixedReturnTypeCoercion>
+    <MoreSpecificReturnType>
+      <code><![CDATA[array<string, array{
+     *     0: InputInterface,
+     *     1: null|string,
+     *     2: null|string,
+     *     3: InputInterface,
+     * }>]]></code>
+    </MoreSpecificReturnType>
     <PossiblyInvalidArgument>
       <code>$input</code>
       <code>$input</code>
@@ -518,10 +528,55 @@
       <code>getName</code>
       <code>isRequired</code>
     </PossiblyUndefinedMethod>
+    <PossiblyUnusedMethod>
+      <code>addMethodArgumentsProvider</code>
+      <code>contextProvider</code>
+      <code>setDataArgumentsProvider</code>
+      <code>unknownScenariosProvider</code>
+    </PossiblyUnusedMethod>
     <PossiblyUnusedParam>
-      <code>$context</code>
       <code>$inputName</code>
     </PossiblyUnusedParam>
+  </file>
+  <file src="test/CollectionInputFilterTest.php">
+    <InvalidArgument>
+      <code>$errorMessage</code>
+    </InvalidArgument>
+    <InvalidReturnStatement>
+      <code><![CDATA[[
+            // Description => [$required, $count, $data, $inputFilter, $expectedRaw, $expectedValues, $expectedValid, $expectedMessages]
+            'Required: T, Count: N, Valid: T'  => [  $isRequired, null, $colRaw, $validIF()  , $colRaw, $colFiltered, true , []],
+            'Required: T, Count: N, Valid: F'  => [  $isRequired, null, $colRaw, $invalidIF(), $colRaw, $colFiltered, false, $colMessages],
+            'Required: T, Count: +1, Valid: F' => [  $isRequired,    2, $colRaw, $invalidIF(), $colRaw, $colFiltered, false, $colMessages],
+            'Required: F, Count: N, Valid: T'  => [! $isRequired, null, $colRaw, $validIF()  , $colRaw, $colFiltered, true , []],
+            'Required: F, Count: N, Valid: F'  => [! $isRequired, null, $colRaw, $invalidIF(), $colRaw, $colFiltered, false, $colMessages],
+            'Required: F, Count: +1, Valid: F' => [! $isRequired,    2, $colRaw, $invalidIF(), $colRaw, $colFiltered, false, $colMessages],
+            'Required: T, Data: [], Valid: X'  => [  $isRequired, null, []     , $noValidIF(), []     , []          , false, [['isEmpty' => 'Value is required and can\'t be empty']]],
+            'Required: F, Data: [], Valid: X'  => [! $isRequired, null, []     , $noValidIF(), []     , []          , true , []],
+        ]]]></code>
+    </InvalidReturnStatement>
+    <InvalidReturnType>
+      <code><![CDATA[array<string, array{
+     *     0: bool,
+     *     1: null|int,
+     *     2: array,
+     *     3: BaseInputFilter&MockObject,
+     *     4: array,
+     *     5: array,
+     *     6: bool,
+     *     7: array
+     * }>]]></code>
+    </InvalidReturnType>
+    <PossiblyUnusedMethod>
+      <code>contextProvider</code>
+      <code>countVsDataProvider</code>
+      <code>dataNestingCollection</code>
+      <code>dataVsValidProvider</code>
+      <code>inputFilterProvider</code>
+      <code>invalidCollections</code>
+      <code>invalidDataType</code>
+      <code>isRequiredProvider</code>
+    </PossiblyUnusedMethod>
   </file>
   <file src="test/FactoryTest.php">
     <PossiblyNullReference>
@@ -532,6 +587,9 @@
       <code>breakOnFailure</code>
       <code>breakOnFailure</code>
     </PossiblyUndefinedMethod>
+    <PossiblyUnusedMethod>
+      <code>inputTypeSpecificationProvider</code>
+    </PossiblyUnusedMethod>
     <UndefinedInterfaceMethod>
       <code>continueIfEmpty</code>
     </UndefinedInterfaceMethod>
@@ -595,22 +653,15 @@
       <code>$generator instanceof Generator</code>
     </TypeDoesNotContainType>
   </file>
-  <file src="test/InputFilterAwareTraitTest.php">
-    <InvalidArgument>
-      <code>InputFilterAwareTrait::class</code>
-      <code>InputFilterAwareTrait::class</code>
-    </InvalidArgument>
-    <MixedMethodCall>
-      <code>getInputFilter</code>
-      <code>getInputFilter</code>
-      <code>setInputFilter</code>
-      <code>setInputFilter</code>
-    </MixedMethodCall>
-  </file>
   <file src="test/InputFilterPluginManagerCompatibilityTest.php">
     <InvalidReturnType>
       <code>getInstanceOf</code>
     </InvalidReturnType>
+  </file>
+  <file src="test/InputFilterPluginManagerFactoryTest.php">
+    <PossiblyUnusedMethod>
+      <code>pluginProvider</code>
+    </PossiblyUnusedMethod>
   </file>
   <file src="test/InputFilterPluginManagerTest.php">
     <LessSpecificReturnStatement>
@@ -627,6 +678,10 @@
      *     2: class-string<InputInterface>
      * }>]]></code>
     </MoreSpecificReturnType>
+    <PossiblyUnusedMethod>
+      <code>defaultInvokableClassesProvider</code>
+      <code>serviceProvider</code>
+    </PossiblyUnusedMethod>
   </file>
   <file src="test/InputFilterTest.php">
     <ImplementedReturnTypeMismatch>
@@ -716,14 +771,6 @@
     <LessSpecificReturnStatement>
       <code>array_merge($emptyValues, $mixedValues)</code>
     </LessSpecificReturnStatement>
-    <MissingClosureParamType>
-      <code>$context</code>
-      <code>$context</code>
-      <code>$context</code>
-      <code>$value</code>
-      <code>$value</code>
-      <code>$value</code>
-    </MissingClosureParamType>
     <MixedArrayAccess>
       <code><![CDATA[$value['filtered']]]></code>
       <code><![CDATA[$value['raw']]]></code>
@@ -766,6 +813,11 @@
   <file src="test/TestAsset/ServiceListenerInterface.php">
     <PossiblyUnusedMethod>
       <code>addServiceManager</code>
+    </PossiblyUnusedMethod>
+  </file>
+  <file src="test/ValidationGroup/InputFilterCollectionsValidationGroupTest.php">
+    <PossiblyUnusedMethod>
+      <code>collectionCountProvider</code>
     </PossiblyUnusedMethod>
   </file>
 </files>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -62,6 +62,11 @@
       <code>isValid</code>
       <code>isValid</code>
     </TooManyArguments>
+    <UnusedPsalmSuppress>
+      <code>DocblockTypeContradiction</code>
+      <code>RedundantConditionGivenDocblockType</code>
+      <code>RedundantConditionGivenDocblockType</code>
+    </UnusedPsalmSuppress>
   </file>
   <file src="src/CollectionInputFilter.php">
     <ImplementedParamTypeMismatch>
@@ -92,6 +97,23 @@
     <MixedAssignment>
       <code>$data</code>
     </MixedAssignment>
+    <PossiblyUnusedReturnValue>
+      <code>array[]</code>
+      <code>array[]</code>
+    </PossiblyUnusedReturnValue>
+    <UnusedPsalmSuppress>
+      <code>DocblockTypeContradiction</code>
+      <code>DocblockTypeContradiction</code>
+      <code>DocblockTypeContradiction</code>
+      <code>RedundantConditionGivenDocblockType</code>
+      <code>RedundantConditionGivenDocblockType</code>
+      <code>RedundantConditionGivenDocblockType</code>
+    </UnusedPsalmSuppress>
+  </file>
+  <file src="src/EmptyContextInterface.php">
+    <PossiblyUnusedReturnValue>
+      <code>self</code>
+    </PossiblyUnusedReturnValue>
   </file>
   <file src="src/Factory.php">
     <InvalidReturnStatement>
@@ -139,6 +161,12 @@
       <code>add</code>
       <code>add</code>
     </PossiblyUndefinedMethod>
+    <UnusedPsalmSuppress>
+      <code>DeprecatedMethod</code>
+      <code>DocblockTypeContradiction</code>
+      <code>DocblockTypeContradiction</code>
+      <code>RedundantConditionGivenDocblockType</code>
+    </UnusedPsalmSuppress>
   </file>
   <file src="src/FileInput.php">
     <InvalidPropertyAssignmentValue>
@@ -251,6 +279,17 @@
       <code>$services</code>
     </ParamNameMismatch>
   </file>
+  <file src="src/InputFilterAwareInterface.php">
+    <PossiblyUnusedMethod>
+      <code>getInputFilter</code>
+      <code>setInputFilter</code>
+    </PossiblyUnusedMethod>
+  </file>
+  <file src="src/InputFilterInterface.php">
+    <PossiblyUnusedReturnValue>
+      <code>InputFilterInterface</code>
+    </PossiblyUnusedReturnValue>
+  </file>
   <file src="src/InputFilterPluginManager.php">
     <DeprecatedInterface>
       <code>null|ConfigInterface|ContainerInterface</code>
@@ -265,6 +304,12 @@
     <NonInvariantDocblockPropertyType>
       <code>$factories</code>
     </NonInvariantDocblockPropertyType>
+    <PossiblyUnusedMethod>
+      <code>validatePlugin</code>
+    </PossiblyUnusedMethod>
+    <PossiblyUnusedProperty>
+      <code>$shareByDefault</code>
+    </PossiblyUnusedProperty>
     <PropertyTypeCoercion>
       <code><![CDATA[$this->initializers]]></code>
       <code><![CDATA[$this->initializers]]></code>
@@ -280,8 +325,31 @@
     <ParamNameMismatch>
       <code>$container</code>
     </ParamNameMismatch>
+    <PossiblyUnusedMethod>
+      <code>setCreationOptions</code>
+    </PossiblyUnusedMethod>
+    <UnusedPsalmSuppress>
+      <code>MismatchingDocblockParamType</code>
+      <code>MismatchingDocblockParamType</code>
+      <code>MoreSpecificImplementedParamType</code>
+    </UnusedPsalmSuppress>
+  </file>
+  <file src="src/InputInterface.php">
+    <PossiblyUnusedReturnValue>
+      <code>$this</code>
+      <code>$this</code>
+      <code>$this</code>
+      <code>$this</code>
+      <code>$this</code>
+      <code>$this</code>
+      <code>$this</code>
+      <code>$this</code>
+    </PossiblyUnusedReturnValue>
   </file>
   <file src="src/Module.php">
+    <PossiblyUnusedParam>
+      <code>$moduleManager</code>
+    </PossiblyUnusedParam>
     <UndefinedDocblockClass>
       <code>ModuleManager</code>
     </UndefinedDocblockClass>
@@ -450,6 +518,10 @@
       <code>getName</code>
       <code>isRequired</code>
     </PossiblyUndefinedMethod>
+    <PossiblyUnusedParam>
+      <code>$context</code>
+      <code>$inputName</code>
+    </PossiblyUnusedParam>
   </file>
   <file src="test/FactoryTest.php">
     <PossiblyNullReference>
@@ -680,5 +752,20 @@
     <RedundantCondition>
       <code>isArray</code>
     </RedundantCondition>
+  </file>
+  <file src="test/TestAsset/ModuleEventInterface.php">
+    <PossiblyUnusedMethod>
+      <code>getParam</code>
+    </PossiblyUnusedMethod>
+  </file>
+  <file src="test/TestAsset/ModuleManagerInterface.php">
+    <PossiblyUnusedMethod>
+      <code>getEvent</code>
+    </PossiblyUnusedMethod>
+  </file>
+  <file src="test/TestAsset/ServiceListenerInterface.php">
+    <PossiblyUnusedMethod>
+      <code>addServiceManager</code>
+    </PossiblyUnusedMethod>
   </file>
 </files>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,218 +1,218 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="5.4.0@62db5d4f6a7ae0a20f7cc5a4952d730272fc0863">
+<files psalm-version="5.12.0@f90118cdeacd0088e7215e64c0c99ceca819e176">
   <file src="src/ArrayInput.php">
-    <DocblockTypeContradiction occurrences="1">
+    <DocblockTypeContradiction>
       <code>is_array($value)</code>
     </DocblockTypeContradiction>
-    <InvalidPropertyAssignmentValue occurrences="2">
-      <code>$this-&gt;prepareRequiredValidationFailureMessage()</code>
-      <code>$this-&gt;prepareRequiredValidationFailureMessage()</code>
+    <InvalidPropertyAssignmentValue>
+      <code><![CDATA[$this->prepareRequiredValidationFailureMessage()]]></code>
+      <code><![CDATA[$this->prepareRequiredValidationFailureMessage()]]></code>
     </InvalidPropertyAssignmentValue>
-    <MixedArgument occurrences="2">
-      <code>$this-&gt;getFallbackValue()</code>
-      <code>$this-&gt;getFallbackValue()</code>
+    <MixedArgument>
+      <code><![CDATA[$this->getFallbackValue()]]></code>
+      <code><![CDATA[$this->getFallbackValue()]]></code>
     </MixedArgument>
-    <MixedAssignment occurrences="3">
+    <MixedAssignment>
       <code>$result[$key]</code>
       <code>$value</code>
       <code>$value</code>
     </MixedAssignment>
-    <MoreSpecificImplementedParamType occurrences="2">
+    <MoreSpecificImplementedParamType>
       <code>$value</code>
       <code>$value</code>
     </MoreSpecificImplementedParamType>
-    <NonInvariantDocblockPropertyType occurrences="1">
+    <NonInvariantDocblockPropertyType>
       <code>$value</code>
     </NonInvariantDocblockPropertyType>
   </file>
   <file src="src/BaseInputFilter.php">
-    <DocblockTypeContradiction occurrences="1">
-      <code>$input instanceof InputInterface &amp;&amp; (empty($name) || is_int($name))</code>
+    <DocblockTypeContradiction>
+      <code><![CDATA[$input instanceof InputInterface && (empty($name) || is_int($name))]]></code>
     </DocblockTypeContradiction>
-    <InvalidReturnStatement occurrences="1">
+    <InvalidReturnStatement>
       <code>$messages</code>
     </InvalidReturnStatement>
-    <InvalidReturnType occurrences="1">
-      <code>array&lt;string, array&lt;array-key, string&gt;&gt;</code>
+    <InvalidReturnType>
+      <code><![CDATA[array<string, array<array-key, string>>]]></code>
     </InvalidReturnType>
-    <MixedArgument occurrences="1">
+    <MixedArgument>
       <code>$input</code>
     </MixedArgument>
-    <MixedArgumentTypeCoercion occurrences="1">
+    <MixedArgumentTypeCoercion>
       <code>$inputs</code>
     </MixedArgumentTypeCoercion>
-    <MixedAssignment occurrences="3">
+    <MixedAssignment>
       <code>$inputContext</code>
       <code>$unknownInputs[$key]</code>
       <code>$value</code>
     </MixedAssignment>
-    <MixedPropertyTypeCoercion occurrences="1">
+    <MixedPropertyTypeCoercion>
       <code>$inputs</code>
     </MixedPropertyTypeCoercion>
-    <PossiblyInvalidArgument occurrences="1">
+    <PossiblyInvalidArgument>
       <code>$input</code>
     </PossiblyInvalidArgument>
-    <PossiblyNullArrayOffset occurrences="1">
-      <code>$this-&gt;inputs</code>
+    <PossiblyNullArrayOffset>
+      <code><![CDATA[$this->inputs]]></code>
     </PossiblyNullArrayOffset>
-    <RedundantCastGivenDocblockType occurrences="1">
+    <RedundantCastGivenDocblockType>
       <code>(string) $name</code>
     </RedundantCastGivenDocblockType>
-    <TooManyArguments occurrences="2">
+    <TooManyArguments>
       <code>isValid</code>
       <code>isValid</code>
     </TooManyArguments>
   </file>
   <file src="src/CollectionInputFilter.php">
-    <ImplementedParamTypeMismatch occurrences="2">
+    <ImplementedParamTypeMismatch>
       <code>$name</code>
       <code>$name</code>
     </ImplementedParamTypeMismatch>
-    <ImplementedReturnTypeMismatch occurrences="2">
-      <code>array&lt;array-key, array&lt;string, array&lt;array-key, string&gt;&gt;&gt;</code>
-      <code>array&lt;array-key, array&lt;string, array&lt;array-key, string&gt;&gt;&gt;</code>
+    <ImplementedReturnTypeMismatch>
+      <code><![CDATA[array<array-key, array<string, array<array-key, string>>>]]></code>
+      <code><![CDATA[array<array-key, array<string, array<array-key, string>>>]]></code>
     </ImplementedReturnTypeMismatch>
-    <InvalidArgument occurrences="1">
+    <InvalidArgument>
       <code>$data</code>
     </InvalidArgument>
-    <InvalidPropertyAssignmentValue occurrences="5">
+    <InvalidPropertyAssignmentValue>
       <code>$name</code>
-      <code>$this-&gt;collectionMessages</code>
-      <code>$this-&gt;collectionMessages</code>
-      <code>$this-&gt;invalidInputs</code>
-      <code>$this-&gt;validInputs</code>
+      <code><![CDATA[$this->collectionMessages]]></code>
+      <code><![CDATA[$this->collectionMessages]]></code>
+      <code><![CDATA[$this->invalidInputs]]></code>
+      <code><![CDATA[$this->validInputs]]></code>
     </InvalidPropertyAssignmentValue>
-    <LessSpecificImplementedReturnType occurrences="2">
-      <code>array&lt;array-key, array&gt;</code>
-      <code>array&lt;array-key, array&gt;</code>
+    <LessSpecificImplementedReturnType>
+      <code><![CDATA[array<array-key, array>]]></code>
+      <code><![CDATA[array<array-key, array>]]></code>
     </LessSpecificImplementedReturnType>
-    <MixedArgument occurrences="1">
+    <MixedArgument>
       <code>$data</code>
     </MixedArgument>
-    <MixedAssignment occurrences="1">
+    <MixedAssignment>
       <code>$data</code>
     </MixedAssignment>
   </file>
   <file src="src/Factory.php">
-    <InvalidReturnStatement occurrences="1">
+    <InvalidReturnStatement>
       <code>$inputFilter</code>
     </InvalidReturnStatement>
-    <InvalidReturnType occurrences="1">
+    <InvalidReturnType>
       <code>InputFilterInterface</code>
     </InvalidReturnType>
-    <MixedArgument occurrences="9">
-      <code>$inputFilterSpecification['count']</code>
-      <code>$inputFilterSpecification['input_filter']</code>
-      <code>$inputFilterSpecification['required']</code>
-      <code>$inputFilterSpecification['required_message']</code>
+    <MixedArgument>
+      <code><![CDATA[$inputFilterSpecification['count']]]></code>
+      <code><![CDATA[$inputFilterSpecification['input_filter']]]></code>
+      <code><![CDATA[$inputFilterSpecification['required']]]></code>
+      <code><![CDATA[$inputFilterSpecification['required_message']]]></code>
       <code>$key</code>
       <code>$name</code>
       <code>$priority</code>
       <code>$value</code>
-      <code>$value['type']</code>
+      <code><![CDATA[$value['type']]]></code>
     </MixedArgument>
-    <MixedArgumentTypeCoercion occurrences="3">
+    <MixedArgumentTypeCoercion>
       <code>$filter</code>
       <code>$inputSpecification</code>
       <code>$key</code>
     </MixedArgumentTypeCoercion>
-    <MixedArrayAccess occurrences="3">
-      <code>$filter['name']</code>
-      <code>$filter['options']</code>
-      <code>$filter['priority']</code>
+    <MixedArrayAccess>
+      <code><![CDATA[$filter['name']]]></code>
+      <code><![CDATA[$filter['options']]]></code>
+      <code><![CDATA[$filter['priority']]]></code>
     </MixedArrayAccess>
-    <MixedAssignment occurrences="5">
+    <MixedAssignment>
       <code>$key</code>
       <code>$name</code>
       <code>$options</code>
       <code>$priority</code>
       <code>$value</code>
     </MixedAssignment>
-    <MixedMethodCall occurrences="1">
+    <MixedMethodCall>
       <code>new $class()</code>
     </MixedMethodCall>
-    <PossiblyInvalidArgument occurrences="2">
+    <PossiblyInvalidArgument>
       <code>$value</code>
       <code>$value</code>
     </PossiblyInvalidArgument>
-    <PossiblyUndefinedMethod occurrences="2">
+    <PossiblyUndefinedMethod>
       <code>add</code>
       <code>add</code>
     </PossiblyUndefinedMethod>
   </file>
   <file src="src/FileInput.php">
-    <InvalidPropertyAssignmentValue occurrences="1">
-      <code>$this-&gt;prepareRequiredValidationFailureMessage()</code>
+    <InvalidPropertyAssignmentValue>
+      <code><![CDATA[$this->prepareRequiredValidationFailureMessage()]]></code>
     </InvalidPropertyAssignmentValue>
-    <MixedAssignment occurrences="1">
+    <MixedAssignment>
       <code>$rawValue</code>
     </MixedAssignment>
-    <MoreSpecificImplementedParamType occurrences="2">
+    <MoreSpecificImplementedParamType>
       <code>$value</code>
       <code>$value</code>
     </MoreSpecificImplementedParamType>
   </file>
   <file src="src/FileInput/HttpServerFileInputDecorator.php">
-    <MixedAssignment occurrences="5">
+    <MixedAssignment>
       <code>$fileData</code>
       <code>$newValue[]</code>
       <code>$rawValue</code>
       <code>$value</code>
       <code>$value</code>
     </MixedAssignment>
-    <RedundantCondition occurrences="2">
+    <RedundantCondition>
       <code>is_array($rawValue)</code>
       <code>is_array($rawValue)</code>
     </RedundantCondition>
   </file>
   <file src="src/FileInput/PsrFileInputDecorator.php">
-    <MixedArgument occurrences="1">
+    <MixedArgument>
       <code>$rawValue[0]</code>
     </MixedArgument>
-    <MixedAssignment occurrences="5">
+    <MixedAssignment>
       <code>$fileData</code>
       <code>$newValue[]</code>
       <code>$rawValue</code>
       <code>$value</code>
       <code>$value</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="1">
+    <MixedInferredReturnType>
       <code>UploadedFileInterface|UploadedFileInterface[]</code>
     </MixedInferredReturnType>
-    <MixedReturnStatement occurrences="2">
-      <code>$filter-&gt;filter($value)</code>
+    <MixedReturnStatement>
+      <code><![CDATA[$filter->filter($value)]]></code>
       <code>$value</code>
     </MixedReturnStatement>
-    <MixedReturnTypeCoercion occurrences="1">
+    <MixedReturnTypeCoercion>
       <code>$newValue</code>
     </MixedReturnTypeCoercion>
-    <MoreSpecificImplementedParamType occurrences="1">
+    <MoreSpecificImplementedParamType>
       <code>$rawValue</code>
     </MoreSpecificImplementedParamType>
   </file>
   <file src="src/Input.php">
-    <DocblockTypeContradiction occurrences="1">
-      <code>is_array($this-&gt;errorMessage)</code>
+    <DocblockTypeContradiction>
+      <code><![CDATA[is_array($this->errorMessage)]]></code>
     </DocblockTypeContradiction>
-    <ImplementedReturnTypeMismatch occurrences="1">
+    <ImplementedReturnTypeMismatch>
       <code>null|string</code>
     </ImplementedReturnTypeMismatch>
-    <InvalidPropertyAssignmentValue occurrences="1">
-      <code>$this-&gt;prepareRequiredValidationFailureMessage()</code>
+    <InvalidPropertyAssignmentValue>
+      <code><![CDATA[$this->prepareRequiredValidationFailureMessage()]]></code>
     </InvalidPropertyAssignmentValue>
-    <MixedArgument occurrences="1">
-      <code>$notEmpty-&gt;getTranslatorTextDomain()</code>
+    <MixedArgument>
+      <code><![CDATA[$notEmpty->getTranslatorTextDomain()]]></code>
     </MixedArgument>
-    <MixedAssignment occurrences="2">
+    <MixedAssignment>
       <code>$translator</code>
       <code>$value</code>
     </MixedAssignment>
-    <PossiblyUndefinedMethod occurrences="3">
+    <PossiblyUndefinedMethod>
       <code>getOption</code>
       <code>getTranslator</code>
       <code>getTranslatorTextDomain</code>
     </PossiblyUndefinedMethod>
-    <RedundantCastGivenDocblockType occurrences="4">
+    <RedundantCastGivenDocblockType>
       <code>(bool) $allowEmpty</code>
       <code>(bool) $breakOnFailure</code>
       <code>(bool) $continueIfEmpty</code>
@@ -220,26 +220,29 @@
     </RedundantCastGivenDocblockType>
   </file>
   <file src="src/InputFilter.php">
-    <PossiblyInvalidArgument occurrences="1">
+    <MixedArgumentTypeCoercion>
+      <code>$input</code>
+    </MixedArgumentTypeCoercion>
+    <PossiblyInvalidArgument>
       <code>$input</code>
     </PossiblyInvalidArgument>
   </file>
   <file src="src/InputFilterAbstractServiceFactory.php">
-    <DeprecatedInterface occurrences="1">
+    <DeprecatedInterface>
       <code>InputFilterAbstractServiceFactory</code>
     </DeprecatedInterface>
-    <MixedArgument occurrences="1">
+    <MixedArgument>
       <code>$config</code>
     </MixedArgument>
-    <MixedArrayAccess occurrences="2">
-      <code>$allConfig['input_filter_specs']</code>
-      <code>$allConfig['input_filter_specs'][$rName]</code>
+    <MixedArrayAccess>
+      <code><![CDATA[$allConfig['input_filter_specs']]]></code>
+      <code><![CDATA[$allConfig['input_filter_specs'][$rName]]]></code>
     </MixedArrayAccess>
-    <MixedAssignment occurrences="2">
+    <MixedAssignment>
       <code>$allConfig</code>
       <code>$config</code>
     </MixedAssignment>
-    <ParamNameMismatch occurrences="6">
+    <ParamNameMismatch>
       <code>$cName</code>
       <code>$container</code>
       <code>$container</code>
@@ -249,124 +252,156 @@
     </ParamNameMismatch>
   </file>
   <file src="src/InputFilterPluginManager.php">
-    <MethodSignatureMismatch occurrences="2">
+    <DeprecatedInterface>
+      <code>null|ConfigInterface|ContainerInterface</code>
+    </DeprecatedInterface>
+    <MethodSignatureMismatch>
       <code>InputFilterPluginManager</code>
       <code>InputFilterPluginManager</code>
     </MethodSignatureMismatch>
-    <NonInvariantDocblockPropertyType occurrences="1">
+    <MethodSignatureMustProvideReturnType>
+      <code>Plu</code>
+    </MethodSignatureMustProvideReturnType>
+    <NonInvariantDocblockPropertyType>
       <code>$factories</code>
     </NonInvariantDocblockPropertyType>
-    <PropertyTypeCoercion occurrences="2">
-      <code>$this-&gt;initializers</code>
-      <code>$this-&gt;initializers</code>
+    <PropertyTypeCoercion>
+      <code><![CDATA[$this->initializers]]></code>
+      <code><![CDATA[$this->initializers]]></code>
     </PropertyTypeCoercion>
   </file>
   <file src="src/InputFilterPluginManagerFactory.php">
-    <DeprecatedInterface occurrences="1">
+    <DeprecatedClass>
+      <code><![CDATA[new Config($config['input_filters'])]]></code>
+    </DeprecatedClass>
+    <DeprecatedInterface>
       <code>InputFilterPluginManagerFactory</code>
     </DeprecatedInterface>
-    <ParamNameMismatch occurrences="1">
+    <ParamNameMismatch>
       <code>$container</code>
     </ParamNameMismatch>
   </file>
   <file src="src/Module.php">
-    <UndefinedDocblockClass occurrences="1">
+    <UndefinedDocblockClass>
       <code>ModuleManager</code>
     </UndefinedDocblockClass>
   </file>
   <file src="src/OptionalInputFilter.php">
-    <ImplementedReturnTypeMismatch occurrences="2">
-      <code>array&lt;string, mixed&gt;|null</code>
-      <code>array&lt;string, mixed&gt;|null</code>
+    <ImplementedReturnTypeMismatch>
+      <code><![CDATA[array<string, mixed>|null]]></code>
+      <code><![CDATA[array<string, mixed>|null]]></code>
     </ImplementedReturnTypeMismatch>
   </file>
   <file src="test/ArrayInputTest.php">
-    <ArgumentTypeCoercion occurrences="1">
+    <ArgumentTypeCoercion>
       <code>$valueMap</code>
     </ArgumentTypeCoercion>
-    <ImplementedReturnTypeMismatch occurrences="2">
+    <ImplementedReturnTypeMismatch>
+      <code><![CDATA[array<string, array{
+     *     0: bool,
+     *     1: string[],
+     *     2: string[],
+     *     3: bool,
+     *     4: string[]
+     * }>]]></code>
       <code>string[]</code>
     </ImplementedReturnTypeMismatch>
-    <InvalidReturnStatement occurrences="1">
+    <InvalidReturnStatement>
       <code>$dataSets</code>
     </InvalidReturnStatement>
-    <InvalidReturnType occurrences="1"/>
-    <MissingClosureParamType occurrences="3">
+    <InvalidReturnType>
+      <code><![CDATA[iterable<string, array{
+     *     raw: list<null|string|array>,
+     *     filtered: null|string|array
+     * }>]]></code>
+    </InvalidReturnType>
+    <MissingClosureParamType>
       <code>$set</code>
       <code>$set</code>
       <code>$set</code>
     </MissingClosureParamType>
-    <MixedArgument occurrences="1">
-      <code>$this-&gt;input-&gt;getValue()</code>
+    <MixedArgument>
+      <code><![CDATA[$this->input->getValue()]]></code>
     </MixedArgument>
-    <MixedArrayAccess occurrences="5">
-      <code>$set['raw']</code>
-      <code>$set['raw']</code>
+    <MixedArrayAccess>
+      <code><![CDATA[$set['raw']]]></code>
+      <code><![CDATA[$set['raw']]]></code>
       <code>$set[1]</code>
       <code>$set[2]</code>
       <code>$set[4]</code>
     </MixedArrayAccess>
-    <MixedArrayAssignment occurrences="5">
-      <code>$set['raw']</code>
-      <code>$set['raw']</code>
+    <MixedArrayAssignment>
+      <code><![CDATA[$set['raw']]]></code>
+      <code><![CDATA[$set['raw']]]></code>
       <code>$set[1]</code>
       <code>$set[2]</code>
       <code>$set[4]</code>
     </MixedArrayAssignment>
-    <MixedAssignment occurrences="4">
+    <MixedAssignment>
       <code>$value</code>
       <code>$values[0]</code>
       <code>$values[0]</code>
       <code>$values[1]</code>
     </MixedAssignment>
-    <MixedReturnTypeCoercion occurrences="4">
+    <MixedReturnTypeCoercion>
       <code>$dataSets</code>
       <code>$dataSets</code>
+      <code><![CDATA[array<string, array{
+     *     0: bool,
+     *     1: string[],
+     *     2: string[],
+     *     3: bool,
+     *     4: string[]
+     * }>]]></code>
+      <code><![CDATA[array<string, array{
+     *     raw: list<bool|int|float|string|list<string>|object>,
+     *     filtered:  bool|int|float|string|list<string>|object
+     * }>]]></code>
     </MixedReturnTypeCoercion>
-    <RedundantCondition occurrences="2">
+    <RedundantCondition>
       <code>isArray</code>
       <code>isArray</code>
     </RedundantCondition>
   </file>
   <file src="test/BaseInputFilterTest.php">
-    <InvalidArgument occurrences="1">
-      <code>['nested' =&gt; ['nested-input1', 'nested-input2']]</code>
+    <InvalidArgument>
+      <code><![CDATA[['nested' => ['nested-input1', 'nested-input2']]]]></code>
     </InvalidArgument>
-    <InvalidDocblock occurrences="1">
+    <InvalidDocblock>
       <code>public function addMethodArgumentsProvider(): array</code>
     </InvalidDocblock>
-    <MissingClosureParamType occurrences="2">
+    <MissingClosureParamType>
       <code>$inputTypeData</code>
       <code>$inputTypeData</code>
     </MissingClosureParamType>
-    <MissingClosureReturnType occurrences="2">
-      <code>static fn($inputTypeData) =&gt; $inputTypeData[1]</code>
-      <code>static fn($inputTypeData) =&gt; $inputTypeData[2]</code>
+    <MissingClosureReturnType>
+      <code><![CDATA[static fn($inputTypeData) => $inputTypeData[1]]]></code>
+      <code><![CDATA[static fn($inputTypeData) => $inputTypeData[2]]]></code>
     </MissingClosureReturnType>
-    <MixedArgument occurrences="4">
-      <code>$dataTypes['Traversable']($data)</code>
+    <MixedArgument>
+      <code><![CDATA[$dataTypes['Traversable']($data)]]></code>
       <code>$input</code>
       <code>$set[5]</code>
       <code>$set[6]</code>
     </MixedArgument>
-    <MixedArgumentTypeCoercion occurrences="3">
+    <MixedArgumentTypeCoercion>
       <code>$msg</code>
       <code>$msg</code>
       <code>$name</code>
     </MixedArgumentTypeCoercion>
-    <MixedArrayAccess occurrences="5">
-      <code>$filter1-&gt;getValues()['nested']['nestedField1']</code>
-      <code>$filter1-&gt;getValues()['nested']['nestedField1']</code>
-      <code>$filter1-&gt;getValues()['nested']['nestedField1']</code>
+    <MixedArrayAccess>
+      <code><![CDATA[$filter1->getValues()['nested']['nestedField1']]]></code>
+      <code><![CDATA[$filter1->getValues()['nested']['nestedField1']]]></code>
+      <code><![CDATA[$filter1->getValues()['nested']['nestedField1']]]></code>
       <code>$inputTypeData[1]</code>
       <code>$inputTypeData[2]</code>
     </MixedArrayAccess>
-    <MixedArrayAssignment occurrences="3">
+    <MixedArrayAssignment>
       <code>$set[0][$name]</code>
       <code>$set[5][$name]</code>
       <code>$set[6][$name]</code>
     </MixedArrayAssignment>
-    <MixedAssignment occurrences="9">
+    <MixedAssignment>
       <code>$expectedRawValue</code>
       <code>$expectedValue</code>
       <code>$input</code>
@@ -377,83 +412,123 @@
       <code>$tmpTemplate[2]</code>
       <code>$tmpTemplate[3]</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="1"/>
-    <MixedReturnTypeCoercion occurrences="2">
+    <MixedInferredReturnType>
+      <code><![CDATA[<string, array{
+     *     0: InputInterface,
+     *     1: null|string,
+     *     2: null|string,
+     *     3: MockObject&InputInterface
+     * }>]]></code>
+    </MixedInferredReturnType>
+    <MixedReturnTypeCoercion>
       <code>$dataSets</code>
+      <code><![CDATA[array<string, array{
+     *     0: array<string, InputInterface|InputFilterInterface|iterable>,
+     *     1: iterable<mixed>,
+     *     2: array<string, mixed>,
+     *     3: array<string, mixed>,
+     *     4: bool,
+     *     5: list<InputInterface>,
+     *     6: list<InputInterface>,
+     *     7: string[]
+     * }>]]></code>
     </MixedReturnTypeCoercion>
-    <PossiblyInvalidArgument occurrences="3">
+    <PossiblyInvalidArgument>
       <code>$input</code>
       <code>$input</code>
       <code>$input</code>
     </PossiblyInvalidArgument>
-    <PossiblyNullArgument occurrences="5">
+    <PossiblyNullArgument>
       <code>$expectedInputName</code>
       <code>$expectedInputName</code>
       <code>$expectedInputName</code>
       <code>$expectedInputName</code>
       <code>$expectedInputName</code>
     </PossiblyNullArgument>
-    <PossiblyUndefinedMethod occurrences="3">
+    <PossiblyUndefinedMethod>
       <code>getName</code>
       <code>getName</code>
       <code>isRequired</code>
     </PossiblyUndefinedMethod>
   </file>
   <file src="test/FactoryTest.php">
-    <PossiblyNullReference occurrences="2">
+    <PossiblyNullReference>
       <code>getPluginManager</code>
       <code>getPluginManager</code>
     </PossiblyNullReference>
-    <PossiblyUndefinedMethod occurrences="2">
+    <PossiblyUndefinedMethod>
       <code>breakOnFailure</code>
       <code>breakOnFailure</code>
     </PossiblyUndefinedMethod>
-    <UndefinedInterfaceMethod occurrences="1">
+    <UndefinedInterfaceMethod>
       <code>continueIfEmpty</code>
     </UndefinedInterfaceMethod>
   </file>
   <file src="test/FileInput/HttpServerFileInputDecoratorTest.php">
-    <ImplementedReturnTypeMismatch occurrences="1">
-      <code>array&lt;string, string&gt;</code>
+    <ImplementedReturnTypeMismatch>
+      <code><![CDATA[array<string, string>]]></code>
     </ImplementedReturnTypeMismatch>
-    <InvalidArgument occurrences="2">
-      <code>''</code>
-      <code>''</code>
+    <InvalidArgument>
+      <code><![CDATA['']]></code>
+      <code><![CDATA['']]></code>
     </InvalidArgument>
-    <InvalidReturnStatement occurrences="1">
+    <InvalidReturnStatement>
       <code>$dataSets</code>
     </InvalidReturnStatement>
-    <InvalidReturnType occurrences="1">
+    <InvalidReturnType>
       <code>iterable</code>
     </InvalidReturnType>
-    <NonInvariantDocblockPropertyType occurrences="1">
+    <NonInvariantDocblockPropertyType>
       <code>$input</code>
     </NonInvariantDocblockPropertyType>
-    <PropertyTypeCoercion occurrences="1">
-      <code>new FileInput('foo')</code>
+    <PropertyTypeCoercion>
+      <code><![CDATA[new FileInput('foo')]]></code>
     </PropertyTypeCoercion>
   </file>
   <file src="test/FileInput/PsrFileInputDecoratorTest.php">
-    <ImplementedReturnTypeMismatch occurrences="3">
+    <ImplementedReturnTypeMismatch>
       <code>UploadedFileInterface</code>
+      <code><![CDATA[iterable<string, array{
+     *     0: bool,
+     *     1: bool,
+     *     2: bool,
+     *     3: callable,
+     *     4: mixed,
+     *     5: bool,
+     *     6: string[]
+     * }>]]></code>
+      <code><![CDATA[iterable<string, array{
+     *     raw: UploadedFileInterface|list<UploadedFileInterface>,
+     *     filtered: UploadedFileInterface
+     * }>]]></code>
     </ImplementedReturnTypeMismatch>
-    <InvalidReturnType occurrences="1"/>
-    <NonInvariantDocblockPropertyType occurrences="1">
+    <InvalidReturnType>
+      <code><![CDATA[iterable<string, array{
+     *     0: bool,
+     *     1: bool,
+     *     2: bool,
+     *     3: callable,
+     *     4: mixed,
+     *     5: bool,
+     *     6: string[]
+     * }>]]></code>
+    </InvalidReturnType>
+    <NonInvariantDocblockPropertyType>
       <code>$input</code>
     </NonInvariantDocblockPropertyType>
-    <PropertyTypeCoercion occurrences="1">
-      <code>new FileInput('foo')</code>
+    <PropertyTypeCoercion>
+      <code><![CDATA[new FileInput('foo')]]></code>
     </PropertyTypeCoercion>
-    <TypeDoesNotContainType occurrences="1">
+    <TypeDoesNotContainType>
       <code>$generator instanceof Generator</code>
     </TypeDoesNotContainType>
   </file>
   <file src="test/InputFilterAwareTraitTest.php">
-    <InvalidArgument occurrences="2">
+    <InvalidArgument>
       <code>InputFilterAwareTrait::class</code>
       <code>InputFilterAwareTrait::class</code>
     </InvalidArgument>
-    <MixedMethodCall occurrences="4">
+    <MixedMethodCall>
       <code>getInputFilter</code>
       <code>getInputFilter</code>
       <code>setInputFilter</code>
@@ -461,34 +536,115 @@
     </MixedMethodCall>
   </file>
   <file src="test/InputFilterPluginManagerCompatibilityTest.php">
-    <InvalidReturnType occurrences="1">
+    <InvalidReturnType>
       <code>getInstanceOf</code>
     </InvalidReturnType>
   </file>
   <file src="test/InputFilterPluginManagerTest.php">
-    <LessSpecificReturnStatement occurrences="1"/>
-    <MoreSpecificReturnType occurrences="1"/>
+    <LessSpecificReturnStatement>
+      <code><![CDATA[[
+            // Description         => [$serviceName,                  $service,                  $instanceOf]
+            'InputFilterInterface' => ['inputFilterInterfaceService', $inputFilterInterfaceMock, InputFilterInterface::class],
+            'InputInterface'       => ['inputInterfaceService',       $inputInterfaceMock,       InputInterface::class],
+        ]]]></code>
+    </LessSpecificReturnStatement>
+    <MoreSpecificReturnType>
+      <code><![CDATA[array<string, array{
+     *     0: string,
+     *     1: InputInterface,
+     *     2: class-string<InputInterface>
+     * }>]]></code>
+    </MoreSpecificReturnType>
   </file>
   <file src="test/InputFilterTest.php">
-    <ImplementedReturnTypeMismatch occurrences="1"/>
-    <LessSpecificReturnStatement occurrences="1">
+    <ImplementedReturnTypeMismatch>
+      <code><![CDATA[array<string, array{
+     *     0: array|Traversable,
+     *     1: string,
+     *     2: Input
+     * }>]]></code>
+    </ImplementedReturnTypeMismatch>
+    <LessSpecificReturnStatement>
       <code>$dataSets</code>
     </LessSpecificReturnStatement>
-    <MoreSpecificReturnType occurrences="1"/>
-    <NonInvariantDocblockPropertyType occurrences="1">
+    <MoreSpecificReturnType>
+      <code><![CDATA[array<string, array{
+     *     0: array|Traversable,
+     *     1: string,
+     *     2: Input
+     * }>]]></code>
+    </MoreSpecificReturnType>
+    <NonInvariantDocblockPropertyType>
       <code>$inputFilter</code>
     </NonInvariantDocblockPropertyType>
-    <PossiblyInvalidArgument occurrences="1">
+    <PossiblyInvalidArgument>
       <code>$factory</code>
     </PossiblyInvalidArgument>
   </file>
   <file src="test/InputTest.php">
-    <InvalidReturnStatement occurrences="1"/>
-    <InvalidReturnType occurrences="1"/>
-    <LessSpecificReturnStatement occurrences="1">
+    <InvalidReturnStatement>
+      <code><![CDATA[[
+            // Description => [$value]
+            '"0"' => [
+                'raw'      => '0',
+                'filtered' => '0',
+            ],
+            '0'   => [
+                'raw'      => 0,
+                'filtered' => 0,
+            ],
+            '0.0' => [
+                'raw'      => 0.0,
+                'filtered' => 0.0,
+            ],
+            /* @todo enable me
+            'false' => [
+                'raw' => false,
+                'filtered' => false,
+            ],
+             */
+            'php' => [
+                'raw'      => 'php',
+                'filtered' => 'php',
+            ],
+            /* @todo enable me
+            'whitespace' => [
+                'raw' => ' ',
+                'filtered' => ' ',
+            ],
+             */
+            '1'       => [
+                'raw'      => 1,
+                'filtered' => 1,
+            ],
+            '1.0'     => [
+                'raw'      => 1.0,
+                'filtered' => 1.0,
+            ],
+            'true'    => [
+                'raw'      => true,
+                'filtered' => true,
+            ],
+            '["php"]' => [
+                'raw'      => ['php'],
+                'filtered' => ['php'],
+            ],
+            'object'  => [
+                'raw'      => new stdClass(),
+                'filtered' => new stdClass(),
+            ],
+        ]]]></code>
+    </InvalidReturnStatement>
+    <InvalidReturnType>
+      <code><![CDATA[array<string, array{
+     *     raw: mixed,
+     *     filtered: mixed,
+     * }>]]></code>
+    </InvalidReturnType>
+    <LessSpecificReturnStatement>
       <code>array_merge($emptyValues, $mixedValues)</code>
     </LessSpecificReturnStatement>
-    <MissingClosureParamType occurrences="6">
+    <MissingClosureParamType>
       <code>$context</code>
       <code>$context</code>
       <code>$context</code>
@@ -496,27 +652,32 @@
       <code>$value</code>
       <code>$value</code>
     </MissingClosureParamType>
-    <MixedArrayAccess occurrences="2">
-      <code>$value['filtered']</code>
-      <code>$value['raw']</code>
+    <MixedArrayAccess>
+      <code><![CDATA[$value['filtered']]]></code>
+      <code><![CDATA[$value['raw']]]></code>
     </MixedArrayAccess>
-    <MixedAssignment occurrences="2">
+    <MixedAssignment>
       <code>$tmpTemplate[4]</code>
       <code>$value</code>
     </MixedAssignment>
-    <MixedMethodCall occurrences="3">
+    <MixedMethodCall>
       <code>method</code>
       <code>willReturn</code>
       <code>with</code>
     </MixedMethodCall>
-    <MoreSpecificReturnType occurrences="1"/>
-    <PossiblyInvalidArgument occurrences="1">
+    <MoreSpecificReturnType>
+      <code><![CDATA[array<string, array{
+     *     raw: bool|int|float|string|list<string>|object,
+     *     filtered:  bool|int|float|string|list<string>|object
+     * }>]]></code>
+    </MoreSpecificReturnType>
+    <PossiblyInvalidArgument>
       <code>$translator</code>
     </PossiblyInvalidArgument>
-    <PossiblyUndefinedMethod occurrences="1">
+    <PossiblyUndefinedMethod>
       <code>expects</code>
     </PossiblyUndefinedMethod>
-    <RedundantCondition occurrences="1">
+    <RedundantCondition>
       <code>isArray</code>
     </RedundantCondition>
   </file>

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -5,7 +5,11 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
-    errorBaseline="psalm-baseline.xml">
+    errorBaseline="psalm-baseline.xml"
+    findUnusedCode="true"
+    findUnusedBaselineEntry="true"
+    findUnusedPsalmSuppress="true"
+>
     <projectFiles>
         <directory name="src"/>
         <directory name="test"/>
@@ -13,31 +17,6 @@
             <directory name="vendor"/>
         </ignoreFiles>
     </projectFiles>
-
-    <issueHandlers>
-        <InternalMethod>
-            <errorLevel type="suppress">
-                <referencedMethod name="PHPUnit\Framework\MockObject\Builder\InvocationMocker::method"/>
-            </errorLevel>
-
-            <errorLevel type="suppress">
-                <referencedMethod name="PHPUnit\Framework\MockObject\Builder\InvocationMocker::willReturn"/>
-            </errorLevel>
-
-            <errorLevel type="suppress">
-                <referencedMethod name="PHPUnit\Framework\MockObject\Builder\InvocationMocker::with"/>
-            </errorLevel>
-        </InternalMethod>
-
-        <UndefinedClass>
-            <errorLevel type="suppress">
-                <referencedClass name="Zend\InputFilter\CollectionInputFilter" />
-                <referencedClass name="Zend\InputFilter\InputFilter" />
-                <referencedClass name="Zend\InputFilter\InputFilterPluginManager" />
-                <referencedClass name="Zend\InputFilter\OptionalInputFilter" />
-            </errorLevel>
-        </UndefinedClass>
-    </issueHandlers>
 
     <plugins>
         <pluginClass class="Psalm\PhpUnitPlugin\Plugin"/>

--- a/src/InputFilterAwareTrait.php
+++ b/src/InputFilterAwareTrait.php
@@ -6,7 +6,7 @@ namespace Laminas\InputFilter;
 
 trait InputFilterAwareTrait
 {
-    /** @var InputFilterInterface */
+    /** @var InputFilterInterface|null */
     protected $inputFilter;
 
     /**

--- a/src/InputFilterInterface.php
+++ b/src/InputFilterInterface.php
@@ -38,7 +38,7 @@ use Traversable;
  * }
  * @psalm-type InputFilterSpecification = array{
  *     type?: class-string<InputFilterInterface>|string,
- * }&array<array-key, InputSpecification>
+ * }&array<array-key, InputSpecification|InputFilterInterface|InputInterface>
  * @psalm-type CollectionSpecification = array{
  *     type?: class-string<InputFilterInterface>|string,
  *     input_filter?: InputFilterSpecification|InputFilterInterface,

--- a/test/ArrayInputTest.php
+++ b/test/ArrayInputTest.php
@@ -7,8 +7,9 @@ namespace LaminasTest\InputFilter;
 use Laminas\Filter\FilterChain;
 use Laminas\InputFilter\ArrayInput;
 use Laminas\InputFilter\Exception\InvalidArgumentException;
-use Laminas\Validator\NotEmpty;
+use Laminas\Validator\NotEmpty as NotEmptyValidator;
 use Laminas\Validator\ValidatorChain;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\MockObject;
 use Webmozart\Assert\Assert;
 
@@ -18,9 +19,7 @@ use function array_walk;
 use function current;
 use function is_array;
 
-/**
- * @covers \Laminas\InputFilter\ArrayInput
- */
+#[CoversClass(ArrayInput::class)]
 class ArrayInputTest extends InputTest
 {
     protected function setUp(): void
@@ -76,7 +75,7 @@ class ArrayInputTest extends InputTest
      *     4: string[]
      * }>
      */
-    public function fallbackValueVsIsValidProvider(): array
+    public static function fallbackValueVsIsValidProvider(): array
     {
         $dataSets = parent::fallbackValueVsIsValidProvider();
         Assert::isArray($dataSets);
@@ -95,7 +94,7 @@ class ArrayInputTest extends InputTest
      *     filtered: null|string|array
      * }>
      */
-    public function emptyValueProvider(): iterable
+    public static function emptyValueProvider(): iterable
     {
         $dataSets = parent::emptyValueProvider();
         Assert::isArray($dataSets);
@@ -112,7 +111,7 @@ class ArrayInputTest extends InputTest
      *     filtered:  bool|int|float|string|list<string>|object
      * }>
      */
-    public function mixedValueProvider(): array
+    public static function mixedValueProvider(): array
     {
         $dataSets = parent::mixedValueProvider();
         Assert::isArray($dataSets);
@@ -167,14 +166,11 @@ class ArrayInputTest extends InputTest
         return parent::createValidatorChainMock($valueMap, $messages);
     }
 
-    /**
-     * @param bool $isValid
-     * @param mixed $value
-     * @param mixed $context
-     * @return NotEmpty&MockObject
-     */
-    protected function createNonEmptyValidatorMock($isValid, $value, $context = null)
-    {
+    protected function createNonEmptyValidatorMock(
+        bool $isValid,
+        mixed $value,
+        mixed $context = null,
+    ): NotEmptyValidator&MockObject {
         // ArrayInput validates per each array value
         if (is_array($value)) {
             $value = current($value);

--- a/test/BaseInputFilterTest.php
+++ b/test/BaseInputFilterTest.php
@@ -12,6 +12,10 @@ use Laminas\InputFilter\Input;
 use Laminas\InputFilter\InputFilterInterface;
 use Laminas\InputFilter\InputInterface;
 use Laminas\InputFilter\UnfilteredDataInterface;
+use LaminasTest\InputFilter\TestAsset\InputFilterInterfaceStub;
+use LaminasTest\InputFilter\TestAsset\InputInterfaceStub;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use ReflectionObject;
@@ -28,9 +32,7 @@ use function sprintf;
 
 use const JSON_THROW_ON_ERROR;
 
-/**
- * @covers \Laminas\InputFilter\BaseInputFilter
- */
+#[CoversClass(BaseInputFilter::class)]
 class BaseInputFilterTest extends TestCase
 {
     /** @var BaseInputFilter */
@@ -207,9 +209,8 @@ class BaseInputFilterTest extends TestCase
 
     /**
      * Verify the state of the input filter is the desired after change it using the method `add()`
-     *
-     * @dataProvider addMethodArgumentsProvider
      */
+    #[DataProvider('addMethodArgumentsProvider')]
     public function testAddHasGet(
         InputInterface|InputFilterInterface|iterable $input,
         ?string $name,
@@ -236,9 +237,8 @@ class BaseInputFilterTest extends TestCase
 
     /**
      * Verify the state of the input filter is the desired after change it using the method `add()` and `remove()`
-     *
-     * @dataProvider addMethodArgumentsProvider
      */
+    #[DataProvider('addMethodArgumentsProvider')]
     public function testAddRemove(
         InputInterface|InputFilterInterface|iterable $input,
         ?string $name,
@@ -268,9 +268,7 @@ class BaseInputFilterTest extends TestCase
         self::assertEquals('foo', $foo->getName(), 'Input name should not change');
     }
 
-    /**
-     * @dataProvider inputProvider
-     */
+    #[DataProvider('inputProvider')]
     public function testReplace(
         InputInterface|InputFilterInterface|iterable $input,
         ?string $inputName,
@@ -292,7 +290,6 @@ class BaseInputFilterTest extends TestCase
     }
 
     /**
-     * @dataProvider setDataArgumentsProvider
      * @param array<string, InputInterface|InputFilterInterface|iterable> $inputs
      * @param iterable<mixed> $data
      * @param array<string, mixed> $expectedRawValues
@@ -301,6 +298,7 @@ class BaseInputFilterTest extends TestCase
      * @param list<InputInterface> $expectedValidInputs
      * @param string[] $expectedMessages
      */
+    #[DataProvider('setDataArgumentsProvider')]
     public function testSetDataAndGetRawValueGetValue(
         array $inputs,
         iterable $data,
@@ -351,7 +349,6 @@ class BaseInputFilterTest extends TestCase
     }
 
     /**
-     * @dataProvider setDataArgumentsProvider
      * @param array<string, InputInterface|InputFilterInterface|iterable> $inputs
      * @param iterable<mixed> $data
      * @param array<string, mixed> $expectedRawValues
@@ -360,6 +357,7 @@ class BaseInputFilterTest extends TestCase
      * @param list<InputInterface> $expectedValidInputs
      * @param string[] $expectedMessages
      */
+    #[DataProvider('setDataArgumentsProvider')]
     public function testSetTraversableDataAndGetRawValueGetValue(
         array $inputs,
         iterable $data,
@@ -436,7 +434,7 @@ class BaseInputFilterTest extends TestCase
      *     2: array<string, string>|string
      * }>
      */
-    public function contextProvider(): array
+    public static function contextProvider(): array
     {
         $data             = ['fooInput' => 'fooValue'];
         $traversableData  = new ArrayObject(['fooInput' => 'fooValue']);
@@ -451,15 +449,15 @@ class BaseInputFilterTest extends TestCase
     }
 
     /**
-     * @dataProvider contextProvider
      * @param iterable<array-key, mixed> $data
      * @param string|array<string, string> $expectedContext
      */
+    #[DataProvider('contextProvider')]
     public function testValidationContext($data, ?string $customContext, $expectedContext): void
     {
         $filter = $this->inputFilter;
 
-        $input = $this->createInputInterfaceMock('fooInput', true, true, $expectedContext);
+        $input = self::createInputInterfaceMock('fooInput', true, true, $expectedContext);
         $filter->add($input, 'fooInput');
 
         $filter->setData($data);
@@ -476,7 +474,7 @@ class BaseInputFilterTest extends TestCase
         $expectedContext = ['fooInput' => 'fooRawValue'];
         $filter          = $this->inputFilter;
 
-        $input = $this->createInputInterfaceMock('fooInput', true, true, $expectedContext, 'fooRawValue');
+        $input = self::createInputInterfaceMock('fooInput', true, true, $expectedContext, 'fooRawValue');
         $filter->add($input, 'fooInput');
 
         $filter->setData($data);
@@ -496,8 +494,8 @@ class BaseInputFilterTest extends TestCase
             'inputRequired' => 'inputRequiredValue',
             'inputOptional' => null,
         ];
-        $inputRequired   = $this->createInputInterfaceMock('fooInput', true, true, $expectedContext);
-        $inputOptional   = $this->createInputInterfaceMock('fooInput', false);
+        $inputRequired   = self::createInputInterfaceMock('fooInput', true, true, $expectedContext);
+        $inputOptional   = self::createInputInterfaceMock('fooInput', false);
 
         $filter = $this->inputFilter;
         $filter->add($inputRequired, 'inputRequired');
@@ -544,9 +542,7 @@ class BaseInputFilterTest extends TestCase
         );
     }
 
-    /**
-     * @dataProvider unknownScenariosProvider
-     */
+    #[DataProvider('unknownScenariosProvider')]
     public function testUnknown(array $inputs, array $data, bool $hasUnknown, array $getUnknown): void
     {
         $inputFilter = $this->inputFilter;
@@ -705,16 +701,16 @@ class BaseInputFilterTest extends TestCase
     }
 
     /**
-     * @psalm-return<string, array{
+     * @psalm-return array<string, array{
      *     0: InputInterface,
      *     1: null|string,
      *     2: null|string,
-     *     3: MockObject&InputInterface
+     *     3: InputInterface,
      * }>
      */
-    public function addMethodArgumentsProvider(): array
+    public static function addMethodArgumentsProvider(): array
     {
-        $inputTypes = $this->inputProvider();
+        $inputTypes = static::inputProvider();
 
         $inputName = static fn($inputTypeData) => $inputTypeData[1];
 
@@ -759,7 +755,7 @@ class BaseInputFilterTest extends TestCase
      *     7: string[]
      * }>
      */
-    public function setDataArgumentsProvider(): array
+    public static function setDataArgumentsProvider(): array
     {
         $iAName    = 'InputA';
         $iBName    = 'InputB';
@@ -783,7 +779,7 @@ class BaseInputFilterTest extends TestCase
 
         /**
          * @param array<string, string> $msg
-         * @return callable(): InputInterface&MockObject
+         * @return callable(): InputInterface
          */
         $input = function (
             string $iName,
@@ -795,7 +791,7 @@ class BaseInputFilterTest extends TestCase
             $vRaw,
             $vFiltered
         ): callable {
-            return fn(array|null|string $context): InputInterface => $this->createInputInterfaceMock(
+            return fn(array|null|string $context): InputInterface => self::createInputInterfaceMock(
                 $iName,
                 $required,
                 $isValid,
@@ -808,10 +804,10 @@ class BaseInputFilterTest extends TestCase
         };
 
         $inputFilter = fn(bool $isValid, array $msg = []): callable =>
-            function (array|null|string $context) use ($isValid, $vRaw, $vFiltered, $msg): InputFilterInterface {
+            function () use ($isValid, $vRaw, $vFiltered, $msg): InputFilterInterface {
                 $vRaw      = ['fooInput' => $vRaw];
                 $vFiltered = ['fooInput' => $vFiltered];
-                return $this->createInputFilterInterfaceMock($isValid, $context, $vRaw, $vFiltered, $msg);
+                return BaseInputFilterTest::createInputFilterInterfaceMock($isValid, $vRaw, $vFiltered, $msg);
             };
 
         // phpcs:disable Generic.Formatting.MultipleStatementAlignment.NotSame,Generic.Functions.FunctionCallArgumentSpacing.TooMuchSpaceAfterComma,WebimpressCodingStandard.WhiteSpace.CommaSpacing.SpacingAfterComma
@@ -891,9 +887,9 @@ class BaseInputFilterTest extends TestCase
      *     3: array<string, string>
      * }>
      */
-    public function unknownScenariosProvider(): array
+    public static function unknownScenariosProvider(): array
     {
-        $inputA          = $this->createInputInterfaceMock('inputA', true);
+        $inputA          = self::createInputInterfaceMock('inputA', true);
         $dataA           = ['inputA' => 'foo'];
         $dataUnknown     = ['inputUnknown' => 'unknownValue'];
         $dataAAndUnknown = array_merge($dataA, $dataUnknown);
@@ -913,15 +909,15 @@ class BaseInputFilterTest extends TestCase
 
     /**
      * @psalm-return array<string, array{
-     *     0: MockObject&InputInterface|MockObject&InputFilterInterface,
+     *     0: InputInterface|InputFilterInterface,
      *     1: null|string,
-     *     2: MockObject&InputInterface|MockObject&InputFilterInterface,
+     *     2: InputInterface|InputFilterInterface,
      * }>
      */
-    public function inputProvider(): array
+    public static function inputProvider(): array
     {
-        $input       = $this->createInputInterfaceMock('fooInput', null);
-        $inputFilter = $this->createInputFilterInterfaceMock();
+        $input       = self::createInputInterfaceMock('fooInput', null);
+        $inputFilter = self::createInputFilterInterfaceMock();
 
         // phpcs:disable WebimpressCodingStandard.WhiteSpace.CommaSpacing.SpaceBeforeComma
         return [
@@ -935,41 +931,19 @@ class BaseInputFilterTest extends TestCase
     /**
      * @param array<string, mixed> $getRawValues
      * @param array<string, mixed> $getValues
-     * @param string[] $getMessages
-     * @return MockObject&InputFilterInterface
+     * @param array<array-key, array<string, string>> $getMessages
      */
-    protected function createInputFilterInterfaceMock(
+    private static function createInputFilterInterfaceMock(
         bool|null $isValid = null,
-        mixed $context = null,
         array $getRawValues = [],
         array $getValues = [],
         array $getMessages = []
-    ) {
-        /** @var InputFilterInterface&MockObject $inputFilter */
-        $inputFilter = $this->createMock(InputFilterInterface::class);
-        $inputFilter->method('getRawValues')
-            ->willReturn($getRawValues);
-        $inputFilter->method('getValues')
-            ->willReturn($getValues);
-        if (($isValid === false) || ($isValid === true)) {
-            $inputFilter->expects(self::once())
-                ->method('isValid')
-                ->willReturn($isValid);
-        } else {
-            $inputFilter->expects(self::never())
-                ->method('isValid');
-        }
-        $inputFilter->method('getMessages')
-            ->willReturn($getMessages);
-
-        return $inputFilter;
+    ): InputFilterInterfaceStub {
+        return new InputFilterInterfaceStub($isValid, $getRawValues, $getValues, $getMessages);
     }
 
-    /**
-     * @param string[] $getMessages
-     * @return MockObject&InputInterface
-     */
-    protected function createInputInterfaceMock(
+    /** @param array<string, string> $getMessages */
+    private static function createInputInterfaceMock(
         string $name,
         bool|null $isRequired,
         bool|null $isValid = null,
@@ -978,33 +952,17 @@ class BaseInputFilterTest extends TestCase
         mixed $getValue = null,
         array $getMessages = [],
         bool $breakOnFailure = false
-    ) {
-        /** @var InputInterface&MockObject $input */
-        $input = $this->createMock(InputInterface::class);
-        $input->method('getName')
-            ->willReturn($name);
-        $input->method('isRequired')
-            ->willReturn($isRequired);
-        $input->method('getRawValue')
-            ->willReturn($getRawValue);
-        $input->method('getValue')
-            ->willReturn($getValue);
-        $input->method('breakOnFailure')
-            ->willReturn($breakOnFailure);
-        if (($isValid === false) || ($isValid === true)) {
-            $input->expects(self::any())
-                ->method('isValid')
-                ->with($context)
-                ->willReturn($isValid);
-        } else {
-            $input->expects(self::never())
-                ->method('isValid')
-                ->with($context);
-        }
-        $input->method('getMessages')
-            ->willReturn($getMessages);
-
-        return $input;
+    ): InputInterfaceStub {
+        return new InputInterfaceStub(
+            $name,
+            $isRequired,
+            $isValid,
+            $context,
+            $getRawValue,
+            $getValue,
+            $getMessages,
+            $breakOnFailure,
+        );
     }
 
     /**

--- a/test/BaseInputFilterTest.php
+++ b/test/BaseInputFilterTest.php
@@ -140,7 +140,6 @@ class BaseInputFilterTest extends TestCase
 
         $r = new ReflectionObject($inputFilter);
         $p = $r->getProperty('validationGroup');
-        $p->setAccessible(true);
         self::assertEquals(['fooInput'], $p->getValue($inputFilter));
     }
 
@@ -164,7 +163,6 @@ class BaseInputFilterTest extends TestCase
 
         $r = new ReflectionObject($inputFilter);
         $p = $r->getProperty('validationGroup');
-        $p->setAccessible(true);
         self::assertEquals(['nested'], $p->getValue($inputFilter));
         self::assertEquals(['nested-input1', 'nested-input2'], $p->getValue($nestedInputFilter));
     }

--- a/test/CollectionInputFilterTest.php
+++ b/test/CollectionInputFilterTest.php
@@ -15,6 +15,9 @@ use Laminas\InputFilter\InputFilterInterface;
 use Laminas\Validator\Between;
 use Laminas\Validator\Digits;
 use Laminas\Validator\NotEmpty;
+use LaminasTest\InputFilter\TestAsset\InputFilterInterfaceStub;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use stdClass;
@@ -26,9 +29,9 @@ use function json_encode;
 use const JSON_THROW_ON_ERROR;
 
 /**
- * @covers \Laminas\InputFilter\CollectionInputFilter
  * @psalm-import-type InputFilterSpecification from InputFilterInterface
  */
+#[CoversClass(CollectionInputFilter::class)]
 class CollectionInputFilterTest extends TestCase
 {
     private CollectionInputFilter $inputFilter;
@@ -51,10 +54,10 @@ class CollectionInputFilterTest extends TestCase
     }
 
     /**
-     * @dataProvider inputFilterProvider
      * @param InputFilterSpecification|Traversable|BaseInputFilter $inputFilter
      * @param class-string $expectedType
      */
+    #[DataProvider('inputFilterProvider')]
     public function testSetInputFilter(mixed $inputFilter, string $expectedType): void
     {
         $this->inputFilter->setInputFilter($inputFilter);
@@ -67,18 +70,14 @@ class CollectionInputFilterTest extends TestCase
         self::assertInstanceOf(BaseInputFilter::class, $this->inputFilter->getInputFilter());
     }
 
-    /**
-     * @dataProvider isRequiredProvider
-     */
+    #[DataProvider('isRequiredProvider')]
     public function testSetRequired(bool $value): void
     {
         $this->inputFilter->setIsRequired($value);
         self::assertEquals($value, $this->inputFilter->getIsRequired());
     }
 
-    /**
-     * @dataProvider countVsDataProvider
-     */
+    #[DataProvider('countVsDataProvider')]
     public function testSetCount(?int $count, ?array $data, int $expectedCount): void
     {
         if ($count !== null) {
@@ -108,9 +107,7 @@ class CollectionInputFilterTest extends TestCase
         self::assertEquals(1, $this->inputFilter->getCount());
     }
 
-    /**
-     * @dataProvider dataVsValidProvider
-     */
+    #[DataProvider('dataVsValidProvider')]
     public function testDataVsValid(
         bool $required,
         ?int $count,
@@ -150,7 +147,7 @@ class CollectionInputFilterTest extends TestCase
      *     7: array
      * }>
      */
-    public function dataVsValidProvider(): array
+    public static function dataVsValidProvider(): array
     {
         $dataRaw      = [
             'fooInput' => 'fooRaw',
@@ -166,11 +163,11 @@ class CollectionInputFilterTest extends TestCase
         $colMessages  = [$errorMessage];
 
         $invalidIF  = fn(): BaseInputFilter =>
-            $this->createBaseInputFilterMock(false, $dataRaw, $dataFiltered, $errorMessage);
+            new InputFilterInterfaceStub(false, $dataRaw, $dataFiltered, $errorMessage);
         $validIF    = fn(): BaseInputFilter =>
-            $this->createBaseInputFilterMock(true, $dataRaw, $dataFiltered);
+            new InputFilterInterfaceStub(true, $dataRaw, $dataFiltered);
         $noValidIF  = fn(): BaseInputFilter =>
-            $this->createBaseInputFilterMock(null, $dataRaw, $dataFiltered);
+            new InputFilterInterfaceStub(null, $dataRaw, $dataFiltered);
         $isRequired = true;
 
         // @phpcs:disable Generic.Files.LineLength.TooLong,WebimpressCodingStandard.Arrays.Format.SingleLineSpaceBefore,WebimpressCodingStandard.WhiteSpace.CommaSpacing.SpaceBeforeComma
@@ -222,7 +219,7 @@ class CollectionInputFilterTest extends TestCase
     }
 
     /** @psalm-return array<string, array{count: null|int, isValid: bool}> */
-    public function dataNestingCollection(): array
+    public static function dataNestingCollection(): array
     {
         return [
             'count not specified' => [
@@ -248,9 +245,7 @@ class CollectionInputFilterTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider dataNestingCollection
-     */
+    #[DataProvider('dataNestingCollection')]
     public function testNestingCollectionCountCached(?int $count, bool $expectedIsValid): void
     {
         $firstInputFilter = new InputFilter();
@@ -305,7 +300,7 @@ class CollectionInputFilterTest extends TestCase
      *     1: class-string<InputFilterInterface>
      * }>
      */
-    public function inputFilterProvider(): array
+    public static function inputFilterProvider(): array
     {
         $baseInputFilter = new BaseInputFilter();
 
@@ -330,7 +325,7 @@ class CollectionInputFilterTest extends TestCase
      *     2: int
      * }>
      */
-    public function countVsDataProvider(): array
+    public static function countVsDataProvider(): array
     {
         $data0 = [];
         $data1 = [['A' => 'a']];
@@ -356,7 +351,7 @@ class CollectionInputFilterTest extends TestCase
     }
 
     /** @psalm-return array<string, array{0: bool}> */
-    public function isRequiredProvider(): array
+    public static function isRequiredProvider(): array
     {
         return [
             'enabled'  => [true],
@@ -446,7 +441,7 @@ class CollectionInputFilterTest extends TestCase
     }
 
     /** @psalm-return array<string, array{0: array}> */
-    public function invalidCollections(): array
+    public static function invalidCollections(): array
     {
         return [
             'null'       => [[['this' => 'is valid'], null]],
@@ -461,9 +456,7 @@ class CollectionInputFilterTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider invalidCollections
-     */
+    #[DataProvider('invalidCollections')]
     public function testSettingDataAsArrayWithInvalidCollectionsRaisesException(array $data): void
     {
         $collectionInputFilter = $this->inputFilter;
@@ -473,9 +466,7 @@ class CollectionInputFilterTest extends TestCase
         $collectionInputFilter->setData($data);
     }
 
-    /**
-     * @dataProvider invalidCollections
-     */
+    #[DataProvider('invalidCollections')]
     public function testSettingDataAsTraversableWithInvalidCollectionsRaisesException(array $data): void
     {
         $collectionInputFilter = $this->inputFilter;
@@ -487,7 +478,7 @@ class CollectionInputFilterTest extends TestCase
     }
 
     /** @psalm-return array<string, array{0: mixed}> */
-    public function invalidDataType(): array
+    public static function invalidDataType(): array
     {
         return [
             'null'       => [null],
@@ -502,9 +493,7 @@ class CollectionInputFilterTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider invalidDataType
-     */
+    #[DataProvider('invalidDataType')]
     public function testSettingDataWithNonArrayNonTraversableRaisesException(mixed $data): void
     {
         $collectionInputFilter = $this->inputFilter;
@@ -817,9 +806,7 @@ class CollectionInputFilterTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider contextProvider
-     */
+    #[DataProvider('contextProvider')]
     public function testValidationContext(array $data, ?array $customContext, ?array $expectedContext): void
     {
         $baseInputFilter = $this->createMock(BaseInputFilter::class);

--- a/test/FactoryTest.php
+++ b/test/FactoryTest.php
@@ -49,7 +49,6 @@ class FactoryTest extends TestCase
             ->with($type)
             ->willReturn(false);
 
-        /** @psalm-suppress MixedArgumentTypeCoercion */
         $factory = new Factory($pluginManager);
 
         $this->expectException(RuntimeException::class);
@@ -65,7 +64,6 @@ class FactoryTest extends TestCase
     {
         $pluginManager = $this->createMock(InputFilterPluginManager::class);
         $factory       = new Factory();
-        /** @psalm-suppress MixedArgumentTypeCoercion */
         $factory->setInputFilterManager($pluginManager);
         self::assertSame($pluginManager, $factory->getInputFilterManager());
     }
@@ -73,8 +71,7 @@ class FactoryTest extends TestCase
     public function testGetInputFilterManagerWhenYouConstructFactoryWithIt(): void
     {
         $pluginManager = $this->createMock(InputFilterPluginManager::class);
-        /** @psalm-suppress MixedArgumentTypeCoercion */
-        $factory = new Factory($pluginManager);
+        $factory       = new Factory($pluginManager);
         self::assertSame($pluginManager, $factory->getInputFilterManager());
     }
 
@@ -215,7 +212,6 @@ class FactoryTest extends TestCase
         $this->expectExceptionMessage(
             sprintf('"%s" can only set to inputs of type "Laminas\InputFilter\Input"', $specificationKey)
         );
-        /** @psalm-suppress ArgumentTypeCoercion */
         $factory->createInput([
             'type'            => $type,
             $specificationKey => true,

--- a/test/FactoryTest.php
+++ b/test/FactoryTest.php
@@ -871,6 +871,11 @@ class FactoryTest extends TestCase
     {
         $factory = $this->createDefaultFactory();
 
+        /**
+         * null is not acceptable as an input spec for the psalm type
+         *
+         * @psalm-suppress InvalidArgument
+         */
         $inputFilter = $factory->createInputFilter([
             'foo' => [
                 'name' => 'foo',

--- a/test/FactoryTest.php
+++ b/test/FactoryTest.php
@@ -19,15 +19,15 @@ use Laminas\InputFilter\InputProviderInterface;
 use Laminas\ServiceManager;
 use Laminas\Validator;
 use LaminasTest\InputFilter\TestAsset\CustomInput;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 
 use function sprintf;
 
-/**
- * @covers \Laminas\InputFilter\Factory
- */
+#[CoversClass(Factory::class)]
 class FactoryTest extends TestCase
 {
     public function testCreateInputWithInvalidDataTypeThrowsInvalidArgumentException(): void
@@ -184,7 +184,7 @@ class FactoryTest extends TestCase
     }
 
     /** @psalm-return array<string, array{0: 'continue_if_empty'|'fallback_value'}> */
-    public function inputTypeSpecificationProvider(): array
+    public static function inputTypeSpecificationProvider(): array
     {
         return [
             // Description => [$specificationKey]
@@ -194,9 +194,9 @@ class FactoryTest extends TestCase
     }
 
     /**
-     * @dataProvider inputTypeSpecificationProvider
      * @psalm-param 'continue_if_empty'|'fallback_value' $specificationKey
      */
+    #[DataProvider('inputTypeSpecificationProvider')]
     public function testCreateInputWithSpecificInputTypeSettingsThrowException(string $specificationKey): void
     {
         $factory = $this->createDefaultFactory();
@@ -851,9 +851,6 @@ class FactoryTest extends TestCase
         self::assertSame($inputFilterManager, $factory->getInputFilterManager());
     }
 
-    /**
-     * @covers \Laminas\InputFilter\Factory::createInput
-     */
     public function testSetsBreakChainOnFailure(): void
     {
         $factory = $this->createDefaultFactory();

--- a/test/FileInput/HttpServerFileInputDecoratorTest.php
+++ b/test/FileInput/HttpServerFileInputDecoratorTest.php
@@ -8,6 +8,7 @@ use Laminas\InputFilter\FileInput;
 use Laminas\InputFilter\FileInput\HttpServerFileInputDecorator;
 use Laminas\Validator;
 use LaminasTest\InputFilter\InputTest;
+use PHPUnit\Framework\Attributes\CoversClass;
 use Webmozart\Assert\Assert;
 
 use function json_encode;
@@ -16,10 +17,8 @@ use const JSON_THROW_ON_ERROR;
 use const UPLOAD_ERR_NO_FILE;
 use const UPLOAD_ERR_OK;
 
-/**
- * @covers \Laminas\InputFilter\FileInput\HttpServerFileInputDecorator
- * @covers \Laminas\InputFilter\FileInput
- */
+#[CoversClass(HttpServerFileInputDecorator::class)]
+#[CoversClass(FileInput::class)]
 class HttpServerFileInputDecoratorTest extends InputTest
 {
     /** @var HttpServerFileInputDecorator */
@@ -332,7 +331,7 @@ class HttpServerFileInputDecoratorTest extends InputTest
         );
     }
 
-    public function isRequiredVsAllowEmptyVsContinueIfEmptyVsIsValidProvider(): iterable
+    public static function isRequiredVsAllowEmptyVsContinueIfEmptyVsIsValidProvider(): iterable
     {
         $dataSets = parent::isRequiredVsAllowEmptyVsContinueIfEmptyVsIsValidProvider();
         Assert::isArrayAccessible($dataSets);
@@ -345,7 +344,7 @@ class HttpServerFileInputDecoratorTest extends InputTest
         return $dataSets;
     }
 
-    public function emptyValueProvider(): iterable
+    public static function emptyValueProvider(): iterable
     {
         return [
             'tmp_name' => [
@@ -383,7 +382,7 @@ class HttpServerFileInputDecoratorTest extends InputTest
         ];
     }
 
-    public function mixedValueProvider(): array
+    public static function mixedValueProvider(): array
     {
         $fooUploadErrOk = [
             'tmp_name' => 'foo',

--- a/test/FileInput/PsrFileInputDecoratorTest.php
+++ b/test/FileInput/PsrFileInputDecoratorTest.php
@@ -9,6 +9,8 @@ use Laminas\InputFilter\FileInput;
 use Laminas\InputFilter\FileInput\PsrFileInputDecorator;
 use Laminas\Validator;
 use LaminasTest\InputFilter\InputTest;
+use LaminasTest\InputFilter\TestAsset\UploadedFileInterfaceStub;
+use PHPUnit\Framework\Attributes\CoversClass;
 use Psr\Http\Message\UploadedFileInterface;
 
 use function in_array;
@@ -19,10 +21,8 @@ use const UPLOAD_ERR_CANT_WRITE;
 use const UPLOAD_ERR_NO_FILE;
 use const UPLOAD_ERR_OK;
 
-/**
- * @covers \Laminas\InputFilter\FileInput\PsrFileInputDecorator
- * @covers \Laminas\InputFilter\FileInput
- */
+#[CoversClass(PsrFileInputDecorator::class)]
+#[CoversClass(FileInput::class)]
 class PsrFileInputDecoratorTest extends InputTest
 {
     /** @var PsrFileInputDecorator */
@@ -308,8 +308,7 @@ class PsrFileInputDecoratorTest extends InputTest
         $return = $target->merge($source);
         self::assertSame($target, $return, 'merge() must return it self');
 
-        self::assertEquals(
-            true,
+        self::assertTrue(
             $target->getAutoPrependUploadValidator(),
             'getAutoPrependUploadValidator() value not match'
         );
@@ -326,7 +325,7 @@ class PsrFileInputDecoratorTest extends InputTest
      *     6: string[]
      * }>
      */
-    public function isRequiredVsAllowEmptyVsContinueIfEmptyVsIsValidProvider(): iterable
+    public static function isRequiredVsAllowEmptyVsContinueIfEmptyVsIsValidProvider(): iterable
     {
         $generator = parent::isRequiredVsAllowEmptyVsContinueIfEmptyVsIsValidProvider();
         if ($generator instanceof Generator) {
@@ -354,14 +353,10 @@ class PsrFileInputDecoratorTest extends InputTest
      *     filtered: UploadedFileInterface
      * }>
      */
-    public function emptyValueProvider(): iterable
+    public static function emptyValueProvider(): iterable
     {
         foreach (['single', 'multi'] as $type) {
-            $raw = $this->createMock(UploadedFileInterface::class);
-            $raw->expects(self::atLeast(1))
-                ->method('getError')
-                ->willReturn(UPLOAD_ERR_NO_FILE);
-
+            $raw = new UploadedFileInterfaceStub(UPLOAD_ERR_NO_FILE);
             yield $type => [
                 'raw'      => $type === 'multi'
                     ? [$raw]
@@ -377,10 +372,9 @@ class PsrFileInputDecoratorTest extends InputTest
      *     filtered: UploadedFileInterface
      * }>
      */
-    public function mixedValueProvider(): array
+    public static function mixedValueProvider(): array
     {
-        $fooUploadErrOk = $this->createMock(UploadedFileInterface::class);
-        $fooUploadErrOk->method('getError')->willReturn(UPLOAD_ERR_OK);
+        $fooUploadErrOk = new UploadedFileInterfaceStub(UPLOAD_ERR_OK);
 
         return [
             'single' => [

--- a/test/InputFilterAbstractServiceFactoryTest.php
+++ b/test/InputFilterAbstractServiceFactoryTest.php
@@ -19,13 +19,13 @@ use Laminas\Validator\ValidatorChain;
 use Laminas\Validator\ValidatorInterface;
 use Laminas\Validator\ValidatorPluginManager;
 use LaminasTest\InputFilter\TestAsset\Foo;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Depends;
 use PHPUnit\Framework\TestCase;
 
 use function call_user_func_array;
 
-/**
- * @covers \Laminas\InputFilter\InputFilterAbstractServiceFactory
- */
+#[CoversClass(InputFilterAbstractServiceFactory::class)]
 class InputFilterAbstractServiceFactoryTest extends TestCase
 {
     private ServiceManager $services;
@@ -92,9 +92,7 @@ class InputFilterAbstractServiceFactoryTest extends TestCase
         self::assertInstanceOf(InputFilterInterface::class, $filter);
     }
 
-    /**
-     * @depends testCreatesInputFilterInstance
-     */
+    #[Depends('testCreatesInputFilterInstance')]
     public function testUsesConfiguredValidationAndFilterManagerServicesWhenCreatingInputFilter(): void
     {
         $filters = new FilterPluginManager($this->services);
@@ -185,9 +183,7 @@ class InputFilterAbstractServiceFactoryTest extends TestCase
         self::assertInstanceOf(InputFilterInterface::class, $inputFilter);
     }
 
-    /**
-     * @depends testCreatesInputFilterInstance
-     */
+    #[Depends('testCreatesInputFilterInstance')]
     public function testInjectsInputFilterManagerFromServiceManager(): void
     {
         $this->services->setService('config', [

--- a/test/InputFilterAwareTraitTest.php
+++ b/test/InputFilterAwareTraitTest.php
@@ -21,7 +21,6 @@ class InputFilterAwareTraitTest extends TestCase
 
         $r = new ReflectionObject($object);
         $p = $r->getProperty('inputFilter');
-        $p->setAccessible(true);
         $this->assertNull($p->getValue($object));
 
         $inputFilter = new InputFilter();

--- a/test/InputFilterAwareTraitTest.php
+++ b/test/InputFilterAwareTraitTest.php
@@ -6,18 +6,17 @@ namespace LaminasTest\InputFilter;
 
 use Laminas\InputFilter\InputFilter;
 use Laminas\InputFilter\InputFilterAwareTrait;
+use LaminasTest\InputFilter\TestAsset\InputFilterAware;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use ReflectionObject;
 
-/**
- * @requires PHP 5.4
- * @covers \Laminas\InputFilter\InputFilterAwareTrait
- */
+#[CoversClass(InputFilterAwareTrait::class)]
 class InputFilterAwareTraitTest extends TestCase
 {
     public function testSetInputFilter(): void
     {
-        $object = $this->getObjectForTrait(InputFilterAwareTrait::class);
+        $object = new InputFilterAware();
 
         $r = new ReflectionObject($object);
         $p = $r->getProperty('inputFilter');
@@ -32,7 +31,7 @@ class InputFilterAwareTraitTest extends TestCase
 
     public function testGetInputFilter(): void
     {
-        $object = $this->getObjectForTrait(InputFilterAwareTrait::class);
+        $object = new InputFilterAware();
 
         $this->assertNull($object->getInputFilter());
 

--- a/test/InputFilterPluginManagerCompatibilityTest.php
+++ b/test/InputFilterPluginManagerCompatibilityTest.php
@@ -19,7 +19,7 @@ class InputFilterPluginManagerCompatibilityTest extends TestCase
         $this->markTestSkipped("InputFilterPluginManager accepts multiple instances");
     }
 
-    protected function getPluginManager(): InputFilterPluginManager
+    protected static function getPluginManager(): InputFilterPluginManager
     {
         return new InputFilterPluginManager(new ServiceManager());
     }

--- a/test/InputFilterPluginManagerFactoryTest.php
+++ b/test/InputFilterPluginManagerFactoryTest.php
@@ -25,7 +25,6 @@ class InputFilterPluginManagerFactoryTest extends TestCase
 
         $r = new ReflectionObject($filters);
         $p = $r->getProperty('creationContext');
-        $p->setAccessible(true);
         self::assertSame($container, $p->getValue($filters));
     }
 

--- a/test/InputFilterPluginManagerFactoryTest.php
+++ b/test/InputFilterPluginManagerFactoryTest.php
@@ -9,6 +9,8 @@ use Laminas\InputFilter\InputFilterPluginManager;
 use Laminas\InputFilter\InputFilterPluginManagerFactory;
 use Laminas\InputFilter\InputInterface;
 use Laminas\ServiceManager\ServiceLocatorInterface;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Depends;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 use ReflectionObject;
@@ -29,7 +31,7 @@ class InputFilterPluginManagerFactoryTest extends TestCase
     }
 
     /** @psalm-return array<string, array{0: class-string}> */
-    public function pluginProvider(): array
+    public static function pluginProvider(): array
     {
         return [
             'input'        => [InputInterface::class],
@@ -38,10 +40,10 @@ class InputFilterPluginManagerFactoryTest extends TestCase
     }
 
     /**
-     * @depends testFactoryReturnsPluginManager
-     * @dataProvider pluginProvider
      * @psalm-param class-string $pluginType
      */
+    #[DataProvider('pluginProvider')]
+    #[Depends('testFactoryReturnsPluginManager')]
     public function testFactoryConfiguresPluginManagerUnderContainerInterop(string $pluginType): void
     {
         $container = $this->createMock(ContainerInterface::class);

--- a/test/InputFilterPluginManagerTest.php
+++ b/test/InputFilterPluginManagerTest.php
@@ -14,21 +14,22 @@ use Laminas\InputFilter\InputFilterPluginManager;
 use Laminas\InputFilter\InputInterface;
 use Laminas\ServiceManager\AbstractPluginManager;
 use Laminas\ServiceManager\Exception\InvalidServiceException;
-use Laminas\ServiceManager\ServiceLocatorInterface;
 use Laminas\ServiceManager\ServiceManager;
 use Laminas\Validator\ValidatorChain;
 use Laminas\Validator\ValidatorPluginManager;
 use LaminasTest\InputFilter\FileInput\TestAsset\InitializableInputFilterInterface;
-use PHPUnit\Framework\MockObject\MockObject;
+use LaminasTest\InputFilter\TestAsset\InputFilterInterfaceStub;
+use LaminasTest\InputFilter\TestAsset\InputInterfaceStub;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use ReflectionObject;
+use stdClass;
 use Throwable;
 
 use function method_exists;
 
-/**
- * @covers \Laminas\InputFilter\InputFilterPluginManager
- */
+#[CoversClass(InputFilterPluginManager::class)]
 class InputFilterPluginManagerTest extends TestCase
 {
     private InputFilterPluginManager $manager;
@@ -64,13 +65,13 @@ class InputFilterPluginManagerTest extends TestCase
 
     public function testLoadingInvalidElementRaisesException(): void
     {
-        $this->manager->setInvokableClass('test', self::class);
+        $this->manager->setInvokableClass('test', stdClass::class);
         $this->expectException($this->getServiceNotFoundException());
         $this->manager->get('test');
     }
 
     /** @psalm-return array<string, array{0: string, 1: class-string<InputFilter>}> */
-    public function defaultInvokableClassesProvider(): array
+    public static function defaultInvokableClassesProvider(): array
     {
         return [
             // Description => [$alias, $expectedInstance]
@@ -80,9 +81,9 @@ class InputFilterPluginManagerTest extends TestCase
     }
 
     /**
-     * @dataProvider defaultInvokableClassesProvider
      * @psalm-param class-string $expectedInstance
      */
+    #[DataProvider('defaultInvokableClassesProvider')]
     public function testDefaultInvokableClasses(string $alias, string $expectedInstance): void
     {
         /** @var object $service */
@@ -146,10 +147,10 @@ class InputFilterPluginManagerTest extends TestCase
      *     2: class-string<InputInterface>
      * }>
      */
-    public function serviceProvider(): array
+    public static function serviceProvider(): array
     {
-        $inputFilterInterfaceMock = $this->createInputFilterInterfaceMock();
-        $inputInterfaceMock       = $this->createInputInterfaceMock();
+        $inputFilterInterfaceMock = new InputFilterInterfaceStub();
+        $inputInterfaceMock       = new InputInterfaceStub('foo', true);
 
         // phpcs:disable Generic.Files.LineLength.TooLong
         return [
@@ -160,11 +161,8 @@ class InputFilterPluginManagerTest extends TestCase
         // phpcs:enable
     }
 
-    /**
-     * @dataProvider serviceProvider
-     * @param InputInterface|InputFilterInterface $service
-     */
-    public function testGet(string $serviceName, object $service): void
+    #[DataProvider('serviceProvider')]
+    public function testGet(string $serviceName, InputInterface|InputFilterInterface $service): void
     {
         $this->manager->setService($serviceName, $service);
 
@@ -186,28 +184,6 @@ class InputFilterPluginManagerTest extends TestCase
         $this->manager->populateFactory($inputFilter);
 
         self::assertSame($this->manager, $inputFilter->getFactory()->getInputFilterManager());
-    }
-
-    /**
-     * @return MockObject&InputFilterInterface
-     */
-    protected function createInputFilterInterfaceMock()
-    {
-        /** @var InputFilterInterface&MockObject $inputFilter */
-        $inputFilter = $this->createMock(InputFilterInterface::class);
-
-        return $inputFilter;
-    }
-
-    /**
-     * @return MockObject&InputInterface
-     */
-    protected function createInputInterfaceMock()
-    {
-        /** @var InputInterface&MockObject $input */
-        $input = $this->createMock(InputInterface::class);
-
-        return $input;
     }
 
     /** @return class-string<Throwable> */

--- a/test/InputFilterPluginManagerTest.php
+++ b/test/InputFilterPluginManagerTest.php
@@ -210,17 +210,6 @@ class InputFilterPluginManagerTest extends TestCase
         return $input;
     }
 
-    /**
-     * @return MockObject&ServiceLocatorInterface
-     */
-    protected function createServiceLocatorInterfaceMock()
-    {
-        /** @var ServiceLocatorInterface&MockObject $serviceLocator */
-        $serviceLocator = $this->createMock(ServiceLocatorInterface::class);
-
-        return $serviceLocator;
-    }
-
     /** @return class-string<Throwable> */
     protected function getServiceNotFoundException(): string
     {

--- a/test/InputFilterPluginManagerTest.php
+++ b/test/InputFilterPluginManagerTest.php
@@ -49,7 +49,6 @@ class InputFilterPluginManagerTest extends TestCase
     {
         $r = new ReflectionObject($this->manager);
         $p = $r->getProperty('sharedByDefault');
-        $p->setAccessible(true);
         self::assertFalse($p->getValue($this->manager));
     }
 

--- a/test/InputFilterTest.php
+++ b/test/InputFilterTest.php
@@ -8,14 +8,13 @@ use ArrayIterator;
 use Laminas\InputFilter\Factory;
 use Laminas\InputFilter\Input;
 use Laminas\InputFilter\InputFilter;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\MockObject;
 use Traversable;
 
 use function array_merge;
 
-/**
- * @covers \Laminas\InputFilter\InputFilter
- */
+#[CoversClass(InputFilter::class)]
 class InputFilterTest extends BaseInputFilterTest
 {
     /** @var InputFilter */
@@ -46,7 +45,7 @@ class InputFilterTest extends BaseInputFilterTest
      *     2: Input
      * }>
      */
-    public function inputProvider(): array
+    public static function inputProvider(): array
     {
         $dataSets = parent::inputProvider();
 

--- a/test/InputTest.php
+++ b/test/InputTest.php
@@ -11,6 +11,9 @@ use Laminas\Validator\NotEmpty as NotEmptyValidator;
 use Laminas\Validator\Translator\TranslatorInterface;
 use Laminas\Validator\ValidatorChain;
 use Laminas\Validator\ValidatorInterface;
+use LaminasTest\InputFilter\TestAsset\ValidatorStub;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use stdClass;
@@ -136,9 +139,9 @@ class InputTest extends TestCase
     }
 
     /**
-     * @dataProvider setValueProvider
      * @param mixed $fallbackValue
      */
+    #[DataProvider('setValueProvider')]
     public function testSetFallbackValue($fallbackValue): void
     {
         $input = $this->input;
@@ -151,9 +154,9 @@ class InputTest extends TestCase
     }
 
     /**
-     * @dataProvider setValueProvider
      * @param mixed $fallbackValue
      */
+    #[DataProvider('setValueProvider')]
     public function testClearFallbackValue($fallbackValue): void
     {
         $input = $this->input;
@@ -164,11 +167,11 @@ class InputTest extends TestCase
     }
 
     /**
-     * @dataProvider fallbackValueVsIsValidProvider
      * @param string|string[] $fallbackValue
      * @param string|string[] $originalValue
      * @param string|string[] $expectedValue
      */
+    #[DataProvider('fallbackValueVsIsValidProvider')]
     public function testFallbackValueVsIsValidRules(
         bool $required,
         $fallbackValue,
@@ -195,9 +198,9 @@ class InputTest extends TestCase
     }
 
     /**
-     * @dataProvider fallbackValueVsIsValidProvider
      * @param string|string[] $fallbackValue
      */
+    #[DataProvider('fallbackValueVsIsValidProvider')]
     public function testFallbackValueVsIsValidRulesWhenValueNotSet(bool $required, $fallbackValue): void
     {
         $expectedValue = $fallbackValue; // Should always return the fallback value
@@ -306,7 +309,7 @@ class InputTest extends TestCase
 
         // Validator should not to be called
         $input->getValidatorChain()
-            ->attach($this->createValidatorMock(null, null));
+            ->attach(self::createValidatorMock(null, null));
         self::assertTrue(
             $input->isValid(),
             'isValid() should be return always true when is not required, and no data is set. Detail: '
@@ -316,9 +319,9 @@ class InputTest extends TestCase
     }
 
     /**
-     * @dataProvider emptyValueProvider
      * @param mixed $value
      */
+    #[DataProvider('emptyValueProvider')]
     public function testNotEmptyValidatorNotInjectedIfContinueIfEmptyIsTrue($value): void
     {
         $input = $this->input;
@@ -400,9 +403,9 @@ class InputTest extends TestCase
     }
 
     /**
-     * @dataProvider emptyValueProvider
      * @param mixed $value
      */
+    #[DataProvider('emptyValueProvider')]
     public function testNotEmptyValidatorAddedWhenIsValidIsCalled($value): void
     {
         self::assertTrue($this->input->isRequired());
@@ -421,9 +424,9 @@ class InputTest extends TestCase
     }
 
     /**
-     * @dataProvider emptyValueProvider
      * @param mixed $value
      */
+    #[DataProvider('emptyValueProvider')]
     public function testRequiredNotEmptyValidatorNotAddedWhenOneExists($value): void
     {
         $this->input->setRequired(true);
@@ -441,10 +444,10 @@ class InputTest extends TestCase
     }
 
     /**
-     * @dataProvider emptyValueProvider
      * @param mixed $valueRaw
      * @param mixed $valueFiltered
      */
+    #[DataProvider('emptyValueProvider')]
     public function testDoNotInjectNotEmptyValidatorIfAnywhereInChain($valueRaw, $valueFiltered): void
     {
         $filterChain    = $this->createFilterChainMock([[$valueRaw, $valueFiltered]]);
@@ -456,7 +459,7 @@ class InputTest extends TestCase
 
         $notEmptyMock = $this->createNonEmptyValidatorMock(false, $valueFiltered);
 
-        $validatorChain->attach($this->createValidatorMock(true));
+        $validatorChain->attach(self::createValidatorMock(true));
         $validatorChain->attach($notEmptyMock);
 
         self::assertFalse($this->input->isValid());
@@ -466,17 +469,14 @@ class InputTest extends TestCase
         self::assertEquals($notEmptyMock, $validators[1]['instance']);
     }
 
-    /**
-     * @group 7448
-     * @dataProvider isRequiredVsAllowEmptyVsContinueIfEmptyVsIsValidProvider
-     * @param mixed $value
-     */
+    #[DataProvider('isRequiredVsAllowEmptyVsContinueIfEmptyVsIsValidProvider')]
+    #[Group('7448')]
     public function testIsRequiredVsAllowEmptyVsContinueIfEmptyVsIsValid(
         bool $required,
         bool $allowEmpty,
         bool $continueIfEmpty,
         ValidatorInterface $validator,
-        $value,
+        mixed $value,
         bool $expectedIsValid,
         array $expectedMessages
     ): void {
@@ -498,9 +498,9 @@ class InputTest extends TestCase
     }
 
     /**
-     * @dataProvider setValueProvider
      * @param mixed $value
      */
+    #[DataProvider('setValueProvider')]
     public function testSetValuePutInputInTheDesiredState($value): void
     {
         $input = $this->input;
@@ -511,9 +511,9 @@ class InputTest extends TestCase
     }
 
     /**
-     * @dataProvider setValueProvider
      * @param mixed $value
      */
+    #[DataProvider('setValueProvider')]
     public function testResetValueReturnsInputValueToDefaultValue($value): void
     {
         $input         = $this->input;
@@ -660,7 +660,7 @@ class InputTest extends TestCase
      *     4: string
      * }>
      */
-    public function fallbackValueVsIsValidProvider(): array
+    public static function fallbackValueVsIsValidProvider(): array
     {
         $required = true;
         $isValid  = true;
@@ -685,10 +685,10 @@ class InputTest extends TestCase
      *     filtered:  bool|int|float|string|list<string>|object
      * }>
      */
-    public function setValueProvider(): array
+    public static function setValueProvider(): array
     {
-        $emptyValues = $this->emptyValueProvider();
-        $mixedValues = $this->mixedValueProvider();
+        $emptyValues = static::emptyValueProvider();
+        $mixedValues = static::mixedValueProvider();
 
         $emptyValues = $emptyValues instanceof Iterator ? iterator_to_array($emptyValues) : $emptyValues;
         $mixedValues = $mixedValues instanceof Iterator ? iterator_to_array($mixedValues) : $mixedValues;
@@ -710,11 +710,11 @@ class InputTest extends TestCase
      *     6: string[]
      * }>
      */
-    public function isRequiredVsAllowEmptyVsContinueIfEmptyVsIsValidProvider(): iterable
+    public static function isRequiredVsAllowEmptyVsContinueIfEmptyVsIsValidProvider(): iterable
     {
-        $allValues = $this->setValueProvider();
+        $allValues = static::setValueProvider();
 
-        $emptyValues = $this->emptyValueProvider();
+        $emptyValues = static::emptyValueProvider();
         $emptyValues = $emptyValues instanceof Iterator ? iterator_to_array($emptyValues) : $emptyValues;
         Assert::isArray($emptyValues);
 
@@ -729,12 +729,12 @@ class InputTest extends TestCase
         $notEmptyMsg  = ['isEmpty' => "Value is required and can't be empty"];
 
         // phpcs:disable Generic.Formatting.MultipleStatementAlignment.NotSame
-        $validatorNotCall = fn($value, $context = null): ValidatorInterface =>
-            $this->createValidatorMock(null, $value, $context);
-        $validatorInvalid = fn($value, $context = null): ValidatorInterface =>
-            $this->createValidatorMock(false, $value, $context, $validatorMsg);
-        $validatorValid = fn($value, $context = null): ValidatorInterface =>
-            $this->createValidatorMock(true, $value, $context);
+        $validatorNotCall = fn(mixed $value, array|null $context = null): ValidatorInterface =>
+            self::createValidatorMock(null, $value, $context);
+        $validatorInvalid = fn(mixed $value, array|null $context = null): ValidatorInterface =>
+            self::createValidatorMock(false, $value, $context, $validatorMsg);
+        $validatorValid = fn(mixed $value, array|null $context = null): ValidatorInterface =>
+            self::createValidatorMock(true, $value, $context);
 
         // phpcs:disable Generic.Files.LineLength.TooLong,WebimpressCodingStandard.Arrays.DoubleArrow.SpacesBefore,WebimpressCodingStandard.Arrays.Format.SingleLineSpaceBefore,WebimpressCodingStandard.WhiteSpace.CommaSpacing.SpacingAfterComma,WebimpressCodingStandard.WhiteSpace.CommaSpacing.SpaceBeforeComma,WebimpressCodingStandard.Arrays.Format.BlankLine,Generic.Formatting.MultipleStatementAlignment.NotSame
         $dataTemplates = [
@@ -791,7 +791,7 @@ class InputTest extends TestCase
      *     filtered: null|string|array
      * }>
      */
-    public function emptyValueProvider(): iterable
+    public static function emptyValueProvider(): iterable
     {
         return [
             // Description => [$value]
@@ -822,7 +822,7 @@ class InputTest extends TestCase
      *     filtered: mixed,
      * }>
      */
-    public function mixedValueProvider(): array
+    public static function mixedValueProvider(): array
     {
         return [
             // Description => [$value]
@@ -877,15 +877,9 @@ class InputTest extends TestCase
         ];
     }
 
-    /**
-     * @return InputInterface&MockObject
-     */
-    protected function createInputInterfaceMock()
+    protected function createInputInterfaceMock(): InputInterface&MockObject
     {
-        /** @var InputInterface&MockObject $source */
-        $source = $this->createMock(InputInterface::class);
-
-        return $source;
+        return $this->createMock(InputInterface::class);
     }
 
     /**
@@ -928,52 +922,30 @@ class InputTest extends TestCase
         return $validatorChain;
     }
 
-    /**
-     * @param null|bool $isValid
-     * @param mixed $value
-     * @param mixed $context
-     * @param string[] $messages
-     * @return ValidatorInterface&MockObject
-     */
-    protected function createValidatorMock($isValid, $value = 'not-set', $context = null, $messages = [])
-    {
-        /** @var ValidatorInterface&MockObject $validator */
-        $validator = $this->createMock(ValidatorInterface::class);
-
-        if (($isValid === false) || ($isValid === true)) {
-            $isValidMethod = $validator->expects(self::once())
-                ->method('isValid')
-                ->willReturn($isValid);
-        } else {
-            $isValidMethod = $validator->expects(self::never())
-                ->method('isValid');
-        }
-        if ($value !== 'not-set') {
-            $isValidMethod->with($value, $context);
-        }
-
-        $validator->method('getMessages')
-            ->willReturn($messages);
-
-        return $validator;
+    /** @param array<string, string> $messages */
+    protected static function createValidatorMock(
+        bool|null $isValid,
+        mixed $value = 'not-set',
+        array|null $context = null,
+        array $messages = []
+    ): ValidatorInterface {
+        return new ValidatorStub($isValid, $value, $context, $messages);
     }
 
-    /**
-     * @param bool $isValid
-     * @param mixed $value
-     * @param mixed $context
-     * @return NotEmptyValidator&MockObject
-     */
-    protected function createNonEmptyValidatorMock($isValid, $value, $context = null)
-    {
-        /** @var NotEmptyValidator&MockObject $notEmptyMock */
-        $notEmptyMock = $this->getMockBuilder(NotEmptyValidator::class)
-            ->setMethods(['isValid'])
-            ->getMock();
-        $notEmptyMock->expects($this->once())
+    protected function createNonEmptyValidatorMock(
+        bool $isValid,
+        mixed $value,
+        mixed $context = null
+    ): NotEmptyValidator&MockObject {
+        $notEmptyMock = $this->createMock(NotEmptyValidator::class);
+        $notEmptyMock->expects(self::once())
             ->method('isValid')
             ->with($value, $context)
             ->willReturn($isValid);
+
+        if ($isValid === false) {
+            $notEmptyMock->method('getMessages')->willReturn([]);
+        }
 
         return $notEmptyMock;
     }

--- a/test/OptionalInputFilterTest.php
+++ b/test/OptionalInputFilterTest.php
@@ -10,11 +10,10 @@ use Laminas\InputFilter\Input;
 use Laminas\InputFilter\InputFilter;
 use Laminas\InputFilter\InputFilterInterface;
 use Laminas\InputFilter\OptionalInputFilter;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @covers \Laminas\InputFilter\OptionalInputFilter
- */
+#[CoversClass(OptionalInputFilter::class)]
 class OptionalInputFilterTest extends TestCase
 {
     public function testValidatesSuccessfullyWhenSetDataIsNeverCalled(): void

--- a/test/TestAsset/InputFilterAware.php
+++ b/test/TestAsset/InputFilterAware.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\InputFilter\TestAsset;
+
+use Laminas\InputFilter\InputFilterAwareTrait;
+
+final class InputFilterAware
+{
+    use InputFilterAwareTrait;
+}

--- a/test/TestAsset/InputFilterInterfaceStub.php
+++ b/test/TestAsset/InputFilterInterfaceStub.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\InputFilter\TestAsset;
+
+use Laminas\InputFilter\InputFilter;
+use Laminas\InputFilter\InputFilterInterface;
+
+use function PHPUnit\Framework\assertNotNull;
+
+final class InputFilterInterfaceStub extends InputFilter implements InputFilterInterface
+{
+    /**
+     * @param array<string, mixed> $getRawValues
+     * @param array<string, mixed> $getValues
+     * @param array<string, array<array-key, string>> $getMessages
+     */
+    public function __construct(
+        private readonly bool|null $isValid = null,
+        private readonly array $getRawValues = [],
+        private readonly array $getValues = [],
+        private readonly array $getMessages = []
+    ) {
+    }
+
+    /** @inheritDoc */
+    public function isValid($context = null)
+    {
+        assertNotNull($this->isValid, 'isValid was not expected to be called');
+
+        return $this->isValid;
+    }
+
+    public function getValues(): array
+    {
+        return $this->getValues;
+    }
+
+    public function getRawValues(): array
+    {
+        return $this->getRawValues;
+    }
+
+    /** @inheritDoc */
+    public function getMessages(): array
+    {
+        return $this->getMessages;
+    }
+}

--- a/test/TestAsset/InputInterfaceStub.php
+++ b/test/TestAsset/InputInterfaceStub.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\InputFilter\TestAsset;
+
+use Exception;
+use Laminas\Filter\FilterChain;
+use Laminas\InputFilter\InputInterface;
+use Laminas\Validator\ValidatorChain;
+
+use function func_get_arg;
+use function func_num_args;
+use function PHPUnit\Framework\assertEquals;
+use function PHPUnit\Framework\assertNotNull;
+
+final class InputInterfaceStub implements InputInterface
+{
+    /** @param array<string, string> $getMessages */
+    public function __construct(
+        private readonly string $name,
+        private readonly bool|null $isRequired,
+        private readonly bool|null $isValid = null,
+        private readonly array|string|null $context = null,
+        private readonly mixed $getRawValue = null,
+        private readonly mixed $getValue = null,
+        private readonly array $getMessages = [],
+        private readonly bool $breakOnFailure = false
+    ) {
+    }
+
+    /** @inheritDoc */
+    public function setAllowEmpty($allowEmpty)
+    {
+        return $this;
+    }
+
+    /** @inheritDoc */
+    public function setBreakOnFailure($breakOnFailure)
+    {
+        return $this;
+    }
+
+    /** @inheritDoc */
+    public function setErrorMessage($errorMessage)
+    {
+        return $this;
+    }
+
+    /** @inheritDoc */
+    public function setFilterChain(FilterChain $filterChain): never
+    {
+        throw new Exception('Not implemented');
+    }
+
+    /** @inheritDoc */
+    public function setName($name): never
+    {
+        throw new Exception('Not implemented');
+    }
+
+    /** @inheritDoc */
+    public function setRequired($required): never
+    {
+        throw new Exception('Not implemented');
+    }
+
+    /** @inheritDoc */
+    public function setValidatorChain(ValidatorChain $validatorChain): never
+    {
+        throw new Exception('Not implemented');
+    }
+
+    /** @inheritDoc */
+    public function setValue($value)
+    {
+        return $this;
+    }
+
+    /** @inheritDoc */
+    public function merge(InputInterface $input): never
+    {
+        throw new Exception('Not implemented');
+    }
+
+    /** @inheritDoc */
+    public function allowEmpty(): never
+    {
+        throw new Exception('Not implemented');
+    }
+
+    /** @inheritDoc */
+    public function breakOnFailure(): bool
+    {
+        return $this->breakOnFailure;
+    }
+
+    /** @inheritDoc */
+    public function getErrorMessage(): never
+    {
+        throw new Exception('Not implemented');
+    }
+
+    /** @inheritDoc */
+    public function getFilterChain(): never
+    {
+        throw new Exception('Not implemented');
+    }
+
+    /** @inheritDoc */
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    /** @inheritDoc */
+    public function getRawValue(): mixed
+    {
+        return $this->getRawValue;
+    }
+
+    /** @inheritDoc */
+    public function isRequired(): bool
+    {
+        assertNotNull($this->isRequired, 'isRequired was not expected to be called');
+
+        return $this->isRequired;
+    }
+
+    /** @inheritDoc */
+    public function getValidatorChain(): never
+    {
+        throw new Exception('Not implemented');
+    }
+
+    /** @inheritDoc */
+    public function getValue(): mixed
+    {
+        return $this->getValue;
+    }
+
+    /** @inheritDoc */
+    public function isValid(): bool
+    {
+        assertNotNull($this->isValid, 'isValid was not expected to be called');
+
+        if ($this->context !== null && func_num_args() > 0) {
+            assertEquals($this->context, func_get_arg(0), 'The given context does not match the expected context');
+        }
+
+        return $this->isValid;
+    }
+
+    /** @return array<string, string> */
+    public function getMessages(): array
+    {
+        return $this->getMessages;
+    }
+}

--- a/test/TestAsset/UploadedFileInterfaceStub.php
+++ b/test/TestAsset/UploadedFileInterfaceStub.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\InputFilter\TestAsset;
+
+use Exception;
+use Psr\Http\Message\UploadedFileInterface;
+
+use const UPLOAD_ERR_OK;
+
+final class UploadedFileInterfaceStub implements UploadedFileInterface
+{
+    public function __construct(
+        private readonly int $expectedErrorCode = UPLOAD_ERR_OK
+    ) {
+    }
+
+    public function getStream(): never
+    {
+        throw new Exception('Not Implemented');
+    }
+
+    public function moveTo(string $targetPath): never
+    {
+        throw new Exception('Not Implemented');
+    }
+
+    public function getSize(): never
+    {
+        throw new Exception('Not Implemented');
+    }
+
+    public function getError(): int
+    {
+        return $this->expectedErrorCode;
+    }
+
+    public function getClientFilename(): never
+    {
+        throw new Exception('Not Implemented');
+    }
+
+    public function getClientMediaType(): never
+    {
+        throw new Exception('Not Implemented');
+    }
+}

--- a/test/TestAsset/ValidatorStub.php
+++ b/test/TestAsset/ValidatorStub.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\InputFilter\TestAsset;
+
+use Laminas\Validator\ValidatorInterface;
+
+use function func_get_arg;
+use function func_num_args;
+use function PHPUnit\Framework\assertEquals;
+use function PHPUnit\Framework\assertNotNull;
+
+final class ValidatorStub implements ValidatorInterface
+{
+    /** @param array<string, string> $messages */
+    public function __construct(
+        private readonly bool|null $isValid,
+        private readonly mixed $value = 'not-set',
+        private readonly array|null $context = null,
+        private readonly array $messages = [],
+    ) {
+    }
+
+    public function isValid(mixed $value): bool
+    {
+        if ($this->value !== 'not-set') {
+            assertEquals($this->value, $value, 'isValid did not receive the expected value');
+        }
+
+        if (func_num_args() > 1 && $this->context !== null) {
+            /** @var mixed $givenContext */
+            $givenContext = func_get_arg(1);
+            assertEquals(
+                $this->context,
+                $givenContext,
+                'isValid received a context that did not match the expected context',
+            );
+        }
+
+        assertNotNull($this->isValid, 'isValid was not expected to be called for this instance');
+
+        return $this->isValid;
+    }
+
+    /** @inheritDoc */
+    public function getMessages(): array
+    {
+        return $this->messages;
+    }
+}

--- a/test/ValidationGroup/InputFilterCollectionsValidationGroupTest.php
+++ b/test/ValidationGroup/InputFilterCollectionsValidationGroupTest.php
@@ -8,6 +8,7 @@ use Laminas\InputFilter\CollectionInputFilter;
 use Laminas\InputFilter\Exception\RuntimeException;
 use Laminas\InputFilter\Input;
 use Laminas\InputFilter\InputFilter;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 use function restore_error_handler;
@@ -39,7 +40,7 @@ final class InputFilterCollectionsValidationGroupTest extends TestCase
     }
 
     /** @return array<string, array{0: int|null}> */
-    public function collectionCountProvider(): array
+    public static function collectionCountProvider(): array
     {
         return [
             'Collection Count: None'  => [null],
@@ -61,7 +62,7 @@ final class InputFilterCollectionsValidationGroupTest extends TestCase
         $collection->setCount($count);
     }
 
-    /** @dataProvider collectionCountProvider */
+    #[DataProvider('collectionCountProvider')]
     public function testIncompleteDataFailsValidation(?int $count): void
     {
         $this->setCollectionCount($count);
@@ -73,7 +74,7 @@ final class InputFilterCollectionsValidationGroupTest extends TestCase
         self::assertFalse($this->inputFilter->isValid());
     }
 
-    /** @dataProvider collectionCountProvider */
+    #[DataProvider('collectionCountProvider')]
     public function testCompleteDataPassesValidation(?int $count): void
     {
         $this->setCollectionCount($count);
@@ -89,7 +90,7 @@ final class InputFilterCollectionsValidationGroupTest extends TestCase
         self::assertTrue($this->inputFilter->isValid());
     }
 
-    /** @dataProvider collectionCountProvider */
+    #[DataProvider('collectionCountProvider')]
     public function testValidationFailsForCollectionItemValidity(?int $count): void
     {
         $this->setCollectionCount($count);
@@ -105,7 +106,7 @@ final class InputFilterCollectionsValidationGroupTest extends TestCase
         self::assertFalse($this->inputFilter->isValid());
     }
 
-    /** @dataProvider collectionCountProvider */
+    #[DataProvider('collectionCountProvider')]
     public function testValidationGroupWithCollectionInputFilter(?int $count): void
     {
         $this->setCollectionCount($count);
@@ -125,7 +126,7 @@ final class InputFilterCollectionsValidationGroupTest extends TestCase
         self::assertTrue($this->inputFilter->isValid());
     }
 
-    /** @dataProvider collectionCountProvider */
+    #[DataProvider('collectionCountProvider')]
     public function testValidationGroupViaCollection(?int $count): void
     {
         $this->setCollectionCount($count);
@@ -153,9 +154,8 @@ final class InputFilterCollectionsValidationGroupTest extends TestCase
 
     /**
      * This test documents existing behaviour - the validation group must be set for elements 0 through 3
-     *
-     * @dataProvider collectionCountProvider
      */
+    #[DataProvider('collectionCountProvider')]
     public function testValidationGroupViaCollectionMustSpecifyAllKeys(?int $count): void
     {
         $this->setCollectionCount($count);
@@ -190,7 +190,7 @@ final class InputFilterCollectionsValidationGroupTest extends TestCase
         }
     }
 
-    /** @dataProvider collectionCountProvider */
+    #[DataProvider('collectionCountProvider')]
     public function testValidationGroupViaTopLevelInputFilter(?int $count): void
     {
         $this->setCollectionCount($count);


### PR DESCRIPTION
Closes #86 

This is quite a big patch, but the tests and data providers are hellishly complex, so making them all static was a bit messy.

There's loads of inheritance going on in the tests which really needs to be refactored.