### PR TITLE
Improve consumer type inference with InputFilter templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,19 +3,19 @@
 [![Build Status](https://github.com/laminas/laminas-inputfilter/workflows/Continuous%20Integration/badge.svg)](https://github.com/laminas/laminas-inputfilter/actions?query=workflow%3A"Continuous+Integration")
 
 > ## 🇷🇺 Русским гражданам
-> 
+>
 > Мы, участники Laminas, родились и живем в разных странах. У многих из нас есть друзья, родственники и коллеги как в России, так и в Украине. Некоторые из нас родились в России. Некоторые из нас живут в России. У некоторых бабушки и дедушки сражались с фашистами во Второй мировой войне. Здесь никто не поддерживает фашизм.
-> 
+>
 > У одного из нас есть украинская родственница, которая спаслась из дома вместе с сыном. Поезд задержался из-за бомбежки на дороге впереди. У нас есть друзья, которые прячутся в бомбоубежищах. Мы с тревогой ждем весточки от них после воздушных налетов, которые беспорядочно наносят удары и попадают по больницам, школам, детским садам и домам. Мы не берем это из каких-либо СМИ. Мы наблюдаем это напрямую.
-> 
+>
 > Вы доверяете нам достаточно, чтоб использовать наши программы, и мы просим вас довериться нам вновь. Мы нуждаемся в помощи. Выходите и протестуйте против этой бесполезной войны. Остановите кровопролитие. Скажите "Нет войне!"
-> 
+>
 > ## 🇺🇸 To Citizens of Russia
-> 
+>
 > We at Laminas come from all over the world. Many of us have friends, family and colleagues in both Russia and Ukraine. Some of us were born in Russia. Some of us currently live in Russia. Some have grandparents who fought Nazis in World War II. Nobody here supports fascism.
-> 
+>
 > One team member has a Ukrainian relative who fled her home with her son. The train was delayed due to bombing on the road ahead. We have friends who are hiding in bomb shelters. We anxiously follow up on them after the air raids, which indiscriminately fire at hospitals, schools, kindergartens and houses. We're not taking this from any media. These are our actual experiences.
-> 
+>
 > You trust us enough to use our software. We ask that you trust us to say the truth on this. We need your help. Go out and protest this unnecessary war. Stop the bloodshed. Say "stop the war!"
 
 The laminas-inputfilter component can be used to filter and validate generic sets

--- a/composer.json
+++ b/composer.json
@@ -32,10 +32,10 @@
     },
     "require": {
         "php": "~8.1.0 || ~8.2.0",
-        "laminas/laminas-filter": "^2.13",
+        "laminas/laminas-filter": "^2.19",
         "laminas/laminas-servicemanager": "^3.21.0",
         "laminas/laminas-stdlib": "^3.0",
-        "laminas/laminas-validator": "^2.15"
+        "laminas/laminas-validator": "^2.25"
     },
     "require-dev": {
         "ext-json": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6f933bb0ad284be284d96f3d19a6c74e",
+    "content-hash": "0e07d889fbc5b2112645d5d0df7017dd",
     "packages": [
         {
             "name": "laminas/laminas-filter",
@@ -2016,16 +2016,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "10.2.4",
+            "version": "10.2.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "68484779b5a2ed711fbdeba6ca01910d87acdff2"
+                "reference": "15a89f123d8ca9c1e1598d6d87a56a8bf28c72cd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/68484779b5a2ed711fbdeba6ca01910d87acdff2",
-                "reference": "68484779b5a2ed711fbdeba6ca01910d87acdff2",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/15a89f123d8ca9c1e1598d6d87a56a8bf28c72cd",
+                "reference": "15a89f123d8ca9c1e1598d6d87a56a8bf28c72cd",
                 "shasum": ""
             },
             "require": {
@@ -2097,7 +2097,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.2.4"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.2.5"
             },
             "funding": [
                 {
@@ -2113,7 +2113,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-07-10T04:06:08+00:00"
+            "time": "2023-07-14T04:18:47+00:00"
         },
         {
             "name": "psalm/plugin-phpunit",

--- a/docs/book/cookbook/enhanced-type-inference.md
+++ b/docs/book/cookbook/enhanced-type-inference.md
@@ -1,0 +1,72 @@
+# Using Laminas InputFilter with Static Analysis Tools
+
+It can be tedious to assert that the array returned by a given input filter contains the keys and value types that you would expect before using those values in your domain.
+If you use static analysis tools such as Psalm or PHPStan, `InputFilterInterface` defines a generic template that can be used to refine the types you receive from the `getValues()` method.
+
+```php
+<?php
+
+namespace My;
+
+use Laminas\Filter\ToInt;
+use Laminas\Filter\ToNull;
+use Laminas\I18n\Validator\IsInt;
+use Laminas\InputFilter\InputFilter;use Laminas\Validator\GreaterThan;
+
+/**
+ * @psalm-type ValidPayload = array{
+ *     anInteger: int<1, max>,
+ * }
+ * @extends InputFilter<ValidPayload>     
+ */
+final class SomeInputFilter extends InputFilter
+{
+    public function init(): void
+    {
+        $this->add([
+            'name' => 'anInteger',
+            'required' => true,
+            'filters' => [
+                ['name' => ToNull::class],
+                ['name' => ToInt::class],
+            ],
+            'validators' => [
+                ['name' => NotEmpty::class],
+                ['name' => IsInt::class],
+                [
+                    'name' => GreaterThan::class,
+                    'options' => [
+                        'min' => 1,
+                    ],
+                ],
+            ],
+        ]);
+    }
+}
+```
+
+With the above input filter specification, one can guarantee that, if the input payload is deemed valid, then you will receive an array with the expected shape from `InputFilter::getValues()`, therefore, your static analysis tooling will not complain when you pass that value directly to something that expects a `positive-int`, for example:
+
+```php
+/**
+ * @param positive-int $value
+ * @return positive-int 
+ */
+function addTo5(int $value): int
+{
+    return $value + 5;
+}
+
+$filter = new SomeInputFilter();
+$filter->setData(['anInteger' => '123']);
+assert($filter->isValid());
+
+$result = addTo5($filter->getValues()['anInteger']);
+```
+
+## Further reading
+
+- [Psalm documentation on array shapes](https://psalm.dev/docs/annotating_code/type_syntax/array_types/#array-shapes)
+- [Psalm documentation on type aliases](https://psalm.dev/docs/annotating_code/type_syntax/utility_types/#type-aliases)
+- [PHPStan documentation on array shapes](https://phpstan.org/writing-php-code/phpdoc-types#array-shapes)
+- [PHPStan documentation on type aliases](https://phpstan.org/writing-php-code/phpdoc-types#local-type-aliases)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -14,6 +14,7 @@ nav:
         - "Usage in a mezzio application": application-integration/usage-in-a-mezzio-application.md
     - Cookbook:
         - "Using Input Filters in Forms of laminas-form": cookbook/input-filter-in-forms.md
+        - "Using Static Analysis tools with laminas-inputfilter": cookbook/enhanced-type-inference.md
 site_name: laminas-inputfilter
 site_description: 'Normalize and validate input sets from the web, APIs, the CLI, and more, including files.'
 repo_url: 'https://github.com/laminas/laminas-inputfilter'

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -26,18 +26,12 @@
     </NonInvariantDocblockPropertyType>
   </file>
   <file src="src/BaseInputFilter.php">
-    <DocblockTypeContradiction>
-      <code><![CDATA[$input instanceof InputInterface && (empty($name) || is_int($name))]]></code>
-    </DocblockTypeContradiction>
     <InvalidReturnStatement>
-      <code>$messages</code>
+      <code>$values</code>
     </InvalidReturnStatement>
     <InvalidReturnType>
-      <code><![CDATA[array<string, array<array-key, string>>]]></code>
+      <code>TFilteredValues</code>
     </InvalidReturnType>
-    <MixedArgument>
-      <code>$input</code>
-    </MixedArgument>
     <MixedArgumentTypeCoercion>
       <code>$inputs</code>
     </MixedArgumentTypeCoercion>
@@ -52,9 +46,6 @@
     <PossiblyNullArrayOffset>
       <code><![CDATA[$this->inputs]]></code>
     </PossiblyNullArrayOffset>
-    <RedundantCastGivenDocblockType>
-      <code>(string) $name</code>
-    </RedundantCastGivenDocblockType>
     <TooManyArguments>
       <code>isValid</code>
       <code>isValid</code>
@@ -69,10 +60,6 @@
       <code>$name</code>
       <code>$name</code>
     </ImplementedParamTypeMismatch>
-    <ImplementedReturnTypeMismatch>
-      <code><![CDATA[array<array-key, array<string, array<array-key, string>>>]]></code>
-      <code><![CDATA[array<array-key, array<string, array<array-key, string>>>]]></code>
-    </ImplementedReturnTypeMismatch>
     <InvalidArgument>
       <code>$data</code>
     </InvalidArgument>
@@ -83,12 +70,21 @@
       <code><![CDATA[$this->invalidInputs]]></code>
       <code><![CDATA[$this->validInputs]]></code>
     </InvalidPropertyAssignmentValue>
+    <InvalidReturnStatement>
+      <code><![CDATA[$this->collectionValues]]></code>
+    </InvalidReturnStatement>
+    <InvalidReturnType>
+      <code>TFilteredValues</code>
+    </InvalidReturnType>
     <MixedArgument>
       <code>$data</code>
     </MixedArgument>
     <MixedAssignment>
       <code>$data</code>
     </MixedAssignment>
+    <MixedPropertyTypeCoercion>
+      <code><![CDATA[$this->collectionValues]]></code>
+    </MixedPropertyTypeCoercion>
     <PossiblyUnusedReturnValue>
       <code>array[]</code>
       <code>array[]</code>
@@ -128,7 +124,6 @@
     <MixedArgumentTypeCoercion>
       <code>$filter</code>
       <code>$inputSpecification</code>
-      <code>$key</code>
     </MixedArgumentTypeCoercion>
     <MixedArrayAccess>
       <code><![CDATA[$filter['name']]]></code>
@@ -351,12 +346,6 @@
       <code>ModuleManager</code>
     </UndefinedDocblockClass>
   </file>
-  <file src="src/OptionalInputFilter.php">
-    <ImplementedReturnTypeMismatch>
-      <code><![CDATA[array<string, mixed>|null]]></code>
-      <code><![CDATA[array<string, mixed>|null]]></code>
-    </ImplementedReturnTypeMismatch>
-  </file>
   <file src="test/ArrayInputTest.php">
     <ArgumentTypeCoercion>
       <code>$valueMap</code>
@@ -457,12 +446,8 @@
       <code>$getMessages</code>
       <code>$msg</code>
       <code>$msg</code>
-      <code>$name</code>
     </MixedArgumentTypeCoercion>
     <MixedArrayAccess>
-      <code><![CDATA[$filter1->getValues()['nested']['nestedField1']]]></code>
-      <code><![CDATA[$filter1->getValues()['nested']['nestedField1']]]></code>
-      <code><![CDATA[$filter1->getValues()['nested']['nestedField1']]]></code>
       <code>$inputTypeData[1]</code>
       <code>$inputTypeData[2]</code>
     </MixedArrayAccess>
@@ -518,7 +503,6 @@
     <PossiblyUndefinedMethod>
       <code>getName</code>
       <code>getName</code>
-      <code>isRequired</code>
     </PossiblyUndefinedMethod>
     <PossiblyUnusedMethod>
       <code>addMethodArgumentsProvider</code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -49,9 +49,6 @@
     <MixedPropertyTypeCoercion>
       <code>$inputs</code>
     </MixedPropertyTypeCoercion>
-    <PossiblyInvalidArgument>
-      <code>$input</code>
-    </PossiblyInvalidArgument>
     <PossiblyNullArrayOffset>
       <code><![CDATA[$this->inputs]]></code>
     </PossiblyNullArrayOffset>
@@ -63,7 +60,6 @@
       <code>isValid</code>
     </TooManyArguments>
     <UnusedPsalmSuppress>
-      <code>DocblockTypeContradiction</code>
       <code>RedundantConditionGivenDocblockType</code>
       <code>RedundantConditionGivenDocblockType</code>
     </UnusedPsalmSuppress>
@@ -87,10 +83,6 @@
       <code><![CDATA[$this->invalidInputs]]></code>
       <code><![CDATA[$this->validInputs]]></code>
     </InvalidPropertyAssignmentValue>
-    <LessSpecificImplementedReturnType>
-      <code><![CDATA[array<array-key, array>]]></code>
-      <code><![CDATA[array<array-key, array>]]></code>
-    </LessSpecificImplementedReturnType>
     <MixedArgument>
       <code>$data</code>
     </MixedArgument>

--- a/src/BaseInputFilter.php
+++ b/src/BaseInputFilter.php
@@ -23,7 +23,7 @@ use function is_int;
 use function sprintf;
 
 /**
- * @template TFilteredValues of array<array-key, mixed>
+ * @template TFilteredValues
  * @implements InputFilterInterface<TFilteredValues>
  */
 class BaseInputFilter implements

--- a/src/BaseInputFilter.php
+++ b/src/BaseInputFilter.php
@@ -22,6 +22,10 @@ use function is_array;
 use function is_int;
 use function sprintf;
 
+/**
+ * @template TFilteredValues of array<array-key, mixed>
+ * @implements InputFilterInterface<TFilteredValues>
+ */
 class BaseInputFilter implements
     InputFilterInterface,
     UnknownInputsCapableInterface,
@@ -403,6 +407,7 @@ class BaseInputFilter implements
      * validation failed, this should raise an exception.
      *
      * @return array<string, mixed>
+     * @psalm-return TFilteredValues
      */
     public function getValues()
     {

--- a/src/BaseInputFilter.php
+++ b/src/BaseInputFilter.php
@@ -101,7 +101,11 @@ class BaseInputFilter implements
             $name = $input->getName();
         }
 
-        if (isset($this->inputs[$name]) && $this->inputs[$name] instanceof InputInterface) {
+        if (
+            isset($this->inputs[$name])
+            && $this->inputs[$name] instanceof InputInterface
+            && $input instanceof InputInterface
+        ) {
             // The element already exists, so merge the config. Please note
             // that this merges the new input into the original.
             $original = $this->inputs[$name];

--- a/src/CollectionInputFilter.php
+++ b/src/CollectionInputFilter.php
@@ -15,7 +15,7 @@ use function sprintf;
 
 /**
  * @psalm-import-type InputFilterSpecification from InputFilterInterface
- * @template TFilteredValues of array<array-key, array>
+ * @template TFilteredValues
  * @extends InputFilter<TFilteredValues>
  */
 class CollectionInputFilter extends InputFilter
@@ -268,6 +268,7 @@ class CollectionInputFilter extends InputFilter
 
     /**
      * @return array<array-key, array>
+     * @psalm-return TFilteredValues
      */
     public function getValues()
     {

--- a/src/CollectionInputFilter.php
+++ b/src/CollectionInputFilter.php
@@ -15,6 +15,8 @@ use function sprintf;
 
 /**
  * @psalm-import-type InputFilterSpecification from InputFilterInterface
+ * @template TFilteredValues of array<array-key, array>
+ * @extends InputFilter<TFilteredValues>
  */
 class CollectionInputFilter extends InputFilter
 {

--- a/src/InputFilter.php
+++ b/src/InputFilter.php
@@ -10,7 +10,7 @@ use function is_array;
 
 /**
  * @psalm-import-type InputSpecification from InputFilterInterface
- * @template TFilteredValues of array<array-key, mixed>
+ * @template TFilteredValues
  * @extends BaseInputFilter<TFilteredValues>
  */
 class InputFilter extends BaseInputFilter

--- a/src/InputFilter.php
+++ b/src/InputFilter.php
@@ -48,7 +48,7 @@ class InputFilter extends BaseInputFilter
      * Add an input to the input filter
      *
      * @param  InputSpecification|Traversable|InputInterface|InputFilterInterface $input
-     * @param  null|string $name
+     * @param  array-key|null $name
      * @return $this
      */
     public function add($input, $name = null)
@@ -60,6 +60,8 @@ class InputFilter extends BaseInputFilter
             $factory = $this->getFactory();
             $input   = $factory->createInput($input);
         }
+
+        // At this point $input is potentially invalid. parent::add() will throw an exception in this case.
 
         parent::add($input, $name);
 

--- a/src/InputFilter.php
+++ b/src/InputFilter.php
@@ -10,7 +10,9 @@ use function is_array;
 
 /**
  * @psalm-import-type InputSpecification from InputFilterInterface
- **/
+ * @template TFilteredValues of array<array-key, mixed>
+ * @extends BaseInputFilter<TFilteredValues>
+ */
 class InputFilter extends BaseInputFilter
 {
     /** @var Factory|null */

--- a/src/InputFilterInterface.php
+++ b/src/InputFilterInterface.php
@@ -26,7 +26,7 @@ use Traversable;
  * }
  * @psalm-type InputSpecification = array{
  *     type?: string|class-string<InputFilterInterface>,
- *     name?: string,
+ *     name?: array-key,
  *     required?: bool,
  *     allow_empty?: bool,
  *     continue_if_empty?: bool,

--- a/src/InputFilterInterface.php
+++ b/src/InputFilterInterface.php
@@ -12,6 +12,7 @@ use Laminas\Validator\ValidatorInterface; // phpcs:ignore
 use Traversable;
 
 /**
+ * @template TFilteredValues of array<array-key, mixed>
  * @psalm-type FilterSpecification = array{
  *     name: string|class-string<FilterInterface>,
  *     priority?: int,
@@ -153,6 +154,7 @@ interface InputFilterInterface extends Countable
      * validation failed, this should raise an exception.
      *
      * @return array<string, mixed>
+     * @psalm-return TFilteredValues
      */
     public function getValues();
 

--- a/src/InputFilterInterface.php
+++ b/src/InputFilterInterface.php
@@ -12,7 +12,7 @@ use Laminas\Validator\ValidatorInterface; // phpcs:ignore
 use Traversable;
 
 /**
- * @template TFilteredValues of array<array-key, mixed>
+ * @template TFilteredValues
  * @psalm-type FilterSpecification = array{
  *     name: string|class-string<FilterInterface>,
  *     priority?: int,
@@ -58,7 +58,7 @@ interface InputFilterInterface extends Countable
      * @param  InputInterface|InputFilterInterface|InputSpecification|Traversable $input
      *     Implementations MUST handle at least one of the specified types, and
      *     raise an exception for any they cannot process.
-     * @param  null|string $name Name used to retrieve this input
+     * @param  null|array-key $name Name used to retrieve this input
      * @return InputFilterInterface
      * @throws Exception\InvalidArgumentException If unable to handle the input type.
      */
@@ -67,7 +67,7 @@ interface InputFilterInterface extends Countable
     /**
      * Retrieve a named input
      *
-     * @param  string $name
+     * @param  array-key $name
      * @return InputInterface|InputFilterInterface
      */
     public function get($name);
@@ -75,7 +75,7 @@ interface InputFilterInterface extends Countable
     /**
      * Test if an input or input filter by the given name is attached
      *
-     * @param  string $name
+     * @param  array-key $name
      * @return bool
      */
     public function has($name);
@@ -83,7 +83,7 @@ interface InputFilterInterface extends Countable
     /**
      * Remove a named input
      *
-     * @param  string $name
+     * @param  array-key $name
      * @return InputFilterInterface
      */
     public function remove($name);
@@ -114,7 +114,7 @@ interface InputFilterInterface extends Countable
      * Implementations should allow passing a single array value, or multiple arguments,
      * each specifying a single input.
      *
-     * @param  string|list<string> $name
+     * @param  array-key|list<array-key> $name
      * @return InputFilterInterface
      */
     public function setValidationGroup($name);
@@ -125,7 +125,7 @@ interface InputFilterInterface extends Countable
      * Implementations should return an associative array of name/input pairs
      * that failed validation.
      *
-     * @return array<string, InputInterface|InputFilterInterface>
+     * @return array<array-key, InputInterface|InputFilterInterface>
      */
     public function getInvalidInput();
 
@@ -135,14 +135,14 @@ interface InputFilterInterface extends Countable
      * Implementations should return an associative array of name/input pairs
      * that passed validation.
      *
-     * @return array<string, InputInterface|InputFilterInterface>
+     * @return array<array-key, InputInterface|InputFilterInterface>
      */
     public function getValidInput();
 
     /**
      * Retrieve a value from a named input
      *
-     * @param  string $name
+     * @param  array-key $name
      * @return mixed
      */
     public function getValue($name);
@@ -153,7 +153,7 @@ interface InputFilterInterface extends Countable
      * List should be an associative array, with the values filtered. If
      * validation failed, this should raise an exception.
      *
-     * @return array<string, mixed>
+     * @return array<array-key, mixed>
      * @psalm-return TFilteredValues
      */
     public function getValues();
@@ -161,7 +161,7 @@ interface InputFilterInterface extends Countable
     /**
      * Retrieve a raw (unfiltered) value from a named input
      *
-     * @param  string $name
+     * @param  array-key $name
      * @return mixed
      */
     public function getRawValue($name);
@@ -182,7 +182,7 @@ interface InputFilterInterface extends Countable
      * Should return an associative array of named input/message list pairs.
      * Pairs should only be returned for inputs that failed validation.
      *
-     * @return array<array-key, array<array-key, string>>
+     * @return array<array-key, array<array-key, string|array>>
      */
     public function getMessages();
 }

--- a/src/OptionalInputFilter.php
+++ b/src/OptionalInputFilter.php
@@ -9,7 +9,7 @@ namespace Laminas\InputFilter;
  * else it reports valid
  * This is analog to {@see Input} with the option ->setRequired(false)
  *
- * @template TFilteredValues of array<string, mixed>
+ * @template TFilteredValues
  * @extends InputFilter<TFilteredValues>
  */
 class OptionalInputFilter extends InputFilter
@@ -49,7 +49,7 @@ class OptionalInputFilter extends InputFilter
      *     which would likely cause failures later on in your program
      * Fallbacks for the inputs are not respected by design
      *
-     * @return array<string, mixed>|null
+     * @return TFilteredValues|null
      */
     public function getValues()
     {

--- a/src/OptionalInputFilter.php
+++ b/src/OptionalInputFilter.php
@@ -8,6 +8,9 @@ namespace Laminas\InputFilter;
  * InputFilter which only checks the containing Inputs when non-empty data is set,
  * else it reports valid
  * This is analog to {@see Input} with the option ->setRequired(false)
+ *
+ * @template TFilteredValues of array<string, mixed>
+ * @extends InputFilter<TFilteredValues>
  */
 class OptionalInputFilter extends InputFilter
 {

--- a/test/BaseInputFilterTest.php
+++ b/test/BaseInputFilterTest.php
@@ -25,6 +25,7 @@ use stdClass;
 use function array_keys;
 use function array_merge;
 use function array_walk;
+use function assert;
 use function count;
 use function in_array;
 use function is_callable;
@@ -82,6 +83,7 @@ class BaseInputFilterTest extends TestCase
             'expects an instance of Laminas\InputFilter\InputInterface or Laminas\InputFilter\InputFilterInterface '
             . 'as its first argument; received "stdClass"'
         );
+        /** @psalm-suppress InvalidArgument */
         $inputFilter->replace(new stdClass(), 'replace_me');
     }
 
@@ -291,7 +293,7 @@ class BaseInputFilterTest extends TestCase
     }
 
     /**
-     * @param array<string, InputInterface|InputFilterInterface|iterable> $inputs
+     * @param array<string, InputInterface|InputFilterInterface> $inputs
      * @param iterable<mixed> $data
      * @param array<string, mixed> $expectedRawValues
      * @param array<string, mixed> $expectedValues
@@ -350,7 +352,7 @@ class BaseInputFilterTest extends TestCase
     }
 
     /**
-     * @param array<string, InputInterface|InputFilterInterface|iterable> $inputs
+     * @param array<string, InputInterface|InputFilterInterface> $inputs
      * @param iterable<mixed> $data
      * @param array<string, mixed> $expectedRawValues
      * @param array<string, mixed> $expectedValues
@@ -586,7 +588,9 @@ class BaseInputFilterTest extends TestCase
         $foo2->setRequired(false);
         $filter->add($foo2);
 
-        self::assertFalse($filter->get('foo')->isRequired());
+        $input = $filter->get('foo');
+        assert($input instanceof Input);
+        self::assertFalse($input->isRequired());
     }
 
     public function testAddingAnInputFilterWithTheSameNameAsTheInputWillReplace(): void
@@ -627,6 +631,7 @@ class BaseInputFilterTest extends TestCase
 
     public function testNestedInputFilterShouldAllowNonArrayValueForData(): void
     {
+        /** @psalm-var BaseInputFilter<array{nested: array{nestedField1: mixed}}> $filter1 */
         $filter1      = new BaseInputFilter();
         $nestedFilter = new BaseInputFilter();
         $nestedFilter->add(new Input('nestedField1'));

--- a/test/BaseInputFilterTest.php
+++ b/test/BaseInputFilterTest.php
@@ -9,6 +9,7 @@ use Laminas\InputFilter\BaseInputFilter;
 use Laminas\InputFilter\Exception\InvalidArgumentException;
 use Laminas\InputFilter\Exception\RuntimeException;
 use Laminas\InputFilter\Input;
+use Laminas\InputFilter\InputFilter;
 use Laminas\InputFilter\InputFilterInterface;
 use Laminas\InputFilter\InputInterface;
 use Laminas\InputFilter\UnfilteredDataInterface;
@@ -586,6 +587,20 @@ class BaseInputFilterTest extends TestCase
         $filter->add($foo2);
 
         self::assertFalse($filter->get('foo')->isRequired());
+    }
+
+    public function testAddingAnInputFilterWithTheSameNameAsTheInputWillReplace(): void
+    {
+        $input  = new Input('a');
+        $filter = new InputFilter();
+
+        $this->inputFilter->add($input);
+
+        self::assertSame($input, $this->inputFilter->get('a'));
+
+        $this->inputFilter->add($filter, 'a');
+
+        self::assertSame($filter, $this->inputFilter->get('a'));
     }
 
     public function testMerge(): void

--- a/test/FileInput/TestAsset/InitializableInputFilterInterface.php
+++ b/test/FileInput/TestAsset/InitializableInputFilterInterface.php
@@ -7,6 +7,7 @@ namespace LaminasTest\InputFilter\FileInput\TestAsset;
 use Laminas\InputFilter\InputFilterInterface;
 use Laminas\Stdlib\InitializableInterface;
 
+/** @extends InputFilterInterface<array<array-key, mixed>> */
 interface InitializableInputFilterInterface extends InputFilterInterface, InitializableInterface
 {
 }

--- a/test/InputFilterTest.php
+++ b/test/InputFilterTest.php
@@ -108,4 +108,17 @@ class InputFilterTest extends BaseInputFilterTest
         $filter1->setData(['nested' => null]);
         self::assertEquals($expect, $filter1->getValues());
     }
+
+    public function testInputsWithoutANameYieldMergedInputsWithAnEmptyName(): void
+    {
+        $a = new Input();
+        $b = new Input();
+
+        $filter = new InputFilter();
+        $filter->add($a);
+        $filter->add($b);
+
+        self::assertCount(1, $filter->getInputs());
+        self::assertSame($a, $filter->get(''));
+    }
 }

--- a/test/OptionalInputFilterTest.php
+++ b/test/OptionalInputFilterTest.php
@@ -122,6 +122,7 @@ class OptionalInputFilterTest extends TestCase
     protected function getNestedCarInputFilter(): InputFilter
     {
         if (! $this->nestedCarInputFilter) {
+            /** @var OptionalInputFilter<array{brand: mixed, model:mixed}> $optionalInputFilter */
             $optionalInputFilter = new OptionalInputFilter();
             $optionalInputFilter->add(new Input('brand'));
             $optionalInputFilter->add(new Input('model'));

--- a/test/StaticAnalysis/AddingInputsWithArraySpecs.php
+++ b/test/StaticAnalysis/AddingInputsWithArraySpecs.php
@@ -8,7 +8,10 @@ use Laminas\Filter\StringTrim;
 use Laminas\InputFilter\InputFilter;
 use Laminas\Validator\NotEmpty;
 
-/** @psalm-suppress UnusedClass */
+/**
+ * @extends InputFilter<array<string, mixed>>
+ * @psalm-suppress UnusedClass
+ */
 final class AddingInputsWithArraySpecs extends InputFilter
 {
     public function addsAnInputWithAnArraySpec(): void

--- a/test/StaticAnalysis/CollectionWithTemplatedValues.php
+++ b/test/StaticAnalysis/CollectionWithTemplatedValues.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\InputFilter\StaticAnalysis;
+
+use Laminas\InputFilter\CollectionInputFilter;
+
+/**
+ * @psalm-import-type FilteredValues from InputFilterWithTemplatedValues as CollectionShape
+ * @psalm-type FilteredValues = array<array-key, CollectionShape>
+ * @extends CollectionInputFilter<FilteredValues>
+ */
+final class CollectionWithTemplatedValues extends CollectionInputFilter
+{
+    public function init(): void
+    {
+        $this->setInputFilter(new InputFilterWithTemplatedValues());
+    }
+}

--- a/test/StaticAnalysis/InputFilterTemplateInfersFilterValueTypes.php
+++ b/test/StaticAnalysis/InputFilterTemplateInfersFilterValueTypes.php
@@ -5,12 +5,16 @@ declare(strict_types=1);
 namespace LaminasTest\InputFilter\StaticAnalysis;
 
 use function assert;
+use function count;
+use function reset;
 
+/** @psalm-suppress UnusedClass */
 final class InputFilterTemplateInfersFilterValueTypes
 {
     public function __construct(
         private readonly InputFilterWithTemplatedValues $inputFilter,
         private readonly NestedInputFilterWithTemplatedValues $nestedFilter,
+        private readonly CollectionWithTemplatedValues $collection,
     ) {
     }
 
@@ -45,5 +49,19 @@ final class InputFilterTemplateInfersFilterValueTypes
         assert($this->nestedFilter->isValid());
 
         return $this->nestedFilter->getValues()['nested']['someString'];
+    }
+
+    /** @param array<array-key, mixed> $input */
+    public function retrieveCollectionValue(array $input): int
+    {
+        $this->collection->setData($input);
+        assert($this->collection->isValid());
+
+        $values = $this->collection->getValues();
+        assert(count($values) >= 1);
+
+        $first = reset($values);
+
+        return $first['someInt'];
     }
 }

--- a/test/StaticAnalysis/InputFilterTemplateInfersFilterValueTypes.php
+++ b/test/StaticAnalysis/InputFilterTemplateInfersFilterValueTypes.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\InputFilter\StaticAnalysis;
+
+use function assert;
+
+final class InputFilterTemplateInfersFilterValueTypes
+{
+    public function __construct(
+        private readonly InputFilterWithTemplatedValues $inputFilter,
+        private readonly NestedInputFilterWithTemplatedValues $nestedFilter,
+    ) {
+    }
+
+    /** @param array<array-key, mixed> $input */
+    public function retrieveInteger(array $input): int
+    {
+        $this->inputFilter->setData($input);
+        assert($this->inputFilter->isValid());
+
+        return $this->inputFilter->getValues()['someInt'];
+    }
+
+    /**
+     * @param array<array-key, mixed> $input
+     * @return non-empty-string
+     */
+    public function retrieveString(array $input): string
+    {
+        $this->inputFilter->setData($input);
+        assert($this->inputFilter->isValid());
+
+        return $this->inputFilter->getValues()['someString'];
+    }
+
+    /**
+     * @param array<array-key, mixed> $input
+     * @return non-empty-string
+     */
+    public function retrieveNestedString(array $input): string
+    {
+        $this->nestedFilter->setData($input);
+        assert($this->nestedFilter->isValid());
+
+        return $this->nestedFilter->getValues()['nested']['someString'];
+    }
+}

--- a/test/StaticAnalysis/InputFilterWithTemplatedValues.php
+++ b/test/StaticAnalysis/InputFilterWithTemplatedValues.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\InputFilter\StaticAnalysis;
+
+use Laminas\Filter\StringTrim;
+use Laminas\Filter\ToInt;
+use Laminas\Filter\ToNull;
+use Laminas\InputFilter\InputFilter;
+
+/**
+ * @psalm-type FilteredValues = array{
+ *     someInt: int,
+ *     someString: non-empty-string,
+ * }
+ * @extends InputFilter<FilteredValues>
+ */
+final class InputFilterWithTemplatedValues extends InputFilter
+{
+    public function init(): void
+    {
+        $this->add([
+            'name'     => 'someInt',
+            'required' => true,
+            'filters'  => [
+                'toNull' => ['name' => ToNull::class],
+                'toInt'  => ['name' => ToInt::class],
+            ],
+        ]);
+
+        $this->add([
+            'name'     => 'someString',
+            'required' => true,
+            'filters'  => [
+                'trim'   => ['name' => StringTrim::class],
+                'toNull' => ['name' => ToNull::class],
+            ],
+        ]);
+    }
+}

--- a/test/StaticAnalysis/NestedInputFilterWithTemplatedValues.php
+++ b/test/StaticAnalysis/NestedInputFilterWithTemplatedValues.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\InputFilter\StaticAnalysis;
+
+use Laminas\Filter\StringTrim;
+use Laminas\Filter\ToInt;
+use Laminas\Filter\ToNull;
+use Laminas\InputFilter\InputFilter;
+
+/**
+ * @psalm-type FilteredValues = array{
+ *     someInt: int,
+ *     someString: non-empty-string,
+ *     nested: array {
+ *         someInt: int,
+ *         someString: non-empty-string,
+ *     }
+ * }
+ * @extends InputFilter<FilteredValues>
+ */
+final class NestedInputFilterWithTemplatedValues extends InputFilter
+{
+    public function init(): void
+    {
+        $this->add([
+            'name'     => 'someInt',
+            'required' => true,
+            'filters'  => [
+                'toNull' => ['name' => ToNull::class],
+                'toInt'  => ['name' => ToInt::class],
+            ],
+        ]);
+
+        $this->add([
+            'name'     => 'someString',
+            'required' => true,
+            'filters'  => [
+                'trim'   => ['name' => StringTrim::class],
+                'toNull' => ['name' => ToNull::class],
+            ],
+        ]);
+
+        $this->add([
+            'name' => 'nested',
+            'type' => InputFilterWithTemplatedValues::class,
+        ]);
+    }
+}

--- a/test/TestAsset/Foo.php
+++ b/test/TestAsset/Foo.php
@@ -6,6 +6,7 @@ namespace LaminasTest\InputFilter\TestAsset;
 
 use Laminas\InputFilter\BaseInputFilter;
 
+/** @extends BaseInputFilter<array<array-key, mixed>> */
 class Foo extends BaseInputFilter
 {
 }

--- a/test/TestAsset/InputFilterInterfaceStub.php
+++ b/test/TestAsset/InputFilterInterfaceStub.php
@@ -5,11 +5,13 @@ declare(strict_types=1);
 namespace LaminasTest\InputFilter\TestAsset;
 
 use Laminas\InputFilter\InputFilter;
-use Laminas\InputFilter\InputFilterInterface;
 
 use function PHPUnit\Framework\assertNotNull;
 
-final class InputFilterInterfaceStub extends InputFilter implements InputFilterInterface
+/**
+ * @extends InputFilter<array<array-key, mixed>>
+ */
+final class InputFilterInterfaceStub extends InputFilter
 {
     /**
      * @param array<string, mixed> $getRawValues


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| RFC           | yes

### Description

Adds a template to InputFilterInterface to define the array shape of filtered values

The plan here is better inference when calling `InputFilterInterface::getValues()`. It might cause a lot of noise for users because psalm requires a template declaration for all inheritors, that said, it'd be useful to those who care.

Once merged, users will be able to define an input filter such as:

```php
/**
 * @psalm-type ValidPayload = array{
 *   inputA: non-empty-string,
 *   inputB: int,
 *   inputC: DateTimeImmutable,
 * @extends InputFilter<ValidPayload>
 */
final class MyInputFilter extends InputFilter
{
  public function init(): void
  {
    // Set up inputs according to desired constraints…
  }
}
```

… and psalm will infer the types for whatever comes out of `$inputFilter->getValues()` such as:

```php
$values = $inputFilter->getValues();

printf('The Date is %s', $values['inputC']->format('Y-m-d'));
```

As part of wrestling with Psalm on this patch, it's worth mentioning that all **input** names can now be `array-key` as opposed to `string`. This is not really related to the patch but something I had to address because `CollectionInputFilter` is effectively a nested list, it's actually a requirement to be able to fetch an input with something like `$inputFilter->get(1)`

This work has also uncovered at least one or two subtle bugs or ambiguous behaviour and fixes an issue where `InputFilter::add` will attempt to call `Input::merge` with an `InputFilter` as an argument
