### PR TITLE
Stop mocking Laminas\Validator\NotEmpty

### DIFF
--- a/test/ArrayInputTest.php
+++ b/test/ArrayInputTest.php
@@ -165,19 +165,6 @@ final class ArrayInputTest extends InputTest
         return parent::createValidatorChainMock($valueMap, $messages);
     }
 
-    protected function createNonEmptyValidatorMock(
-        bool $isValid,
-        mixed $value,
-        mixed $context = null,
-    ): NotEmptyValidator&MockObject {
-        // ArrayInput validates per each array value
-        if (is_array($value)) {
-            $value = current($value);
-        }
-
-        return parent::createNonEmptyValidatorMock($isValid, $value, $context);
-    }
-
     /** @return string[] */
     protected function getDummyValue(bool $raw = true)
     {

--- a/test/InputTest.php
+++ b/test/InputTest.php
@@ -267,14 +267,8 @@ class InputTest extends TestCase
             NotEmptyValidator::IS_EMPTY => "Custom message",
         ];
 
-        $notEmpty = $this->createMock(NotEmptyValidator::class);
-        $notEmpty->expects(self::once())
-            ->method('getOption')
-            ->with('messageTemplates')
-            ->willReturn($customMessage);
-
         $input->getValidatorChain()
-            ->attach($notEmpty);
+            ->attach(new NotEmptyValidator(['messages' => $customMessage]));
 
         self::assertFalse(
             $input->isValid(),
@@ -421,15 +415,15 @@ class InputTest extends TestCase
         $this->input->setRequired(true);
         $this->input->setValue($raw);
 
-        $notEmptyMock = $this->createNonEmptyValidatorMock(false, $raw);
+        $notEmptyValidator = new NotEmptyValidator();
 
         $validatorChain = $this->input->getValidatorChain();
-        $validatorChain->prependValidator($notEmptyMock);
+        $validatorChain->prependValidator($notEmptyValidator);
         self::assertFalse($this->input->isValid());
 
         $validators = $validatorChain->getValidators();
         self::assertEquals(1, count($validators));
-        self::assertEquals($notEmptyMock, $validators[0]['instance']);
+        self::assertEquals($notEmptyValidator, $validators[0]['instance']);
     }
 
     #[DataProvider('emptyValueProvider')]
@@ -442,16 +436,16 @@ class InputTest extends TestCase
         $this->input->setFilterChain($filterChain);
         $this->input->setValue($raw);
 
-        $notEmptyMock = $this->createNonEmptyValidatorMock(false, $filtered);
+        $notEmptyValidator = new NotEmptyValidator();
 
         $validatorChain->attach(self::createValidatorMock(true));
-        $validatorChain->attach($notEmptyMock);
+        $validatorChain->attach($notEmptyValidator);
 
         self::assertFalse($this->input->isValid());
 
         $validators = $validatorChain->getValidators();
         self::assertEquals(2, count($validators));
-        self::assertEquals($notEmptyMock, $validators[1]['instance']);
+        self::assertEquals($notEmptyValidator, $validators[1]['instance']);
     }
 
     #[DataProvider('isRequiredVsAllowEmptyVsContinueIfEmptyVsIsValidProvider')]
@@ -1042,24 +1036,6 @@ class InputTest extends TestCase
         array $messages = []
     ): ValidatorInterface {
         return new ValidatorStub($isValid, $value, $context, $messages);
-    }
-
-    protected function createNonEmptyValidatorMock(
-        bool $isValid,
-        mixed $value,
-        mixed $context = null
-    ): NotEmptyValidator&MockObject {
-        $notEmptyMock = $this->createMock(NotEmptyValidator::class);
-        $notEmptyMock->expects(self::once())
-            ->method('isValid')
-            ->with($value, $context)
-            ->willReturn($isValid);
-
-        if ($isValid === false) {
-            $notEmptyMock->method('getMessages')->willReturn([]);
-        }
-
-        return $notEmptyMock;
     }
 
     /** @return string */


### PR DESCRIPTION
Rasing draft PR to discuss how to tackle the tests that fail using a real NotEmpty instance.

Currently ArrayInputTest, HttpServerFileInputDecoratorTest, and PsrFileInputDecoratorTest all inherit from InputTest.

HttpServerFileInputDecoratorTest and PsrFileInputDecoratorTest both override`emptyValueProvider` with methods that provide values that do not fail validation as "NotEmpty". This causes `testDoNotInjectNotEmptyValidatorIfAnywhereInChain` to fail.

1st question is, should we remove the test inheriatance? Given there are several tests overridden so they can be skipped with `self::markTestSkipped('Test are not enabled in FileInputTest')`, this might be making things more difficult to maintain than have some duplicated logic. (We could also potentially use a trait to just depuplicate the ones that are actully common to all)

2nd question. Is there any intent to remove some or all of the chain of inheritence in the future that would negate the need for this test? The logic to automatically add a NotEmpty validator in Input, is overriden in FileInput to not run (which HttpServerFileInputDecorator and PsrFileInputDecorator inherit from).

Any other comments or suggestions on an alternative appraoch would also be appreciated


|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | yes

### Description

As of laminas-validator v3 NotEmpty is final and cannot be mocked by PHPUnit