### PR TITLE
Improve inference for `InputFilterPluginManager::get()`

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -282,7 +282,7 @@
       <code>get</code>
     </MethodSignatureMustProvideReturnType>
     <MixedInferredReturnType>
-      <code><![CDATA[($name is class-string<T1> ? T1 : ($name is class-string<T2> ? T2 : T1|T2))]]></code>
+      <code><![CDATA[($name is class-string<T> ? T : InputInterface|InputFilterInterface)]]></code>
     </MixedInferredReturnType>
     <MixedReturnStatement>
       <code>parent::get($name, $options)</code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -104,12 +104,6 @@
     </PossiblyUnusedReturnValue>
   </file>
   <file src="src/Factory.php">
-    <InvalidReturnStatement>
-      <code>$inputFilter</code>
-    </InvalidReturnStatement>
-    <InvalidReturnType>
-      <code>InputFilterInterface</code>
-    </InvalidReturnType>
     <MixedArgument>
       <code><![CDATA[$inputFilterSpecification['count']]]></code>
       <code><![CDATA[$inputFilterSpecification['input_filter']]]></code>
@@ -142,10 +136,6 @@
       <code>$value</code>
       <code>$value</code>
     </PossiblyInvalidArgument>
-    <PossiblyUndefinedMethod>
-      <code>add</code>
-      <code>add</code>
-    </PossiblyUndefinedMethod>
     <UnusedPsalmSuppress>
       <code>DeprecatedMethod</code>
       <code>DocblockTypeContradiction</code>
@@ -288,9 +278,6 @@
       <code>InputFilterPluginManager</code>
       <code>InputFilterPluginManager</code>
     </MethodSignatureMismatch>
-    <MethodSignatureMustProvideReturnType>
-      <code>Plu</code>
-    </MethodSignatureMustProvideReturnType>
     <NonInvariantDocblockPropertyType>
       <code>$factories</code>
     </NonInvariantDocblockPropertyType>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -278,6 +278,15 @@
       <code>InputFilterPluginManager</code>
       <code>InputFilterPluginManager</code>
     </MethodSignatureMismatch>
+    <MethodSignatureMustProvideReturnType>
+      <code>get</code>
+    </MethodSignatureMustProvideReturnType>
+    <MixedInferredReturnType>
+      <code><![CDATA[($name is class-string<T1> ? T1 : ($name is class-string<T2> ? T2 : T1|T2))]]></code>
+    </MixedInferredReturnType>
+    <MixedReturnStatement>
+      <code>parent::get($name, $options)</code>
+    </MixedReturnStatement>
     <NonInvariantDocblockPropertyType>
       <code>$factories</code>
     </NonInvariantDocblockPropertyType>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -282,7 +282,7 @@
       <code>get</code>
     </MethodSignatureMustProvideReturnType>
     <MixedInferredReturnType>
-      <code><![CDATA[($name is class-string<T> ? T : InputInterface|InputFilterInterface)]]></code>
+      <code><![CDATA[($name is class-string<InputInterface> ? T1 : ($name is class-string<InputFilterInterface> ? T2 : InputInterface|InputFilterInterface))]]></code>
     </MixedInferredReturnType>
     <MixedReturnStatement>
       <code>parent::get($name, $options)</code>

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -22,6 +22,14 @@
         <pluginClass class="Psalm\PhpUnitPlugin\Plugin"/>
     </plugins>
 
+    <issueHandlers>
+        <UnusedClass>
+            <errorLevel type="suppress">
+                <directory name="test/StaticAnalysis" />
+            </errorLevel>
+        </UnusedClass>
+    </issueHandlers>
+
     <stubs>
         <file name=".psr-container.php.stub" preloadClasses="true" />
     </stubs>

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -28,6 +28,11 @@
                 <directory name="test/StaticAnalysis" />
             </errorLevel>
         </UnusedClass>
+        <PossiblyUnusedMethod>
+            <errorLevel type="suppress">
+                <directory name="test/StaticAnalysis" />
+            </errorLevel>
+        </PossiblyUnusedMethod>
     </issueHandlers>
 
     <stubs>

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -12,6 +12,7 @@ use Laminas\Validator\ValidatorChain;
 use Laminas\Validator\ValidatorInterface;
 use Traversable;
 
+use function assert;
 use function class_exists;
 use function get_debug_type;
 use function gettype;
@@ -317,6 +318,7 @@ class Factory
         }
 
         $inputFilter = $this->getInputFilterManager()->get($type);
