### PR TITLE
Fix "Regression" in `input-filter@2.40.0`

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -8,16 +8,16 @@
     "packages": [
         {
             "name": "laminas/laminas-filter",
-            "version": "2.39.0",
+            "version": "2.40.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-filter.git",
-                "reference": "515f081cdbea90721bfbffdd15184564b256478e"
+                "reference": "9b32ba7c45a302ed349bf42061308e854d56e75b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-filter/zipball/515f081cdbea90721bfbffdd15184564b256478e",
-                "reference": "515f081cdbea90721bfbffdd15184564b256478e",
+                "url": "https://api.github.com/repos/laminas/laminas-filter/zipball/9b32ba7c45a302ed349bf42061308e854d56e75b",
+                "reference": "9b32ba7c45a302ed349bf42061308e854d56e75b",
                 "shasum": ""
             },
             "require": {
@@ -83,7 +83,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2024-10-31T21:18:49+00:00"
+            "time": "2025-01-06T21:36:57+00:00"
         },
         {
             "name": "laminas/laminas-servicemanager",

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -105,6 +105,13 @@
     </PossiblyUnusedReturnValue>
   </file>
   <file src="src/Factory.php">
+    <DeprecatedConstant>
+      <code><![CDATA[FilterChain::DEFAULT_PRIORITY]]></code>
+    </DeprecatedConstant>
+    <DeprecatedMethod>
+      <code><![CDATA[getPluginManager]]></code>
+      <code><![CDATA[setPluginManager]]></code>
+    </DeprecatedMethod>
     <MixedArgument>
       <code><![CDATA[$inputFilterSpecification['count']]]></code>
       <code><![CDATA[$inputFilterSpecification['input_filter']]]></code>
@@ -239,6 +246,9 @@
     <DeprecatedInterface>
       <code><![CDATA[InputFilterAbstractServiceFactory]]></code>
     </DeprecatedInterface>
+    <DeprecatedMethod>
+      <code><![CDATA[setPluginManager]]></code>
+    </DeprecatedMethod>
     <MixedArgument>
       <code><![CDATA[$config]]></code>
     </MixedArgument>
@@ -279,6 +289,9 @@
     <DeprecatedInterface>
       <code><![CDATA[null|ConfigInterface|ContainerInterface]]></code>
     </DeprecatedInterface>
+    <DeprecatedMethod>
+      <code><![CDATA[setPluginManager]]></code>
+    </DeprecatedMethod>
     <MethodSignatureMismatch>
       <code><![CDATA[InputFilterPluginManager]]></code>
       <code><![CDATA[InputFilterPluginManager]]></code>
@@ -553,8 +566,18 @@
     </PossiblyUnusedMethod>
   </file>
   <file src="test/FactoryTest.php">
+    <DeprecatedConstant>
+      <code><![CDATA[Filter\FilterChain::DEFAULT_PRIORITY]]></code>
+      <code><![CDATA[Filter\FilterChain::DEFAULT_PRIORITY]]></code>
+    </DeprecatedConstant>
     <DeprecatedMethod>
+      <code><![CDATA[getFilters]]></code>
       <code><![CDATA[getMessageTemplates]]></code>
+      <code><![CDATA[getPluginManager]]></code>
+      <code><![CDATA[getPluginManager]]></code>
+      <code><![CDATA[getPluginManager]]></code>
+      <code><![CDATA[setPluginManager]]></code>
+      <code><![CDATA[setPluginManager]]></code>
     </DeprecatedMethod>
     <PossiblyNullReference>
       <code><![CDATA[getPluginManager]]></code>
@@ -630,6 +653,13 @@
       <code><![CDATA[$generator instanceof Generator]]></code>
     </TypeDoesNotContainType>
   </file>
+  <file src="test/InputFilterAbstractServiceFactoryTest.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getFilters]]></code>
+      <code><![CDATA[getPluginManager]]></code>
+      <code><![CDATA[plugin]]></code>
+    </DeprecatedMethod>
+  </file>
   <file src="test/InputFilterPluginManagerCompatibilityTest.php">
     <InvalidReturnType>
       <code><![CDATA[getInstanceOf]]></code>
@@ -641,6 +671,9 @@
     </PossiblyUnusedMethod>
   </file>
   <file src="test/InputFilterPluginManagerTest.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getPluginManager]]></code>
+    </DeprecatedMethod>
     <LessSpecificReturnStatement>
       <code><![CDATA[[
             // Description         => [$serviceName,                  $service,                  $instanceOf]

--- a/test/InputFilterAbstractServiceFactoryTest.php
+++ b/test/InputFilterAbstractServiceFactoryTest.php
@@ -7,14 +7,12 @@ namespace LaminasTest\InputFilter;
 use Laminas\Filter;
 use Laminas\Filter\FilterChain;
 use Laminas\Filter\FilterPluginManager;
-use Laminas\InputFilter\FileInput;
 use Laminas\InputFilter\InputFilter;
 use Laminas\InputFilter\InputFilterAbstractServiceFactory;
 use Laminas\InputFilter\InputFilterInterface;
 use Laminas\InputFilter\InputFilterPluginManager;
 use Laminas\InputFilter\InputInterface;
 use Laminas\ServiceManager\ServiceManager;
-use Laminas\Validator;
 use Laminas\Validator\ValidatorChain;
 use Laminas\Validator\ValidatorInterface;
 use Laminas\Validator\ValidatorPluginManager;
@@ -23,7 +21,10 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Depends;
 use PHPUnit\Framework\TestCase;
 
+use function assert;
 use function call_user_func_array;
+use function is_string;
+use function strrev;
 
 #[CoversClass(InputFilterAbstractServiceFactory::class)]
 class InputFilterAbstractServiceFactoryTest extends TestCase
@@ -220,7 +221,20 @@ class InputFilterAbstractServiceFactoryTest extends TestCase
      */
     public function testWillUseCustomFiltersWhenProvided(): void
     {
-        $filter = $this->createMock(Filter\FilterInterface::class);
+        $filter = new class implements Filter\FilterInterface
+        {
+            public function filter(mixed $value): string
+            {
+                assert(is_string($value));
+
+                return strrev($value);
+            }
+
+            public function __invoke(mixed $value): string
+            {
+                return $this->filter($value);
+            }
+        };
 
         $filters = new FilterPluginManager($this->services);
         $filters->setService('CustomFilter', $filter);
@@ -234,31 +248,9 @@ class InputFilterAbstractServiceFactoryTest extends TestCase
             'input_filter_specs' => [
                 'test' => [
                     [
-                        'name'       => 'a-file-element',
-                        'type'       => FileInput::class,
+                        'name'       => 'value',
                         'required'   => true,
-                        'validators' => [
-                            [
-                                'name'    => Validator\File\UploadFile::class,
-                                'options' => [
-                                    'breakchainonfailure' => true,
-                                ],
-                            ],
-                            [
-                                'name'    => Validator\File\Size::class,
-                                'options' => [
-                                    'breakchainonfailure' => true,
-                                    'max'                 => '6GB',
-                                ],
-                            ],
-                            [
-                                'name'    => Validator\File\Extension::class,
-                                'options' => [
-                                    'breakchainonfailure' => true,
-                                    'extension'           => 'csv,zip',
-                                ],
-                            ],
-                        ],
+                        'validators' => [],
                         'filters'    => [
                             ['name' => 'CustomFilter'],
                         ],
@@ -273,14 +265,14 @@ class InputFilterAbstractServiceFactoryTest extends TestCase
         $inputFilter = $this->services->get(InputFilterPluginManager::class)->get('test');
         self::assertInstanceOf(InputFilterInterface::class, $inputFilter);
 
-        $input = $inputFilter->get('a-file-element');
-        self::assertInstanceOf(FileInput::class, $input);
+        $input = $inputFilter->get('value');
+        self::assertInstanceOf(InputInterface::class, $input);
 
         $filters = $input->getFilterChain();
         self::assertCount(1, $filters);
 
         $callback = $filters->getFilters()->top();
-        self::assertIsArray($callback);
-        self::assertSame($filter, $callback[0]);
+        self::assertIsCallable($callback);
+        self::assertSame('oof', $callback('foo'));
     }
 }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| QA            | yes

### Description

`laminas-filter` 2.40 changes the `FilterChain` callable from a legacy callable array to first class callable syntax:

https://github.com/laminas/laminas-filter/pull/190/files#r1912528133

The test case here is wrong to test the implementation detail of the callable, instead it should test behaviour of the expected chain item.

Also baselines deprecations in `laminas-filter` 2.40

