### PR TITLE
Reinstate `ArrayInput` default value to an empty array

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,6 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <files psalm-version="5.23.1@8471a896ccea3526b26d082f4461eeea467f10a4">
   <file src="src/ArrayInput.php">
+    <DeprecatedProperty>
+      <code><![CDATA[$this->value]]></code>
+      <code><![CDATA[$this->value]]></code>
+      <code><![CDATA[$this->value]]></code>
+      <code><![CDATA[$this->value]]></code>
+    </DeprecatedProperty>
     <InvalidPropertyAssignmentValue>
       <code><![CDATA[$this->prepareNotArrayFailureMessage()]]></code>
       <code><![CDATA[$this->prepareRequiredValidationFailureMessage()]]></code>

--- a/src/ArrayInput.php
+++ b/src/ArrayInput.php
@@ -12,6 +12,25 @@ use function is_array;
 
 class ArrayInput extends Input
 {
+    /**
+     * @deprecated since 2.30.1 The default value should be null as in parent `Input`
+     *
+     * @var mixed
+     */
+    protected $value = [];
+
+    /**
+     * @deprecated since 2.30.1 Once the default value is null, this method is no longer required
+     *
+     * @inheritDoc
+     */
+    public function resetValue()
+    {
+        $this->value    = [];
+        $this->hasValue = false;
+        return $this;
+    }
+
     /** @inheritDoc */
     public function getValue()
     {

--- a/test/ArrayInputTest.php
+++ b/test/ArrayInputTest.php
@@ -29,9 +29,13 @@ class ArrayInputTest extends InputTest
         $this->input = new ArrayInput('foo');
     }
 
+    /**
+     * @deprecated Since 2.30.1 The default value should be null in the next major,
+     *             therefore this test can be dropped in favour of parent::testDefaultGetValue()
+     */
     public function testDefaultGetValue(): void
     {
-        self::assertNull($this->input->getValue());
+        self::assertSame([], $this->input->getValue());
     }
 
     public function testArrayInputMarkedRequiredWithoutAFallbackFailsValidationForEmptyArrays(): void


### PR DESCRIPTION
Reinstates removed method and property in `ArrayInput` and also deprecates them so that the default value for an ArrayInput is an empty array, maintaining BC with the 2.x series

Fixes #106 
