### PR TITLE
Update `laminas-validator` to `2.61.0`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "laminas/laminas-filter": "^2.19",
         "laminas/laminas-servicemanager": "^3.21.0",
         "laminas/laminas-stdlib": "^3.0",
-        "laminas/laminas-validator": "^2.52"
+        "laminas/laminas-validator": "^2.60.0"
     },
     "require-dev": {
         "ext-json": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b36b67fe2925d3f4919c3b6eb31ec055",
+    "content-hash": "6462a7622ca48521265f603dfd74a3f6",
     "packages": [
         {
             "name": "laminas/laminas-filter",
@@ -236,16 +236,16 @@
         },
         {
             "name": "laminas/laminas-validator",
-            "version": "2.59.0",
+            "version": "2.61.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-validator.git",
-                "reference": "1ea93397469ddf2d5989706b8d85ab1806b6c5e9"
+                "reference": "df77732fbfab331647a5e718d171507269e73b6c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-validator/zipball/1ea93397469ddf2d5989706b8d85ab1806b6c5e9",
-                "reference": "1ea93397469ddf2d5989706b8d85ab1806b6c5e9",
+                "url": "https://api.github.com/repos/laminas/laminas-validator/zipball/df77732fbfab331647a5e718d171507269e73b6c",
+                "reference": "df77732fbfab331647a5e718d171507269e73b6c",
                 "shasum": ""
             },
             "require": {
@@ -316,7 +316,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2024-06-19T14:26:44+00:00"
+            "time": "2024-07-11T21:26:44+00:00"
         },
         {
             "name": "psr/container",
@@ -1698,16 +1698,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "10.1.14",
+            "version": "10.1.15",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "e3f51450ebffe8e0efdf7346ae966a656f7d5e5b"
+                "reference": "5da8b1728acd1e6ffdf2ff32ffbdfd04307f26ae"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/e3f51450ebffe8e0efdf7346ae966a656f7d5e5b",
-                "reference": "e3f51450ebffe8e0efdf7346ae966a656f7d5e5b",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/5da8b1728acd1e6ffdf2ff32ffbdfd04307f26ae",
+                "reference": "5da8b1728acd1e6ffdf2ff32ffbdfd04307f26ae",
                 "shasum": ""
             },
             "require": {
@@ -1764,7 +1764,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
                 "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/10.1.14"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/10.1.15"
             },
             "funding": [
                 {
@@ -1772,7 +1772,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-03-12T15:33:41+00:00"
+            "time": "2024-06-29T08:25:15+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -2019,16 +2019,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "10.5.24",
+            "version": "10.5.27",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "5f124e3e3e561006047b532fd0431bf5bb6b9015"
+                "reference": "2425f713b2a5350568ccb1a2d3984841a23e83c5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/5f124e3e3e561006047b532fd0431bf5bb6b9015",
-                "reference": "5f124e3e3e561006047b532fd0431bf5bb6b9015",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/2425f713b2a5350568ccb1a2d3984841a23e83c5",
+                "reference": "2425f713b2a5350568ccb1a2d3984841a23e83c5",
                 "shasum": ""
             },
             "require": {
@@ -2038,26 +2038,26 @@
                 "ext-mbstring": "*",
                 "ext-xml": "*",
                 "ext-xmlwriter": "*",
-                "myclabs/deep-copy": "^1.10.1",
-                "phar-io/manifest": "^2.0.3",
-                "phar-io/version": "^3.0.2",
+                "myclabs/deep-copy": "^1.12.0",
+                "phar-io/manifest": "^2.0.4",
+                "phar-io/version": "^3.2.1",
                 "php": ">=8.1",
-                "phpunit/php-code-coverage": "^10.1.5",
-                "phpunit/php-file-iterator": "^4.0",
-                "phpunit/php-invoker": "^4.0",
-                "phpunit/php-text-template": "^3.0",
-                "phpunit/php-timer": "^6.0",
-                "sebastian/cli-parser": "^2.0",
-                "sebastian/code-unit": "^2.0",
-                "sebastian/comparator": "^5.0",
-                "sebastian/diff": "^5.0",
-                "sebastian/environment": "^6.0",
-                "sebastian/exporter": "^5.1",
-                "sebastian/global-state": "^6.0.1",
-                "sebastian/object-enumerator": "^5.0",
-                "sebastian/recursion-context": "^5.0",
-                "sebastian/type": "^4.0",
-                "sebastian/version": "^4.0"
+                "phpunit/php-code-coverage": "^10.1.15",
+                "phpunit/php-file-iterator": "^4.1.0",
+                "phpunit/php-invoker": "^4.0.0",
+                "phpunit/php-text-template": "^3.0.1",
+                "phpunit/php-timer": "^6.0.0",
+                "sebastian/cli-parser": "^2.0.1",
+                "sebastian/code-unit": "^2.0.0",
+                "sebastian/comparator": "^5.0.1",
+                "sebastian/diff": "^5.1.1",
+                "sebastian/environment": "^6.1.0",
+                "sebastian/exporter": "^5.1.2",
+                "sebastian/global-state": "^6.0.2",
+                "sebastian/object-enumerator": "^5.0.0",
+                "sebastian/recursion-context": "^5.0.0",
+                "sebastian/type": "^4.0.0",
+                "sebastian/version": "^4.0.1"
             },
             "suggest": {
                 "ext-soap": "To be able to generate mocks based on WSDL files"
@@ -2100,7 +2100,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.24"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.27"
             },
             "funding": [
                 {
@@ -2116,7 +2116,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-06-20T13:09:54+00:00"
+            "time": "2024-07-10T11:48:06+00:00"
         },
         {
             "name": "psalm/plugin-phpunit",
@@ -3355,16 +3355,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v6.4.8",
+            "version": "v6.4.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "be5854cee0e8c7b110f00d695d11debdfa1a2a91"
+                "reference": "6edb5363ec0c78ad4d48c5128ebf4d083d89d3a9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/be5854cee0e8c7b110f00d695d11debdfa1a2a91",
-                "reference": "be5854cee0e8c7b110f00d695d11debdfa1a2a91",
+                "url": "https://api.github.com/repos/symfony/console/zipball/6edb5363ec0c78ad4d48c5128ebf4d083d89d3a9",
+                "reference": "6edb5363ec0c78ad4d48c5128ebf4d083d89d3a9",
                 "shasum": ""
             },
             "require": {
@@ -3429,7 +3429,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v6.4.8"
+                "source": "https://github.com/symfony/console/tree/v6.4.9"
             },
             "funding": [
                 {
@@ -3445,7 +3445,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-05-31T14:49:08+00:00"
+            "time": "2024-06-28T09:49:33+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -3516,16 +3516,16 @@
         },
         {
             "name": "symfony/filesystem",
-            "version": "v6.4.8",
+            "version": "v6.4.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "4d37529150e7081c51b3c5d5718c55a04a9503f3"
+                "reference": "b51ef8059159330b74a4d52f68e671033c0fe463"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/4d37529150e7081c51b3c5d5718c55a04a9503f3",
-                "reference": "4d37529150e7081c51b3c5d5718c55a04a9503f3",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/b51ef8059159330b74a4d52f68e671033c0fe463",
+                "reference": "b51ef8059159330b74a4d52f68e671033c0fe463",
                 "shasum": ""
             },
             "require": {
@@ -3562,7 +3562,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v6.4.8"
+                "source": "https://github.com/symfony/filesystem/tree/v6.4.9"
             },
             "funding": [
                 {
@@ -3578,7 +3578,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-05-31T14:49:08+00:00"
+            "time": "2024-06-28T09:49:33+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -3983,16 +3983,16 @@
         },
         {
             "name": "symfony/string",
-            "version": "v6.4.8",
+            "version": "v6.4.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "a147c0f826c4a1f3afb763ab8e009e37c877a44d"
+                "reference": "76792dbd99690a5ebef8050d9206c60c59e681d7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/a147c0f826c4a1f3afb763ab8e009e37c877a44d",
-                "reference": "a147c0f826c4a1f3afb763ab8e009e37c877a44d",
+                "url": "https://api.github.com/repos/symfony/string/zipball/76792dbd99690a5ebef8050d9206c60c59e681d7",
+                "reference": "76792dbd99690a5ebef8050d9206c60c59e681d7",
                 "shasum": ""
             },
             "require": {
@@ -4049,7 +4049,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v6.4.8"
+                "source": "https://github.com/symfony/string/tree/v6.4.9"
             },
             "funding": [
                 {
@@ -4065,7 +4065,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-05-31T14:49:08+00:00"
+            "time": "2024-06-28T09:25:38+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="5.24.0@462c80e31c34e58cc4f750c656be3927e80e550e">
+<files psalm-version="5.25.0@01a8eb06b9e9cc6cfb6a320bf9fb14331919d505">
   <file src="src/ArrayInput.php">
     <DeprecatedProperty>
       <code><![CDATA[$this->value]]></code>
@@ -50,6 +50,13 @@
     </UnusedPsalmSuppress>
   </file>
   <file src="src/CollectionInputFilter.php">
+    <DeprecatedInterface>
+      <code><![CDATA[$notEmptyValidator->getTranslator()]]></code>
+    </DeprecatedInterface>
+    <DeprecatedMethod>
+      <code><![CDATA[getOption]]></code>
+      <code><![CDATA[getTranslatorTextDomain]]></code>
+    </DeprecatedMethod>
     <ImplementedParamTypeMismatch>
       <code><![CDATA[$name]]></code>
       <code><![CDATA[$name]]></code>
@@ -188,6 +195,10 @@
     </MoreSpecificImplementedParamType>
   </file>
   <file src="src/Input.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getOption]]></code>
+      <code><![CDATA[getTranslatorTextDomain]]></code>
+    </DeprecatedMethod>
     <DocblockTypeContradiction>
       <code><![CDATA[is_array($this->errorMessage)]]></code>
     </DocblockTypeContradiction>
@@ -543,6 +554,9 @@
     </PossiblyUnusedMethod>
   </file>
   <file src="test/FactoryTest.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getMessageTemplates]]></code>
+    </DeprecatedMethod>
     <PossiblyNullReference>
       <code><![CDATA[getPluginManager]]></code>
       <code><![CDATA[getPluginManager]]></code>
@@ -673,6 +687,9 @@
     </PossiblyInvalidArgument>
   </file>
   <file src="test/InputTest.php">
+    <DeprecatedInterface>
+      <code><![CDATA[$translator]]></code>
+    </DeprecatedInterface>
     <InvalidReturnStatement>
       <code><![CDATA[[
             // Description => [$value]

--- a/test/CollectionInputFilterTest.php
+++ b/test/CollectionInputFilterTest.php
@@ -12,9 +12,9 @@ use Laminas\InputFilter\Factory;
 use Laminas\InputFilter\Input;
 use Laminas\InputFilter\InputFilter;
 use Laminas\InputFilter\InputFilterInterface;
-use Laminas\Validator\Between;
 use Laminas\Validator\Digits;
 use Laminas\Validator\NotEmpty;
+use Laminas\Validator\NumberComparison;
 use LaminasTest\InputFilter\TestAsset\InputFilterInterfaceStub;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -620,7 +620,7 @@ class CollectionInputFilterTest extends TestCase
                                         'required'   => false,
                                         'validators' => [
                                             [
-                                                'name'    => Between::class,
+                                                'name'    => NumberComparison::class,
                                                 'options' => [
                                                     'min'     => 50,
                                                     'max'     => 100,
@@ -633,7 +633,7 @@ class CollectionInputFilterTest extends TestCase
                                         'required'   => false,
                                         'validators' => [
                                             [
-                                                'name'    => Between::class,
+                                                'name'    => NumberComparison::class,
                                                 'options' => [
                                                     'min'     => 50,
                                                     'max'     => 100,
@@ -690,26 +690,26 @@ class CollectionInputFilterTest extends TestCase
                         'test_field' => [
                             [
                                 'test_field1' => [
-                                    'notBetween' => '-20 is incorrect',
+                                    NumberComparison::ERROR_NOT_GREATER_INCLUSIVE => '-20 is incorrect',
                                 ],
                                 'price'       => [
-                                    'notBetween' => '20 is incorrect',
+                                    NumberComparison::ERROR_NOT_GREATER_INCLUSIVE => '20 is incorrect',
                                 ],
                             ],
                             [
                                 'test_field1' => [
-                                    'notBetween' => '-15 is incorrect',
+                                    NumberComparison::ERROR_NOT_GREATER_INCLUSIVE => '-15 is incorrect',
                                 ],
                                 'price'       => [
-                                    'notBetween' => '15 is incorrect',
+                                    NumberComparison::ERROR_NOT_GREATER_INCLUSIVE => '15 is incorrect',
                                 ],
                             ],
                             [
                                 'test_field1' => [
-                                    'notBetween' => '-10 is incorrect',
+                                    NumberComparison::ERROR_NOT_GREATER_INCLUSIVE => '-10 is incorrect',
                                 ],
                                 'price'       => [
-                                    'notBetween' => '10 is incorrect',
+                                    NumberComparison::ERROR_NOT_GREATER_INCLUSIVE => '10 is incorrect',
                                 ],
                             ],
                         ],
@@ -718,10 +718,10 @@ class CollectionInputFilterTest extends TestCase
                         'test_field' => [
                             [
                                 'test_field1' => [
-                                    'notBetween' => '-5 is incorrect',
+                                    NumberComparison::ERROR_NOT_GREATER_INCLUSIVE => '-5 is incorrect',
                                 ],
                                 'price'       => [
-                                    'notBetween' => '5 is incorrect',
+                                    NumberComparison::ERROR_NOT_GREATER_INCLUSIVE => '5 is incorrect',
                                 ],
                             ],
                         ],

--- a/test/FactoryTest.php
+++ b/test/FactoryTest.php
@@ -413,8 +413,10 @@ class FactoryTest extends TestCase
                     break;
                 case 2:
                     self::assertInstanceOf(Validator\StringLength::class, $validator);
-                    self::assertEquals(3, $validator->getMin());
-                    self::assertEquals(5, $validator->getMax());
+                    self::assertFalse($validator->isValid('aa'));
+                    self::assertFalse($validator->isValid('aaaaaa'));
+                    self::assertTrue($validator->isValid('aaa'));
+                    self::assertTrue($validator->isValid('aaaaa'));
                     break;
                 default:
                     self::fail('Found more validators than expected');

--- a/test/InputTest.php
+++ b/test/InputTest.php
@@ -9,8 +9,8 @@ use Laminas\Filter\ToNull;
 use Laminas\InputFilter\Input;
 use Laminas\InputFilter\InputInterface;
 use Laminas\Validator\AbstractValidator;
-use Laminas\Validator\Between;
 use Laminas\Validator\NotEmpty as NotEmptyValidator;
+use Laminas\Validator\NumberComparison;
 use Laminas\Validator\Translator\TranslatorInterface;
 use Laminas\Validator\ValidatorChain;
 use Laminas\Validator\ValidatorInterface;
@@ -593,7 +593,7 @@ class InputTest extends TestCase
     public function testThatMergingTwoInputsMergesTheValidatorChain(): void
     {
         $validator1 = new NotEmptyValidator();
-        $validator2 = new Between(['min' => 1, 'max' => 5]);
+        $validator2 = new NumberComparison(['min' => 1, 'max' => 5]);
 
         $a = new Input('a');
         $b = new Input('b');


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| QA            | yes

### Description

[2.61.0](https://github.com/laminas/laminas-validator/releases/tag/2.61.0) has a number of deprecations.

Tests adjusted to account for deprecations and those that cannot be dealt with without a BC break are base-lined

Minimum validator version requirement is bumped to 2.60 so that we can replace usage of the deprecated `Between` validator with the `NumberComparison` validator