+        assert($inputFilter instanceof InputFilterInterface); // As opposed to InputInterface
 
         if ($inputFilter instanceof CollectionInputFilter) {
             $inputFilter->setFactory($this);

--- a/src/InputFilterPluginManager.php
+++ b/src/InputFilterPluginManager.php
@@ -190,9 +190,12 @@ class InputFilterPluginManager extends AbstractPluginManager
 
     /**
      * @inheritDoc
-     * @template T of InputInterface|InputFilterInterface
-     * @param class-string<T>|string $name
-     * @return ($name is class-string<T> ? T : InputInterface|InputFilterInterface)
+     * phpcs:disable Generic.Files.LineLength.TooLong
+     * // Template constraint required or we get mixed added to output. Two templates because union does not work
+     * @template T1 of InputInterface
+     * @template T2 of InputFilterInterface
+     * @param class-string<T1>|class-string<T2>|string $name
+     * @return ($name is class-string<InputInterface> ? T1 : ($name is class-string<InputFilterInterface> ? T2 : InputInterface|InputFilterInterface))
      */
     public function get($name, ?array $options = null)
     {

--- a/src/InputFilterPluginManager.php
+++ b/src/InputFilterPluginManager.php
@@ -26,7 +26,6 @@ use function sprintf;
  * @psalm-import-type ServiceManagerConfiguration from ServiceManager
  * @template InstanceType of InputFilterInterface|InputInterface
  * @extends AbstractPluginManager<InstanceType>
- * @method InputFilterInterface|InputInterface get(string $name, ?array $options = null)
  */
 class InputFilterPluginManager extends AbstractPluginManager
 {
@@ -187,5 +186,18 @@ class InputFilterPluginManager extends AbstractPluginManager
         } catch (InvalidServiceException $e) {
             throw new Exception\RuntimeException($e->getMessage(), $e->getCode(), $e);
         }
+    }
+
+    /**
+     * @inheritDoc
+     * @template T1 of InputInterface
+     * @template T2 of InputFilterInterface
+     * @param class-string<T1>|class-string<T2>|string $name
+     * @return T1|T2
+     * @psalm-return ($name is class-string<T1> ? T1 : ($name is class-string<T2> ? T2 : T1|T2))
+     */
+    public function get($name, ?array $options = null)
+    {
+        return parent::get($name, $options);
     }
 }

--- a/src/InputFilterPluginManager.php
+++ b/src/InputFilterPluginManager.php
@@ -190,11 +190,9 @@ class InputFilterPluginManager extends AbstractPluginManager
 
     /**
      * @inheritDoc
-     * @template T1 of InputInterface
-     * @template T2 of InputFilterInterface
-     * @param class-string<T1>|class-string<T2>|string $name
-     * @return T1|T2
-     * @psalm-return ($name is class-string<T1> ? T1 : ($name is class-string<T2> ? T2 : T1|T2))
+     * @template T of InputInterface|InputFilterInterface
+     * @param class-string<T>|string $name
+     * @return ($name is class-string<T> ? T : InputInterface|InputFilterInterface)
      */
     public function get($name, ?array $options = null)
     {

--- a/test/StaticAnalysis/AddingInputsWithArraySpecs.php
+++ b/test/StaticAnalysis/AddingInputsWithArraySpecs.php
@@ -10,7 +10,6 @@ use Laminas\Validator\NotEmpty;
 
 /**
  * @extends InputFilter<array<string, mixed>>
- * @psalm-suppress UnusedClass
  */
 final class AddingInputsWithArraySpecs extends InputFilter
 {

--- a/test/StaticAnalysis/InputFilterPluginManagerType.php
+++ b/test/StaticAnalysis/InputFilterPluginManagerType.php
@@ -24,4 +24,9 @@ final class InputFilterPluginManagerType
     {
         return $this->manager->get(InputFilterWithTemplatedValues::class);
     }
+
+    public function getInvalidFQCNReturnsFallbackType(): InputInterface|InputFilterInterface
+    {
+        return $this->manager->get(self::class);
+    }
 }

--- a/test/StaticAnalysis/InputFilterPluginManagerType.php
+++ b/test/StaticAnalysis/InputFilterPluginManagerType.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\InputFilter\StaticAnalysis;
+
+use Laminas\InputFilter\InputFilterInterface;
+use Laminas\InputFilter\InputFilterPluginManager;
+use Laminas\InputFilter\InputInterface;
+
+final class InputFilterPluginManagerType
+{
+    public function __construct(private InputFilterPluginManager $manager)
+    {
+    }
+
+    public function getWillReturnAnInputOrInputFilterGivenAString(
+        string $anyString,
+    ): InputInterface|InputFilterInterface {
+        return $this->manager->get($anyString);
+    }
+
+    public function getWithFQCNWillReturnTheObjectOfType(): InputFilterWithTemplatedValues
+    {
+        return $this->manager->get(InputFilterWithTemplatedValues::class);
+    }
+}

--- a/test/StaticAnalysis/InputFilterTemplateInfersFilterValueTypes.php
+++ b/test/StaticAnalysis/InputFilterTemplateInfersFilterValueTypes.php
@@ -8,7 +8,6 @@ use function assert;
 use function count;
 use function reset;
 
-/** @psalm-suppress UnusedClass */
 final class InputFilterTemplateInfersFilterValueTypes
 {
     public function __construct(


### PR DESCRIPTION
Currently, `InputFilterPluginManager::get(FQCN::class)` yields the union of `InputFilterInterface|InputInterface`.

Ideally, this would be the given FQCN when it implements one of those interfaces.

Also, the `@method get` docblock is problematic as it trumps any user defined stubs and causes other problems that I can't remember!

Because the plugin manager here is guaranteed to return `InputFilterInterface|InputInterface` as opposed to `T|mixed`, this conflicts with `AbstractPluginManager::get()`.

Furthermore, I think psalm might have issues with `class-string<PsalmAliasOfUnion>`.

This patch provides correct inference for consumers when they provide a FQCN or string alias at the expense of 2 or 3 extra baselined issues that I believe are due to using a union type for `InstanceType` on the class level template.

