### PR TITLE
WIP - SM4 compatibility, type declarations, and other refactors

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,18 +32,18 @@
     },
     "require": {
         "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0",
-        "laminas/laminas-filter": "^2.19",
-        "laminas/laminas-servicemanager": "^3.21.0",
-        "laminas/laminas-stdlib": "^3.19",
-        "laminas/laminas-validator": "^2.60.0"
+        "laminas/laminas-filter": "^3.0.0",
+        "laminas/laminas-servicemanager": "^4.4",
+        "laminas/laminas-stdlib": "^3.20",
+        "laminas/laminas-validator": "^3.4"
     },
     "require-dev": {
         "ext-json": "*",
-        "laminas/laminas-coding-standard": "^3.0.1",
+        "laminas/laminas-coding-standard": "^3.1.0",
         "phpunit/phpunit": "^10.5.45",
         "psalm/plugin-phpunit": "^0.19.5",
         "psr/http-message": "^2.0",
-        "vimeo/psalm": "^6.10.0",
+        "vimeo/psalm": "^6.11",
         "webmozart/assert": "^1.11"
     },
     "suggest": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,47 +4,97 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a20831913bb454109341d95fac7113e0",
+    "content-hash": "b363eb344e08560edfc766cbb693e3fd",
     "packages": [
         {
-            "name": "laminas/laminas-filter",
-            "version": "2.40.0",
+            "name": "brick/varexporter",
+            "version": "0.5.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/laminas/laminas-filter.git",
-                "reference": "9b32ba7c45a302ed349bf42061308e854d56e75b"
+                "url": "https://github.com/brick/varexporter.git",
+                "reference": "84b2a7a91f69aa5d079aec5a0a7256ebf2dceb6b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-filter/zipball/9b32ba7c45a302ed349bf42061308e854d56e75b",
-                "reference": "9b32ba7c45a302ed349bf42061308e854d56e75b",
+                "url": "https://api.github.com/repos/brick/varexporter/zipball/84b2a7a91f69aa5d079aec5a0a7256ebf2dceb6b",
+                "reference": "84b2a7a91f69aa5d079aec5a0a7256ebf2dceb6b",
                 "shasum": ""
             },
             "require": {
-                "ext-mbstring": "*",
-                "laminas/laminas-servicemanager": "^3.21.0",
-                "laminas/laminas-stdlib": "^3.19.0",
-                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0"
-            },
-            "conflict": {
-                "laminas/laminas-validator": "<2.10.1",
-                "zendframework/zend-filter": "*"
+                "nikic/php-parser": "^5.0",
+                "php": "^7.4 || ^8.0"
             },
             "require-dev": {
-                "laminas/laminas-coding-standard": "~3.0",
-                "laminas/laminas-crypt": "^3.12",
-                "laminas/laminas-i18n": "^2.28.1",
-                "laminas/laminas-uri": "^2.12",
+                "php-coveralls/php-coveralls": "^2.2",
+                "phpunit/phpunit": "^9.3",
+                "psalm/phar": "5.21.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Brick\\VarExporter\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "A powerful alternative to var_export(), which can export closures and objects without __set_state()",
+            "keywords": [
+                "var_export"
+            ],
+            "support": {
+                "issues": "https://github.com/brick/varexporter/issues",
+                "source": "https://github.com/brick/varexporter/tree/0.5.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/BenMorel",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-05-10T17:15:19+00:00"
+        },
+        {
+            "name": "laminas/laminas-filter",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-filter.git",
+                "reference": "e1d1c9cac048be355893117fd13514f8cc8ff6b3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-filter/zipball/e1d1c9cac048be355893117fd13514f8cc8ff6b3",
+                "reference": "e1d1c9cac048be355893117fd13514f8cc8ff6b3",
+                "shasum": ""
+            },
+            "require": {
+                "ext-fileinfo": "*",
+                "ext-filter": "*",
+                "ext-iconv": "*",
+                "ext-mbstring": "*",
+                "laminas/laminas-servicemanager": "^4.1.0",
+                "laminas/laminas-stdlib": "^3.19.0",
+                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0",
+                "psr/container": "^1 || ^2",
+                "psr/http-factory": "^1.1",
+                "psr/http-message": "^2.0"
+            },
+            "require-dev": {
+                "ext-bz2": "*",
+                "ext-zip": "*",
+                "ext-zlib": "*",
+                "laminas/laminas-coding-standard": "^3.0.1",
+                "laminas/laminas-diactoros": "^3.6",
                 "pear/archive_tar": "^1.5.0",
-                "phpunit/phpunit": "^10.5.36",
-                "psalm/plugin-phpunit": "^0.19.0",
-                "psr/http-factory": "^1.1.0",
-                "vimeo/psalm": "^5.26.1"
+                "pear/pear": "^1.10.16",
+                "phpunit/phpunit": "^10.5.46",
+                "psalm/plugin-phpunit": "^0.19.5",
+                "vimeo/psalm": "^6.10.3"
             },
             "suggest": {
-                "laminas/laminas-crypt": "Laminas\\Crypt component, for encryption filters",
                 "laminas/laminas-i18n": "Laminas\\I18n component for filters depending on i18n functionality",
-                "laminas/laminas-uri": "Laminas\\Uri component, for the UriNormalize filter",
                 "psr/http-factory-implementation": "psr/http-factory-implementation, for creating file upload instances when consuming PSR-7 in file upload filters"
             },
             "type": "library",
@@ -83,63 +133,60 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2025-01-06T21:36:57+00:00"
+            "time": "2025-05-06T10:11:59+00:00"
         },
         {
             "name": "laminas/laminas-servicemanager",
-            "version": "3.23.0",
+            "version": "4.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-servicemanager.git",
-                "reference": "a8640182b892b99767d54404d19c5c3b3699f79b"
+                "reference": "74da44d07e493b834347123242d0047976fb9932"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-servicemanager/zipball/a8640182b892b99767d54404d19c5c3b3699f79b",
-                "reference": "a8640182b892b99767d54404d19c5c3b3699f79b",
+                "url": "https://api.github.com/repos/laminas/laminas-servicemanager/zipball/74da44d07e493b834347123242d0047976fb9932",
+                "reference": "74da44d07e493b834347123242d0047976fb9932",
                 "shasum": ""
             },
             "require": {
+                "brick/varexporter": "^0.3.8 || ^0.4.0 || ^0.5.0",
                 "laminas/laminas-stdlib": "^3.19",
                 "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0",
-                "psr/container": "^1.0"
+                "psr/container": "^1.1 || ^2.0"
             },
             "conflict": {
-                "ext-psr": "*",
                 "laminas/laminas-code": "<4.10.0",
-                "zendframework/zend-code": "<3.3.1",
-                "zendframework/zend-servicemanager": "*"
+                "zendframework/zend-code": "<3.3.1"
             },
             "provide": {
-                "psr/container-implementation": "^1.0"
-            },
-            "replace": {
-                "container-interop/container-interop": "^1.2.0"
+                "psr/container-implementation": "^1.0 || ^2.0"
             },
             "require-dev": {
                 "composer/package-versions-deprecated": "^1.11.99.5",
                 "friendsofphp/proxy-manager-lts": "^1.0.18",
-                "laminas/laminas-code": "^4.14.0",
-                "laminas/laminas-coding-standard": "~2.5.0",
-                "laminas/laminas-container-config-test": "^0.8",
+                "laminas/laminas-cli": "^1.11",
+                "laminas/laminas-coding-standard": "~3.0.1",
+                "laminas/laminas-container-config-test": "^1.0",
                 "mikey179/vfsstream": "^1.6.12",
-                "phpbench/phpbench": "^1.3.1",
-                "phpunit/phpunit": "^10.5.36",
-                "psalm/plugin-phpunit": "^0.18.4",
-                "vimeo/psalm": "^5.26.1"
+                "phpbench/phpbench": "^1.4.0",
+                "phpunit/phpunit": "^10.5.44",
+                "psalm/plugin-phpunit": "^0.19.2",
+                "symfony/console": "^6.4.17 || ^7.0",
+                "vimeo/psalm": "^6.2.0"
             },
             "suggest": {
-                "friendsofphp/proxy-manager-lts": "ProxyManager ^2.1.1 to handle lazy initialization of services"
+                "friendsofphp/proxy-manager-lts": "To handle lazy initialization of services",
+                "laminas/laminas-cli": "To consume CLI commands provided by this component"
             },
-            "bin": [
-                "bin/generate-deps-for-config-factory",
-                "bin/generate-factory-for-class"
-            ],
             "type": "library",
+            "extra": {
+                "laminas": {
+                    "module": "Laminas\\ServiceManager",
+                    "config-provider": "Laminas\\ServiceManager\\ConfigProvider"
+                }
+            },
             "autoload": {
-                "files": [
-                    "src/autoload.php"
-                ],
                 "psr-4": {
                     "Laminas\\ServiceManager\\": "src/"
                 }
@@ -161,11 +208,9 @@
             ],
             "support": {
                 "chat": "https://laminas.dev/chat",
-                "docs": "https://docs.laminas.dev/laminas-servicemanager/",
                 "forum": "https://discourse.laminas.dev",
                 "issues": "https://github.com/laminas/laminas-servicemanager/issues",
-                "rss": "https://github.com/laminas/laminas-servicemanager/releases.atom",
-                "source": "https://github.com/laminas/laminas-servicemanager"
+                "source": "https://github.com/laminas/laminas-servicemanager/tree/4.4.0"
             },
             "funding": [
                 {
@@ -173,7 +218,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2024-10-28T21:32:16+00:00"
+            "time": "2025-02-04T06:13:50+00:00"
         },
         {
             "name": "laminas/laminas-stdlib",
@@ -235,50 +280,96 @@
             "time": "2024-10-29T13:46:07+00:00"
         },
         {
-            "name": "laminas/laminas-validator",
-            "version": "2.64.2",
+            "name": "laminas/laminas-translator",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/laminas/laminas-validator.git",
-                "reference": "771e504760448ac7af660710237ceb93be602e08"
+                "url": "https://github.com/laminas/laminas-translator.git",
+                "reference": "12897e710e21413c1f93fc38fe9dead6b51c5218"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-validator/zipball/771e504760448ac7af660710237ceb93be602e08",
-                "reference": "771e504760448ac7af660710237ceb93be602e08",
+                "url": "https://api.github.com/repos/laminas/laminas-translator/zipball/12897e710e21413c1f93fc38fe9dead6b51c5218",
+                "reference": "12897e710e21413c1f93fc38fe9dead6b51c5218",
                 "shasum": ""
             },
             "require": {
-                "laminas/laminas-servicemanager": "^3.21.0",
-                "laminas/laminas-stdlib": "^3.19",
-                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0",
-                "psr/http-message": "^1.0.1 || ^2.0.0"
-            },
-            "conflict": {
-                "zendframework/zend-validator": "*"
+                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0"
             },
             "require-dev": {
-                "laminas/laminas-coding-standard": "^2.5",
-                "laminas/laminas-db": "^2.20",
-                "laminas/laminas-filter": "^2.35.2",
-                "laminas/laminas-i18n": "^2.26.0",
-                "laminas/laminas-session": "^2.20",
-                "laminas/laminas-uri": "^2.11.0",
-                "phpunit/phpunit": "^10.5.20",
-                "psalm/plugin-phpunit": "^0.19.0",
-                "psr/http-client": "^1.0.3",
-                "psr/http-factory": "^1.1.0",
+                "laminas/laminas-coding-standard": "~3.0.0",
                 "vimeo/psalm": "^5.24.0"
             },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\Translator\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Interfaces for the Translator component of laminas-i18n",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "i18n",
+                "laminas"
+            ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.laminas.dev/laminas-i18n/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/laminas/laminas-translator/issues",
+                "rss": "https://github.com/laminas/laminas-translator/releases.atom",
+                "source": "https://github.com/laminas/laminas-translator"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2024-10-21T15:33:01+00:00"
+        },
+        {
+            "name": "laminas/laminas-validator",
+            "version": "3.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-validator.git",
+                "reference": "1ccdd94d34010d7e5ea1c7333fb1b7949603a06c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-validator/zipball/1ccdd94d34010d7e5ea1c7333fb1b7949603a06c",
+                "reference": "1ccdd94d34010d7e5ea1c7333fb1b7949603a06c",
+                "shasum": ""
+            },
+            "require": {
+                "ext-ctype": "*",
+                "ext-fileinfo": "*",
+                "ext-filter": "*",
+                "ext-intl": "*",
+                "laminas/laminas-servicemanager": "^4.1.0",
+                "laminas/laminas-stdlib": "^3.19",
+                "laminas/laminas-translator": "^1.0",
+                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0",
+                "psr/container": "^1.1 || ^2.0",
+                "psr/http-client": "^1.0.3",
+                "psr/http-factory": "^1.1.0",
+                "psr/http-message": "^1.0.1 || ^2.0.0"
+            },
+            "require-dev": {
+                "laminas/laminas-coding-standard": "^3.0.1",
+                "laminas/laminas-diactoros": "^3.5.0",
+                "phpunit/phpunit": "^10.5.45",
+                "psalm/plugin-phpunit": "^0.19.5",
+                "vimeo/psalm": "^6.10.0"
+            },
             "suggest": {
-                "laminas/laminas-db": "Laminas\\Db component, required by the (No)RecordExists validator",
-                "laminas/laminas-filter": "Laminas\\Filter component, required by the Digits validator",
                 "laminas/laminas-i18n": "Laminas\\I18n component to allow translation of validation error messages",
-                "laminas/laminas-i18n-resources": "Translations of validator messages",
-                "laminas/laminas-servicemanager": "Laminas\\ServiceManager component to allow using the ValidatorPluginManager and validator chains",
-                "laminas/laminas-session": "Laminas\\Session component, ^2.8; required by the Csrf validator",
-                "laminas/laminas-uri": "Laminas\\Uri component, required by the Uri and Sitemap\\Loc validators",
-                "psr/http-message": "psr/http-message, required when validating PSR-7 UploadedFileInterface instances via the Upload and UploadFile validators"
+                "laminas/laminas-i18n-resources": "Translations of validator messages"
             },
             "type": "library",
             "extra": {
@@ -316,26 +407,89 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2024-11-26T21:29:17+00:00"
+            "time": "2025-05-19T07:38:59+00:00"
         },
         {
-            "name": "psr/container",
-            "version": "1.1.2",
+            "name": "nikic/php-parser",
+            "version": "v5.4.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/php-fig/container.git",
-                "reference": "513e0666f7216c7459170d56df27dfcefe1689ea"
+                "url": "https://github.com/nikic/PHP-Parser.git",
+                "reference": "447a020a1f875a434d62f2a401f53b82a396e494"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/container/zipball/513e0666f7216c7459170d56df27dfcefe1689ea",
-                "reference": "513e0666f7216c7459170d56df27dfcefe1689ea",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/447a020a1f875a434d62f2a401f53b82a396e494",
+                "reference": "447a020a1f875a434d62f2a401f53b82a396e494",
+                "shasum": ""
+            },
+            "require": {
+                "ext-ctype": "*",
+                "ext-json": "*",
+                "ext-tokenizer": "*",
+                "php": ">=7.4"
+            },
+            "require-dev": {
+                "ircmaxell/php-yacc": "^0.0.7",
+                "phpunit/phpunit": "^9.0"
+            },
+            "bin": [
+                "bin/php-parse"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpParser\\": "lib/PhpParser"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Nikita Popov"
+                }
+            ],
+            "description": "A PHP parser written in PHP",
+            "keywords": [
+                "parser",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/nikic/PHP-Parser/issues",
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.4.0"
+            },
+            "time": "2024-12-30T11:07:19+00:00"
+        },
+        {
+            "name": "psr/container",
+            "version": "2.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/container.git",
+                "reference": "c71ecc56dfe541dbd90c5360474fbc405f8d5963"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/c71ecc56dfe541dbd90c5360474fbc405f8d5963",
+                "reference": "c71ecc56dfe541dbd90c5360474fbc405f8d5963",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.4.0"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
             "autoload": {
                 "psr-4": {
                     "Psr\\Container\\": "src/"
@@ -362,9 +516,116 @@
             ],
             "support": {
                 "issues": "https://github.com/php-fig/container/issues",
-                "source": "https://github.com/php-fig/container/tree/1.1.2"
+                "source": "https://github.com/php-fig/container/tree/2.0.2"
             },
-            "time": "2021-11-05T16:50:12+00:00"
+            "time": "2021-11-05T16:47:00+00:00"
+        },
+        {
+            "name": "psr/http-client",
+            "version": "1.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-client.git",
+                "reference": "bb5906edc1c324c9a05aa0873d40117941e5fa90"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-client/zipball/bb5906edc1c324c9a05aa0873d40117941e5fa90",
+                "reference": "bb5906edc1c324c9a05aa0873d40117941e5fa90",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0 || ^8.0",
+                "psr/http-message": "^1.0 || ^2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Client\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP clients",
+            "homepage": "https://github.com/php-fig/http-client",
+            "keywords": [
+                "http",
+                "http-client",
+                "psr",
+                "psr-18"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-client"
+            },
+            "time": "2023-09-23T14:17:50+00:00"
+        },
+        {
+            "name": "psr/http-factory",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-factory.git",
+                "reference": "2b4765fddfe3b508ac62f829e852b1501d3f6e8a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-factory/zipball/2b4765fddfe3b508ac62f829e852b1501d3f6e8a",
+                "reference": "2b4765fddfe3b508ac62f829e852b1501d3f6e8a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1",
+                "psr/http-message": "^1.0 || ^2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "PSR-17: Common interfaces for PSR-7 HTTP message factories",
+            "keywords": [
+                "factory",
+                "http",
+                "message",
+                "psr",
+                "psr-17",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-factory"
+            },
+            "time": "2024-04-15T12:06:14+00:00"
         },
         {
             "name": "psr/http-message",
@@ -1891,16 +2152,16 @@
         },
         {
             "name": "laminas/laminas-coding-standard",
-            "version": "3.0.1",
+            "version": "3.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-coding-standard.git",
-                "reference": "ac809f5b27f0b22d0c1ec0cbc78cb67f92bfebcb"
+                "reference": "d4412caba9ed16c93cdcf301759f5ee71f9d9aea"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-coding-standard/zipball/ac809f5b27f0b22d0c1ec0cbc78cb67f92bfebcb",
-                "reference": "ac809f5b27f0b22d0c1ec0cbc78cb67f92bfebcb",
+                "url": "https://api.github.com/repos/laminas/laminas-coding-standard/zipball/d4412caba9ed16c93cdcf301759f5ee71f9d9aea",
+                "reference": "d4412caba9ed16c93cdcf301759f5ee71f9d9aea",
                 "shasum": ""
             },
             "require": {
@@ -1940,7 +2201,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2024-10-16T09:23:09+00:00"
+            "time": "2025-05-13T08:37:04+00:00"
         },
         {
             "name": "league/uri",
@@ -2118,16 +2379,16 @@
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.13.0",
+            "version": "1.13.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "024473a478be9df5fdaca2c793f2232fe788e414"
+                "reference": "1720ddd719e16cf0db4eb1c6eca108031636d46c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/024473a478be9df5fdaca2c793f2232fe788e414",
-                "reference": "024473a478be9df5fdaca2c793f2232fe788e414",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/1720ddd719e16cf0db4eb1c6eca108031636d46c",
+                "reference": "1720ddd719e16cf0db4eb1c6eca108031636d46c",
                 "shasum": ""
             },
             "require": {
@@ -2166,7 +2427,7 @@
             ],
             "support": {
                 "issues": "https://github.com/myclabs/DeepCopy/issues",
-                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.0"
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.1"
             },
             "funding": [
                 {
@@ -2174,7 +2435,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-02-12T12:17:51+00:00"
+            "time": "2025-04-29T12:36:36+00:00"
         },
         {
             "name": "netresearch/jsonmapper",
@@ -2226,64 +2487,6 @@
                 "source": "https://github.com/cweiske/jsonmapper/tree/v5.0.0"
             },
             "time": "2024-09-08T10:20:00+00:00"
-        },
-        {
-            "name": "nikic/php-parser",
-            "version": "v5.4.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "447a020a1f875a434d62f2a401f53b82a396e494"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/447a020a1f875a434d62f2a401f53b82a396e494",
-                "reference": "447a020a1f875a434d62f2a401f53b82a396e494",
-                "shasum": ""
-            },
-            "require": {
-                "ext-ctype": "*",
-                "ext-json": "*",
-                "ext-tokenizer": "*",
-                "php": ">=7.4"
-            },
-            "require-dev": {
-                "ircmaxell/php-yacc": "^0.0.7",
-                "phpunit/phpunit": "^9.0"
-            },
-            "bin": [
-                "bin/php-parse"
-            ],
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "5.0-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "PhpParser\\": "lib/PhpParser"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Nikita Popov"
-                }
-            ],
-            "description": "A PHP parser written in PHP",
-            "keywords": [
-                "parser",
-                "php"
-            ],
-            "support": {
-                "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v5.4.0"
-            },
-            "time": "2024-12-30T11:07:19+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -2948,16 +3151,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "10.5.45",
+            "version": "10.5.46",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "bd68a781d8e30348bc297449f5234b3458267ae8"
+                "reference": "8080be387a5be380dda48c6f41cee4a13aadab3d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/bd68a781d8e30348bc297449f5234b3458267ae8",
-                "reference": "bd68a781d8e30348bc297449f5234b3458267ae8",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/8080be387a5be380dda48c6f41cee4a13aadab3d",
+                "reference": "8080be387a5be380dda48c6f41cee4a13aadab3d",
                 "shasum": ""
             },
             "require": {
@@ -2967,7 +3170,7 @@
                 "ext-mbstring": "*",
                 "ext-xml": "*",
                 "ext-xmlwriter": "*",
-                "myclabs/deep-copy": "^1.12.1",
+                "myclabs/deep-copy": "^1.13.1",
                 "phar-io/manifest": "^2.0.4",
                 "phar-io/version": "^3.2.1",
                 "php": ">=8.1",
@@ -3029,7 +3232,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.45"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.46"
             },
             "funding": [
                 {
@@ -3041,11 +3244,19 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/phpunit/phpunit",
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-02-06T16:08:12+00:00"
+            "time": "2025-05-02T06:46:24+00:00"
         },
         {
             "name": "psalm/plugin-phpunit",
@@ -3104,61 +3315,6 @@
                 "source": "https://github.com/psalm/psalm-plugin-phpunit/tree/0.19.5"
             },
             "time": "2025-03-31T18:49:55+00:00"
-        },
-        {
-            "name": "psr/http-factory",
-            "version": "1.1.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/http-factory.git",
-                "reference": "2b4765fddfe3b508ac62f829e852b1501d3f6e8a"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/http-factory/zipball/2b4765fddfe3b508ac62f829e852b1501d3f6e8a",
-                "reference": "2b4765fddfe3b508ac62f829e852b1501d3f6e8a",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.1",
-                "psr/http-message": "^1.0 || ^2.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Psr\\Http\\Message\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "https://www.php-fig.org/"
-                }
-            ],
-            "description": "PSR-17: Common interfaces for PSR-7 HTTP message factories",
-            "keywords": [
-                "factory",
-                "http",
-                "message",
-                "psr",
-                "psr-17",
-                "psr-7",
-                "request",
-                "response"
-            ],
-            "support": {
-                "source": "https://github.com/php-fig/http-factory"
-            },
-            "time": "2024-04-15T12:06:14+00:00"
         },
         {
             "name": "psr/log",
@@ -4200,32 +4356,32 @@
         },
         {
             "name": "slevomat/coding-standard",
-            "version": "8.17.0",
+            "version": "8.18.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/slevomat/coding-standard.git",
-                "reference": "ace04a4e2e20c9bc26ad14d6c4c737cde6056ec0"
+                "reference": "f3b23cb9b26301b8c3c7bb03035a1bee23974593"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/ace04a4e2e20c9bc26ad14d6c4c737cde6056ec0",
-                "reference": "ace04a4e2e20c9bc26ad14d6c4c737cde6056ec0",
+                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/f3b23cb9b26301b8c3c7bb03035a1bee23974593",
+                "reference": "f3b23cb9b26301b8c3c7bb03035a1bee23974593",
                 "shasum": ""
             },
             "require": {
                 "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7 || ^1.0",
                 "php": "^7.4 || ^8.0",
                 "phpstan/phpdoc-parser": "^2.1.0",
-                "squizlabs/php_codesniffer": "^3.12.1"
+                "squizlabs/php_codesniffer": "^3.12.2"
             },
             "require-dev": {
                 "phing/phing": "3.0.1",
                 "php-parallel-lint/php-parallel-lint": "1.4.0",
-                "phpstan/phpstan": "2.1.11",
-                "phpstan/phpstan-deprecation-rules": "2.0.1",
+                "phpstan/phpstan": "2.1.13",
+                "phpstan/phpstan-deprecation-rules": "2.0.2",
                 "phpstan/phpstan-phpunit": "2.0.6",
                 "phpstan/phpstan-strict-rules": "2.0.4",
-                "phpunit/phpunit": "9.6.8|10.5.45|11.4.4|11.5.17|12.1.2"
+                "phpunit/phpunit": "9.6.8|10.5.45|11.4.4|11.5.17|12.1.3"
             },
             "type": "phpcodesniffer-standard",
             "extra": {
@@ -4249,7 +4405,7 @@
             ],
             "support": {
                 "issues": "https://github.com/slevomat/coding-standard/issues",
-                "source": "https://github.com/slevomat/coding-standard/tree/8.17.0"
+                "source": "https://github.com/slevomat/coding-standard/tree/8.18.0"
             },
             "funding": [
                 {
@@ -4261,7 +4417,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-04-10T06:06:16+00:00"
+            "time": "2025-05-01T09:40:50+00:00"
         },
         {
             "name": "spatie/array-to-xml",
@@ -4333,16 +4489,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.12.2",
+            "version": "3.13.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
-                "reference": "6d4cf6032d4b718f168c90a96e36c7d0eaacb2aa"
+                "reference": "65ff2489553b83b4597e89c3b8b721487011d186"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/6d4cf6032d4b718f168c90a96e36c7d0eaacb2aa",
-                "reference": "6d4cf6032d4b718f168c90a96e36c7d0eaacb2aa",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/65ff2489553b83b4597e89c3b8b721487011d186",
+                "reference": "65ff2489553b83b4597e89c3b8b721487011d186",
                 "shasum": ""
             },
             "require": {
@@ -4413,20 +4569,20 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-04-13T04:10:18+00:00"
+            "time": "2025-05-11T03:36:00+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v6.4.20",
+            "version": "v6.4.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "2e4af9c952617cc3f9559ff706aee420a8464c36"
+                "reference": "a3011c7b7adb58d89f6c0d822abb641d7a5f9719"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/2e4af9c952617cc3f9559ff706aee420a8464c36",
-                "reference": "2e4af9c952617cc3f9559ff706aee420a8464c36",
+                "url": "https://api.github.com/repos/symfony/console/zipball/a3011c7b7adb58d89f6c0d822abb641d7a5f9719",
+                "reference": "a3011c7b7adb58d89f6c0d822abb641d7a5f9719",
                 "shasum": ""
             },
             "require": {
@@ -4491,7 +4647,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v6.4.20"
+                "source": "https://github.com/symfony/console/tree/v6.4.21"
             },
             "funding": [
                 {
@@ -4507,7 +4663,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-03-03T17:16:38+00:00"
+            "time": "2025-04-07T15:42:41+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -4644,7 +4800,7 @@
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.31.0",
+            "version": "v1.32.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
@@ -4703,7 +4859,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.31.0"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.32.0"
             },
             "funding": [
                 {
@@ -4723,7 +4879,7 @@
         },
         {
             "name": "symfony/polyfill-intl-grapheme",
-            "version": "v1.31.0",
+            "version": "v1.32.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
@@ -4781,7 +4937,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.31.0"
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.32.0"
             },
             "funding": [
                 {
@@ -4801,7 +4957,7 @@
         },
         {
             "name": "symfony/polyfill-intl-normalizer",
-            "version": "v1.31.0",
+            "version": "v1.32.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
@@ -4862,7 +5018,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.31.0"
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.32.0"
             },
             "funding": [
                 {
@@ -4882,19 +5038,20 @@
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.31.0",
+            "version": "v1.32.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "85181ba99b2345b0ef10ce42ecac37612d9fd341"
+                "reference": "6d857f4d76bd4b343eac26d6b539585d2bc56493"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/85181ba99b2345b0ef10ce42ecac37612d9fd341",
-                "reference": "85181ba99b2345b0ef10ce42ecac37612d9fd341",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/6d857f4d76bd4b343eac26d6b539585d2bc56493",
+                "reference": "6d857f4d76bd4b343eac26d6b539585d2bc56493",
                 "shasum": ""
             },
             "require": {
+                "ext-iconv": "*",
                 "php": ">=7.2"
             },
             "provide": {
@@ -4942,7 +5099,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.31.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.32.0"
             },
             "funding": [
                 {
@@ -4958,20 +5115,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-09T11:45:10+00:00"
+            "time": "2024-12-23T08:48:59+00:00"
         },
         {
             "name": "symfony/polyfill-php84",
-            "version": "v1.31.0",
+            "version": "v1.32.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php84.git",
-                "reference": "e5493eb51311ab0b1cc2243416613f06ed8f18bd"
+                "reference": "000df7860439609837bbe28670b0be15783b7fbf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php84/zipball/e5493eb51311ab0b1cc2243416613f06ed8f18bd",
-                "reference": "e5493eb51311ab0b1cc2243416613f06ed8f18bd",
+                "url": "https://api.github.com/repos/symfony/polyfill-php84/zipball/000df7860439609837bbe28670b0be15783b7fbf",
+                "reference": "000df7860439609837bbe28670b0be15783b7fbf",
                 "shasum": ""
             },
             "require": {
@@ -5018,7 +5175,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php84/tree/v1.31.0"
+                "source": "https://github.com/symfony/polyfill-php84/tree/v1.32.0"
             },
             "funding": [
                 {
@@ -5034,7 +5191,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-09T12:04:04+00:00"
+            "time": "2025-02-20T12:04:08+00:00"
         },
         {
             "name": "symfony/service-contracts",
@@ -5121,16 +5278,16 @@
         },
         {
             "name": "symfony/string",
-            "version": "v6.4.15",
+            "version": "v6.4.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "73a5e66ea2e1677c98d4449177c5a9cf9d8b4c6f"
+                "reference": "73e2c6966a5aef1d4892873ed5322245295370c6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/73a5e66ea2e1677c98d4449177c5a9cf9d8b4c6f",
-                "reference": "73a5e66ea2e1677c98d4449177c5a9cf9d8b4c6f",
+                "url": "https://api.github.com/repos/symfony/string/zipball/73e2c6966a5aef1d4892873ed5322245295370c6",
+                "reference": "73e2c6966a5aef1d4892873ed5322245295370c6",
                 "shasum": ""
             },
             "require": {
@@ -5187,7 +5344,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v6.4.15"
+                "source": "https://github.com/symfony/string/tree/v6.4.21"
             },
             "funding": [
                 {
@@ -5203,7 +5360,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-11-13T13:31:12+00:00"
+            "time": "2025-04-18T15:23:29+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -5257,16 +5414,16 @@
         },
         {
             "name": "vimeo/psalm",
-            "version": "6.10.0",
+            "version": "6.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vimeo/psalm.git",
-                "reference": "9c0add4eb88d4b169ac04acb7c679918cbb9c252"
+                "reference": "4ed53b7ccebc09ef60ec4c9e464bf8a01bfd35b0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vimeo/psalm/zipball/9c0add4eb88d4b169ac04acb7c679918cbb9c252",
-                "reference": "9c0add4eb88d4b169ac04acb7c679918cbb9c252",
+                "url": "https://api.github.com/repos/vimeo/psalm/zipball/4ed53b7ccebc09ef60ec4c9e464bf8a01bfd35b0",
+                "reference": "4ed53b7ccebc09ef60ec4c9e464bf8a01bfd35b0",
                 "shasum": ""
             },
             "require": {
@@ -5371,7 +5528,7 @@
                 "issues": "https://github.com/vimeo/psalm/issues",
                 "source": "https://github.com/vimeo/psalm"
             },
-            "time": "2025-03-31T10:12:50+00:00"
+            "time": "2025-05-12T11:30:26+00:00"
         },
         {
             "name": "webimpress/coding-standard",

--- a/src/ArrayInput.php
+++ b/src/ArrayInput.php
@@ -13,25 +13,6 @@ use function is_array;
 /** @final */
 class ArrayInput extends Input
 {
-    /**
-     * @deprecated since 2.30.1 The default value should be null as in parent `Input`
-     *
-     * @var mixed
-     */
-    protected $value = [];
-
-    /**
-     * @deprecated since 2.30.1 Once the default value is null, this method is no longer required
-     *
-     * @inheritDoc
-     */
-    public function resetValue()
-    {
-        $this->value    = [];
-        $this->hasValue = false;
-        return $this;
-    }
-
     /** @inheritDoc */
     public function getValue()
     {

--- a/src/ArrayInput.php
+++ b/src/ArrayInput.php
@@ -109,6 +109,6 @@ class ArrayInput extends Input
         $result = $isArray->isValid($this->getValue());
         assert($result === false);
 
-        return $isArray->getMessages();
+        return $isArray->getMessages()[IsArray::NOT_ARRAY] ?? null;
     }
 }

--- a/src/ArrayInput.php
+++ b/src/ArrayInput.php
@@ -13,8 +13,7 @@ use function is_array;
 /** @final */
 class ArrayInput extends Input
 {
-    /** @inheritDoc */
-    public function getValue()
+    public function getValue(): mixed
     {
         if (! is_array($this->value)) {
             return $this->value;
@@ -28,8 +27,7 @@ class ArrayInput extends Input
         );
     }
 
-    /** @inheritDoc */
-    public function isValid($context = null)
+    public function isValid(mixed $context = null): bool
     {
         $hasValue    = $this->hasValue();
         $required    = $this->isRequired();
@@ -96,8 +94,7 @@ class ArrayInput extends Input
         return $result;
     }
 
-    /** @return array<string, string> */
-    private function prepareNotArrayFailureMessage(): array
+    private function prepareNotArrayFailureMessage(): ?string
     {
         $chain   = $this->getValidatorChain();
         $isArray = $chain->plugin(IsArray::class);

--- a/src/ArrayInput.php
+++ b/src/ArrayInput.php
@@ -22,7 +22,7 @@ class ArrayInput extends Input
         $filter = $this->getFilterChain();
 
         return array_map(
-            static fn (mixed $value): mixed => $filter->filter($value),
+            static fn(mixed $value): mixed => $filter?->filter($value) ?? $value,
             $this->value,
         );
     }
@@ -71,6 +71,10 @@ class ArrayInput extends Input
             return false;
         }
 
+        if (! $validator) {
+            return true;
+        }
+
         foreach ($values as $value) {
             $empty = $value === null || $value === '' || $value === [];
             if ($empty && ! $this->isRequired() && ! $this->continueIfEmpty()) {
@@ -96,7 +100,10 @@ class ArrayInput extends Input
 
     private function prepareNotArrayFailureMessage(): ?string
     {
-        $chain   = $this->getValidatorChain();
+        $chain = $this->getValidatorChain();
+        if (! $chain) {
+            return null;
+        }
         $isArray = $chain->plugin(IsArray::class);
 
         foreach ($chain->getValidators() as $validator) {

--- a/src/BaseInputFilter.php
+++ b/src/BaseInputFilter.php
@@ -34,22 +34,22 @@ class BaseInputFilter implements
     UnfilteredDataInterface
 {
     /** @var array<array-key, mixed>|null */
-    protected $data;
+    protected ?array $data = null;
 
     /** @var array<array-key, mixed> */
-    protected $unfilteredData = [];
+    protected array $unfilteredData = [];
 
     /** @var array<array-key, InputInterface|InputFilterInterface> */
-    protected $inputs = [];
+    protected array $inputs = [];
 
     /** @var array<array-key, InputInterface|InputFilterInterface>|null */
-    protected $invalidInputs;
+    protected ?array $invalidInputs = null;
 
     /** @var null|array<array-key, string> Input names */
-    protected $validationGroup;
+    protected ?array $validationGroup = null;
 
     /** @var array<array-key, InputInterface|InputFilterInterface>|null */
-    protected $validInputs;
+    protected ?array $validInputs = null;
 
     /**
      * This function is automatically called when creating element with factory. It
@@ -65,11 +65,9 @@ class BaseInputFilter implements
      * Countable: number of inputs in this input filter
      *
      * Only details the number of direct children.
-     *
-     * @return int
      */
     #[ReturnTypeWillChange]
-    public function count()
+    public function count(): int
     {
         return count($this->inputs);
     }
@@ -77,13 +75,12 @@ class BaseInputFilter implements
     /**
      * Add an input to the input filter
      *
-     * @param InputInterface|InputFilterInterface $input
-     * @param null|string|int $name Name used to retrieve this input. Can be an integer for collections
+     * @param int|string|null $name Name used to retrieve this input. Can be an integer for collections
      * @return $this
      * @psalm-suppress MoreSpecificImplementedParamType
      * @throws Exception\InvalidArgumentException
      */
-    public function add($input, $name = null)
+    public function add(InputFilterInputInterface|iterable $input, int|string|null $name = null): static
     {
         /** @psalm-suppress RedundantConditionGivenDocblockType */
         if (! $input instanceof InputInterface && ! $input instanceof InputFilterInterface) {
@@ -119,12 +116,12 @@ class BaseInputFilter implements
     /**
      * Replace a named input
      *
-     * @param  InputInterface|InputFilterInterface $input
-     * @param  array-key                           $name Name of the input to replace
-     * @throws Exception\InvalidArgumentException If input to replace not exists.
+     * @param InputInterface $input
+     * @param array-key $name Name of the input to replace
      * @return self
+     * @throws Exception\InvalidArgumentException If input to replace not exists.
      */
-    public function replace($input, $name)
+    public function replace(InputFilterInputInterface $input, string|int $name): static
     {
         if (! array_key_exists($name, $this->inputs)) {
             throw new Exception\InvalidArgumentException(sprintf(
@@ -143,11 +140,10 @@ class BaseInputFilter implements
     /**
      * Retrieve a named input
      *
-     * @param  array-key $name
+     * @param array-key $name
      * @throws Exception\InvalidArgumentException
-     * @return InputInterface|InputFilterInterface
      */
-    public function get($name)
+    public function get(int|string $name): InputFilterInputInterface
     {
         if (! array_key_exists($name, $this->inputs)) {
             throw new Exception\InvalidArgumentException(sprintf(
@@ -162,10 +158,9 @@ class BaseInputFilter implements
     /**
      * Test if an input or input filter by the given name is attached
      *
-     * @param  array-key $name
-     * @return bool
+     * @param array-key $name
      */
-    public function has($name)
+    public function has(int|string $name): bool
     {
         return array_key_exists($name, $this->inputs);
     }
@@ -173,10 +168,9 @@ class BaseInputFilter implements
     /**
      * Remove a named input
      *
-     * @param  array-key $name
-     * @return InputFilterInterface
+     * @param array-key $name
      */
-    public function remove($name)
+    public function remove(int|string $name): InputFilterInterface
     {
         unset($this->inputs[$name]);
         return $this;
@@ -185,11 +179,10 @@ class BaseInputFilter implements
     /**
      * Set data to use when validating and filtering
      *
-     * @param  iterable|null $data null is cast to an empty array.
+     * @param iterable|null $data null is cast to an empty array.
      * @throws Exception\InvalidArgumentException
-     * @return InputFilterInterface
      */
-    public function setData($data)
+    public function setData(?iterable $data): InputFilterInterface
     {
         // A null value indicates an empty set
         if (null === $data) {
@@ -220,11 +213,9 @@ class BaseInputFilter implements
     /**
      * Is the data set valid?
      *
-     * @param  mixed|null $context
      * @throws Exception\RuntimeException
-     * @return bool
      */
-    public function isValid($context = null)
+    public function isValid(mixed $context = null): bool
     {
         if (null === $this->data) {
             throw new Exception\RuntimeException(sprintf(
@@ -240,12 +231,10 @@ class BaseInputFilter implements
     /**
      * Validate a set of inputs against the current data
      *
-     * @param  array<array-key, array-key> $inputs Array of input names.
-     * @param  array<array-key, mixed> $data
-     * @param  mixed|null $context
-     * @return bool
+     * @param array<array-key, array-key> $inputs Array of input names.
+     * @param array<array-key, mixed> $data
      */
-    protected function validateInputs(array $inputs, array $data = [], $context = null)
+    protected function validateInputs(array $inputs, array $data = [], mixed $context = null): bool
     {
         $inputContext = $context ?? array_merge($this->getRawValues(), $data);
 
@@ -308,11 +297,11 @@ class BaseInputFilter implements
      * Implementations should allow passing a single array value, or multiple arguments,
      * each specifying a single input.
      *
-     * @param  array-key|array<array-key, array-key> $name
+     * @param array-key|array $name
+     * @return $this
      * @throws Exception\InvalidArgumentException
-     * @return InputFilterInterface
      */
-    public function setValidationGroup($name)
+    public function setValidationGroup(array|int|string $name): static
     {
         if ($name === self::VALIDATE_ALL) {
             $this->validationGroup = null;
@@ -360,7 +349,7 @@ class BaseInputFilter implements
      *
      * @return array<array-key, InputInterface|InputFilterInterface>
      */
-    public function getInvalidInput()
+    public function getInvalidInput(): array
     {
         return is_array($this->invalidInputs) ? $this->invalidInputs : [];
     }
@@ -373,7 +362,7 @@ class BaseInputFilter implements
      *
      * @return array<array-key, InputInterface|InputFilterInterface>
      */
-    public function getValidInput()
+    public function getValidInput(): array
     {
         return is_array($this->validInputs) ? $this->validInputs : [];
     }
@@ -381,11 +370,10 @@ class BaseInputFilter implements
     /**
      * Retrieve a value from a named input
      *
-     * @param  array-key $name
+     * @param array-key $name
      * @throws Exception\InvalidArgumentException
-     * @return mixed
      */
-    public function getValue($name)
+    public function getValue(int|string $name): mixed
     {
         if (! array_key_exists($name, $this->inputs)) {
             throw new Exception\InvalidArgumentException(sprintf(
@@ -400,7 +388,7 @@ class BaseInputFilter implements
             return $input->getValues();
         }
 
-        return $input->getValue();
+        return $input->getValue($name);
     }
 
     /**
@@ -411,7 +399,7 @@ class BaseInputFilter implements
      *
      * @return TFilteredValues
      */
-    public function getValues()
+    public function getValues(): array
     {
         $inputs = $this->validationGroup ?? array_keys($this->inputs);
         $values = [];
@@ -420,7 +408,7 @@ class BaseInputFilter implements
 
             $value = $input instanceof InputFilterInterface
                 ? $input->getValues()
-                : $input->getValue();
+                : $input->getValue($name);
 
             /** @psalm-suppress MixedAssignment */
             $values[$name] = $value;
@@ -431,11 +419,10 @@ class BaseInputFilter implements
     /**
      * Retrieve a raw (unfiltered) value from a named input
      *
-     * @param  array-key $name
+     * @param array-key $name
      * @throws Exception\InvalidArgumentException
-     * @return mixed
      */
-    public function getRawValue($name)
+    public function getRawValue(int|string $name): mixed
     {
         if (! array_key_exists($name, $this->inputs)) {
             throw new Exception\InvalidArgumentException(sprintf(
@@ -448,7 +435,7 @@ class BaseInputFilter implements
         if ($input instanceof InputFilterInterface) {
             return $input->getRawValues();
         }
-        return $input->getRawValue();
+        return $input->getRawValue($name);
     }
 
     /**
@@ -459,7 +446,7 @@ class BaseInputFilter implements
      *
      * @return array<array-key, mixed>
      */
-    public function getRawValues()
+    public function getRawValues(): array
     {
         $values = [];
         foreach ($this->inputs as $name => $input) {
@@ -469,7 +456,7 @@ class BaseInputFilter implements
             }
 
             /** @psalm-suppress MixedAssignment */
-            $values[$name] = $input->getRawValue();
+            $values[$name] = $input->getRawValue($name);
         }
         return $values;
     }
@@ -482,7 +469,7 @@ class BaseInputFilter implements
      *
      * @return array<array-key, array<array-key, string|array>>
      */
-    public function getMessages()
+    public function getMessages(): array
     {
         $messages = [];
         foreach ($this->getInvalidInput() as $name => $input) {
@@ -495,11 +482,10 @@ class BaseInputFilter implements
     /**
      * Ensure all names of a validation group exist as input in the filter
      *
-     * @param  array<array-key, array-key> $inputs Input names
-     * @return void
+     * @param array<array-key, array-key> $inputs Input names
      * @throws Exception\InvalidArgumentException
      */
-    protected function validateValidationGroup(array $inputs)
+    protected function validateValidationGroup(array $inputs): void
     {
         foreach ($inputs as $name) {
             if (! array_key_exists($name, $this->inputs)) {
@@ -513,10 +499,8 @@ class BaseInputFilter implements
 
     /**
      * Populate the values of all attached inputs
-     *
-     * @return void
      */
-    protected function populate()
+    protected function populate(): void
     {
         assert($this->data !== null);
         foreach (array_keys($this->inputs) as $name) {
@@ -564,9 +548,8 @@ class BaseInputFilter implements
      * Is the data set has unknown input ?
      *
      * @throws Exception\RuntimeException
-     * @return bool
      */
-    public function hasUnknown()
+    public function hasUnknown(): bool
     {
         return $this->getUnknown() ? true : false;
     }
@@ -575,9 +558,8 @@ class BaseInputFilter implements
      * Return the unknown input
      *
      * @throws Exception\RuntimeException
-     * @return array
      */
-    public function getUnknown()
+    public function getUnknown(): array
     {
         if (null === $this->data) {
             throw new Exception\RuntimeException(sprintf(
@@ -606,7 +588,7 @@ class BaseInputFilter implements
      *
      * @return array<array-key, InputInterface|InputFilterInterface>
      */
-    public function getInputs()
+    public function getInputs(): array
     {
         return $this->inputs;
     }
@@ -616,7 +598,7 @@ class BaseInputFilter implements
      *
      * @return $this
      */
-    public function merge(BaseInputFilter $inputFilter)
+    public function merge(BaseInputFilter $inputFilter): static
     {
         foreach ($inputFilter->getInputs() as $name => $input) {
             $this->add($input, $name);
@@ -628,16 +610,15 @@ class BaseInputFilter implements
     /**
      * @return array<array-key, mixed>
      */
-    public function getUnfilteredData()
+    public function getUnfilteredData(): array
     {
         return $this->unfilteredData;
     }
 
     /**
-     * @param array<array-key, mixed> $data
      * @return $this
      */
-    public function setUnfilteredData($data)
+    public function setUnfilteredData(array $data): static
     {
         $this->unfilteredData = $data;
         return $this;

--- a/src/CollectionInputFilter.php
+++ b/src/CollectionInputFilter.php
@@ -20,35 +20,31 @@ use function sprintf;
  */
 class CollectionInputFilter extends InputFilter
 {
-    /** @var bool */
-    protected $isRequired = false;
+    protected bool $isRequired = false;
 
-    /** @var null|int */
-    protected $count;
+    protected ?int $count;
 
     /** @var array<array-key, array> */
-    protected $collectionValues = [];
+    protected array $collectionValues = [];
 
     /** @var array<array-key, array> */
-    protected $collectionRawValues = [];
+    protected array $collectionRawValues = [];
 
     /** @var array<array-key, array<string, array<array-key, string>>> */
-    protected $collectionMessages = [];
+    protected array $collectionMessages = [];
 
-    /** @var BaseInputFilter|null */
-    protected $inputFilter;
+    protected ?BaseInputFilter $inputFilter;
 
-    /** @var NotEmpty|null */
-    protected $notEmptyValidator;
+    protected ?NotEmpty $notEmptyValidator;
 
     /**
      * Set the input filter to use when looping the data
      *
      * @param BaseInputFilter|InputFilterSpecification|Traversable $inputFilter
-     * @throws Exception\RuntimeException
      * @return CollectionInputFilter
+     * @throws Exception\RuntimeException
      */
-    public function setInputFilter($inputFilter)
+    public function setInputFilter(BaseInputFilter|iterable $inputFilter): static
     {
         if (is_iterable($inputFilter)) {
             $inputFilter = $this->getFactory()->createInputFilter($inputFilter);
@@ -71,10 +67,8 @@ class CollectionInputFilter extends InputFilter
 
     /**
      * Get the input filter used when looping the data
-     *
-     * @return BaseInputFilter
      */
-    public function getInputFilter()
+    public function getInputFilter(): BaseInputFilter
     {
         if (null === $this->inputFilter) {
             $this->inputFilter = new InputFilter();
@@ -86,10 +80,9 @@ class CollectionInputFilter extends InputFilter
     /**
      * Set if the collection can be empty
      *
-     * @param bool $isRequired
      * @return $this
      */
-    public function setIsRequired($isRequired)
+    public function setIsRequired(bool $isRequired): static
     {
         $this->isRequired = $isRequired;
 
@@ -98,10 +91,8 @@ class CollectionInputFilter extends InputFilter
 
     /**
      * Get if collection can be empty
-     *
-     * @return bool
      */
-    public function getIsRequired()
+    public function getIsRequired(): bool
     {
         return $this->isRequired;
     }
@@ -109,10 +100,9 @@ class CollectionInputFilter extends InputFilter
     /**
      * Set the count of data to validate
      *
-     * @param int $count
      * @return CollectionInputFilter
      */
-    public function setCount($count)
+    public function setCount(int $count): static
     {
         $this->count = $count > 0 ? $count : 0;
 
@@ -121,10 +111,8 @@ class CollectionInputFilter extends InputFilter
 
     /**
      * Get the count of data to validate, use the count of data by default
-     *
-     * @return int
      */
-    public function getCount()
+    public function getCount(): ?int
     {
         if (null === $this->count) {
             return $this->data !== null ? count($this->data) : 0;
@@ -137,7 +125,7 @@ class CollectionInputFilter extends InputFilter
      * @param iterable|null $data
      * @return $this
      */
-    public function setData($data)
+    public function setData(?iterable $data): InputFilterInterface
     {
         /** @psalm-suppress DocblockTypeContradiction, RedundantConditionGivenDocblockType */
         if (! is_array($data) && ! $data instanceof Traversable) {
@@ -175,10 +163,8 @@ class CollectionInputFilter extends InputFilter
      *
      * This validator will be used to produce a validation failure message in
      * cases where the collection is empty but required.
-     *
-     * @return NotEmpty
      */
-    public function getNotEmptyValidator()
+    public function getNotEmptyValidator(): NotEmpty
     {
         if ($this->notEmptyValidator === null) {
             $this->notEmptyValidator = new NotEmpty();
@@ -195,7 +181,7 @@ class CollectionInputFilter extends InputFilter
      *
      * @return $this
      */
-    public function setNotEmptyValidator(NotEmpty $notEmptyValidator)
+    public function setNotEmptyValidator(NotEmpty $notEmptyValidator): static
     {
         $this->notEmptyValidator = $notEmptyValidator;
 
@@ -205,7 +191,7 @@ class CollectionInputFilter extends InputFilter
     /**
      * @inheritDoc
      */
-    public function isValid($context = null)
+    public function isValid(mixed $context = null): bool
     {
         $this->collectionMessages = [];
         $inputFilter              = $this->getInputFilter();
@@ -253,10 +239,9 @@ class CollectionInputFilter extends InputFilter
     }
 
     /**
-     * @param string|array<array-key, list<string>> $name
      * @return $this
      */
-    public function setValidationGroup($name)
+    public function setValidationGroup(array|int|string $name): static
     {
         if ($name === self::VALIDATE_ALL) {
             $name = null;
@@ -270,7 +255,7 @@ class CollectionInputFilter extends InputFilter
      * @return array<array-key, array>
      * @psalm-return TFilteredValues
      */
-    public function getValues()
+    public function getValues(): array
     {
         return $this->collectionValues;
     }
@@ -278,7 +263,7 @@ class CollectionInputFilter extends InputFilter
     /**
      * @return array<array-key, array>
      */
-    public function getRawValues()
+    public function getRawValues(): array
     {
         return $this->collectionRawValues;
     }
@@ -288,7 +273,7 @@ class CollectionInputFilter extends InputFilter
      *
      * @return array[]
      */
-    public function clearValues()
+    public function clearValues(): array
     {
         return $this->collectionValues = [];
     }
@@ -298,7 +283,7 @@ class CollectionInputFilter extends InputFilter
      *
      * @return array[]
      */
-    public function clearRawValues()
+    public function clearRawValues(): array
     {
         return $this->collectionRawValues = [];
     }
@@ -306,7 +291,7 @@ class CollectionInputFilter extends InputFilter
     /**
      * @return array<array-key, array<string, array<array-key, string>>>
      */
-    public function getMessages()
+    public function getMessages(): array
     {
         return $this->collectionMessages;
     }
@@ -314,7 +299,7 @@ class CollectionInputFilter extends InputFilter
     /**
      * {@inheritdoc}
      */
-    public function getUnknown()
+    public function getUnknown(): array
     {
         if ($this->data === null) {
             throw new Exception\RuntimeException(sprintf(
@@ -337,10 +322,7 @@ class CollectionInputFilter extends InputFilter
         return $unknownInputs;
     }
 
-    /**
-     * @return array<string, string>
-     */
-    protected function prepareRequiredValidationFailureMessage()
+    protected function prepareRequiredValidationFailureMessage(): ?string
     {
         $notEmptyValidator = $this->getNotEmptyValidator();
         /** @var array<string, string> $templates */

--- a/src/CollectionInputFilter.php
+++ b/src/CollectionInputFilter.php
@@ -325,15 +325,7 @@ class CollectionInputFilter extends InputFilter
     protected function prepareRequiredValidationFailureMessage(): ?string
     {
         $notEmptyValidator = $this->getNotEmptyValidator();
-        /** @var array<string, string> $templates */
-        $templates  = $notEmptyValidator->getOption('messageTemplates');
-        $message    = $templates[NotEmpty::IS_EMPTY];
-        $translator = $notEmptyValidator->getTranslator();
 
-        return [
-            NotEmpty::IS_EMPTY => $translator
-                ? $translator->translate($message, $notEmptyValidator->getTranslatorTextDomain())
-                : $message,
-        ];
+        return $notEmptyValidator->getMessages()[NotEmpty::IS_EMPTY] ?? null;
     }
 }

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace Laminas\InputFilter;
 
-use Laminas\ServiceManager\ConfigInterface;
+use Laminas\ServiceManager\AbstractFactory\ReflectionBasedAbstractFactory;
+use Laminas\ServiceManager\ServiceManager;
 
 /**
- * @psalm-import-type ServiceManagerConfigurationType from ConfigInterface
- * @final
+ * @psalm-import-type ServiceManagerConfiguration from ServiceManager
  */
 class ConfigProvider
 {
@@ -16,11 +16,11 @@ class ConfigProvider
      * Return configuration for this component.
      *
      * @return array{
-     *     dependencies: ServiceManagerConfigurationType,
-     *     input_filters: ServiceManagerConfigurationType,
+     *     dependencies: ServiceManagerConfiguration,
+     *     input_filters: ServiceManagerConfiguration,
      * }
      */
-    public function __invoke()
+    public function __invoke(): array
     {
         return [
             'dependencies'  => $this->getDependencyConfig(),
@@ -31,10 +31,9 @@ class ConfigProvider
     /**
      * Return dependency mappings for this component.
      *
-     * @psalm-return ServiceManagerConfigurationType
-     * @return array
+     * @return ServiceManagerConfiguration
      */
-    public function getDependencyConfig()
+    public function getDependencyConfig(): array
     {
         return [
             'aliases'   => [
@@ -52,9 +51,9 @@ class ConfigProvider
     /**
      * Get input filter configuration
      *
-     * @return ServiceManagerConfigurationType
+     * @return ServiceManagerConfiguration
      */
-    public function getInputFilterConfig()
+    public function getInputFilterConfig(): array
     {
         return [
             'abstract_factories' => [

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -38,9 +38,6 @@ class ConfigProvider
         return [
             'aliases'   => [
                 'InputFilterManager' => InputFilterPluginManager::class,
-
-                // Legacy Zend Framework aliases
-                'Zend\InputFilter\InputFilterPluginManager' => InputFilterPluginManager::class,
             ],
             'factories' => [
                 InputFilterPluginManager::class => InputFilterPluginManagerFactory::class,

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -10,7 +10,7 @@ use Laminas\ServiceManager\ServiceManager;
 /**
  * @psalm-import-type ServiceManagerConfiguration from ServiceManager
  */
-class ConfigProvider
+final class ConfigProvider
 {
     /**
      * Return configuration for this component.

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -41,6 +41,7 @@ final class ConfigProvider
             ],
             'factories' => [
                 InputFilterPluginManager::class => InputFilterPluginManagerFactory::class,
+                Factory::class                  => ReflectionBasedAbstractFactory::class,
             ],
         ];
     }

--- a/src/EmptyContextInterface.php
+++ b/src/EmptyContextInterface.php
@@ -6,14 +6,7 @@ namespace Laminas\InputFilter;
 
 interface EmptyContextInterface
 {
-    /**
-     * @param bool $continueIfEmpty
-     * @return self
-     */
-    public function setContinueIfEmpty($continueIfEmpty);
+    public function setContinueIfEmpty(bool $continueIfEmpty): EmptyContextInterface;
 
-    /**
-     * @return bool
-     */
-    public function continueIfEmpty();
+    public function continueIfEmpty(): bool;
 }

--- a/src/Exception/InvalidArgumentException.php
+++ b/src/Exception/InvalidArgumentException.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Laminas\InputFilter\Exception;
 
-/** @final */
-class InvalidArgumentException extends \InvalidArgumentException implements ExceptionInterface
+final class InvalidArgumentException extends \InvalidArgumentException implements ExceptionInterface
 {
 }

--- a/src/Exception/RuntimeException.php
+++ b/src/Exception/RuntimeException.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Laminas\InputFilter\Exception;
 
-/** @final */
-class RuntimeException extends \RuntimeException implements ExceptionInterface
+final class RuntimeException extends \RuntimeException implements ExceptionInterface
 {
 }

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -248,7 +248,8 @@ class Factory
                     }
                     if (! is_array($value) && ! $value instanceof Traversable) {
                         throw new Exception\RuntimeException(sprintf(
-                            '%s expects the value associated with "validators" to be an array/Traversable of validators'
+                            '%s expects the value associated with "validators" to be '
+                            . 'an array/Traversable of validators'
                             . ' or validator specifications, or a ValidatorChain; received "%s"',
                             __METHOD__,
                             get_debug_type($value)

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -6,10 +6,12 @@ namespace Laminas\InputFilter;
 
 use Laminas\Filter\FilterChain;
 use Laminas\Filter\FilterInterface;
+use Laminas\Filter\FilterPluginManager;
 use Laminas\ServiceManager\ServiceManager;
 use Laminas\Stdlib\ArrayUtils;
 use Laminas\Validator\ValidatorChain;
 use Laminas\Validator\ValidatorInterface;
+use Laminas\Validator\ValidatorPluginManager;
 use Traversable;
 
 use function assert;
@@ -37,13 +39,20 @@ class Factory
 
     protected ?InputFilterPluginManager $inputFilterManager = null;
 
-    public function __construct(?InputFilterPluginManager $inputFilterManager = null)
-    {
-        $this->defaultFilterChain    = new FilterChain();
-        $this->defaultValidatorChain = new ValidatorChain();
-
+    public function __construct(
+        ?FilterPluginManager $filterPluginManager = null,
+        ?ValidatorPluginManager $validatorPluginManager = null,
+        ?InputFilterPluginManager $inputFilterManager = null,
+    ) {
         if ($inputFilterManager) {
             $this->setInputFilterManager($inputFilterManager);
+        }
+        if ($filterPluginManager) {
+            $this->defaultFilterChain = new FilterChain($filterPluginManager);
+        }
+
+        if ($validatorPluginManager) {
+            $this->defaultValidatorChain = new ValidatorChain($validatorPluginManager);
         }
     }
 
@@ -107,13 +116,12 @@ class Factory
     public function setInputFilterManager(InputFilterPluginManager $inputFilterManager): static
     {
         $this->inputFilterManager = $inputFilterManager;
-        $inputFilterManager->populateFactoryPluginManagers($this);
         return $this;
     }
 
     public function getInputFilterManager(): InputFilterPluginManager
     {
-        if (null === $this->inputFilterManager) {
+        if (! isset($this->inputFilterManager)) {
             $this->inputFilterManager = new InputFilterPluginManager(new ServiceManager());
         }
 
@@ -177,9 +185,7 @@ class Factory
             ));
         }
 
-        $managerInstance
-            ? $this->injectFilterAndValidatorChainsWithPluginManagers($input)
-            : $this->injectDefaultFilterAndValidatorChains($input);
+        $this->injectDefaultFilterAndValidatorChains($input);
 
         /**
          * Even though the specification is typed, psalm cannot tell the individual item types inside the switch
@@ -239,7 +245,9 @@ class Factory
                             get_debug_type($value)
                         ));
                     }
-                    $this->populateFilters($input->getFilterChain(), $value);
+                    if ($input->getFilterChain()) {
+                        $this->populateFilters($input->getFilterChain(), $value);
+                    }
                     break;
                 case 'validators':
                     if ($value instanceof ValidatorChain) {
@@ -256,7 +264,9 @@ class Factory
                         ));
                     }
 
-                    $this->populateValidators($input->getValidatorChain(), $value);
+                    if ($input->getValidatorChain()) {
+                        $this->populateValidators($input->getValidatorChain(), $value);
+                    }
                     break;
                 default:
                     // ignore unknown keys
@@ -305,7 +315,6 @@ class Factory
         assert($inputFilter instanceof InputFilterInterface); // As opposed to InputInterface
 
         if ($inputFilter instanceof CollectionInputFilter) {
-            $inputFilter->setFactory($this);
             if (isset($inputFilterSpecification['input_filter'])) {
                 $inputFilter->setInputFilter($inputFilterSpecification['input_filter']);
             }
@@ -359,7 +368,7 @@ class Factory
     }
 
     /**
-     * @param  iterable<array-key, FilterInterface|callable|FilterSpecification> $filters
+     * @param iterable<array-key, FilterInterface|callable|FilterSpecification> $filters
      * @throws Exception\RuntimeException
      */
     protected function populateFilters(FilterChain $chain, iterable $filters): void
@@ -395,7 +404,7 @@ class Factory
     }
 
     /**
-     * @param  iterable<array-key, ValidatorInterface|ValidatorSpecification> $validators
+     * @param iterable<array-key, ValidatorInterface|ValidatorSpecification> $validators
      * @throws Exception\RuntimeException
      */
     protected function populateValidators(ValidatorChain $chain, iterable $validators): void
@@ -446,33 +455,6 @@ class Factory
 
         if ($this->defaultValidatorChain) {
             $input->setValidatorChain(clone $this->defaultValidatorChain);
-        }
-    }
-
-    /**
-     * Inject filter and validator chains with the plugin managers from
-     * the default chains, if present.
-     *
-     * This ensures custom plugins are made available to the input instance.
-     *
-     * @return void
-     */
-    protected function injectFilterAndValidatorChainsWithPluginManagers(InputInterface $input)
-    {
-        if ($this->defaultFilterChain) {
-            $filterChain = $input->getFilterChain();
-            /** @psalm-suppress RedundantConditionGivenDocblockType, DocblockTypeContradiction */
-            $filterChain instanceof FilterChain
-                ? $filterChain->setPluginManager($this->defaultFilterChain->getPluginManager())
-                : $input->setFilterChain(clone $this->defaultFilterChain);
-        }
-
-        if ($this->defaultValidatorChain) {
-            $validatorChain = $input->getValidatorChain();
-            /** @psalm-suppress RedundantConditionGivenDocblockType, DocblockTypeContradiction */
-            $validatorChain instanceof ValidatorChain
-                ? $validatorChain->setPluginManager($this->defaultValidatorChain->getPluginManager())
-                : $input->setValidatorChain(clone $this->defaultValidatorChain);
         }
     }
 }

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -31,14 +31,11 @@ use function sprintf;
  */
 class Factory
 {
-    /** @var FilterChain|null */
-    protected $defaultFilterChain;
+    protected ?FilterChain $defaultFilterChain = null;
 
-    /** @var ValidatorChain|null */
-    protected $defaultValidatorChain;
+    protected ?ValidatorChain $defaultValidatorChain = null;
 
-    /** @var InputFilterPluginManager|null */
-    protected $inputFilterManager;
+    protected ?InputFilterPluginManager $inputFilterManager = null;
 
     public function __construct(?InputFilterPluginManager $inputFilterManager = null)
     {
@@ -55,7 +52,7 @@ class Factory
      *
      * @return $this
      */
-    public function setDefaultFilterChain(FilterChain $filterChain)
+    public function setDefaultFilterChain(FilterChain $filterChain): static
     {
         $this->defaultFilterChain = $filterChain;
         return $this;
@@ -63,20 +60,16 @@ class Factory
 
     /**
      * Get default filter chain, if any
-     *
-     * @return null|FilterChain
      */
-    public function getDefaultFilterChain()
+    public function getDefaultFilterChain(): ?FilterChain
     {
         return $this->defaultFilterChain;
     }
 
     /**
      * Clear the default filter chain (i.e., don't inject one into new inputs)
-     *
-     * @return void
      */
-    public function clearDefaultFilterChain()
+    public function clearDefaultFilterChain(): void
     {
         $this->defaultFilterChain = null;
     }
@@ -86,7 +79,7 @@ class Factory
      *
      * @return $this
      */
-    public function setDefaultValidatorChain(ValidatorChain $validatorChain)
+    public function setDefaultValidatorChain(ValidatorChain $validatorChain): static
     {
         $this->defaultValidatorChain = $validatorChain;
         return $this;
@@ -94,20 +87,16 @@ class Factory
 
     /**
      * Get default validator chain, if any
-     *
-     * @return null|ValidatorChain
      */
-    public function getDefaultValidatorChain()
+    public function getDefaultValidatorChain(): ?ValidatorChain
     {
         return $this->defaultValidatorChain;
     }
 
     /**
      * Clear the default validator chain (i.e., don't inject one into new inputs)
-     *
-     * @return void
      */
-    public function clearDefaultValidatorChain()
+    public function clearDefaultValidatorChain(): void
     {
         $this->defaultValidatorChain = null;
     }
@@ -115,17 +104,14 @@ class Factory
     /**
      * @return $this
      */
-    public function setInputFilterManager(InputFilterPluginManager $inputFilterManager)
+    public function setInputFilterManager(InputFilterPluginManager $inputFilterManager): static
     {
         $this->inputFilterManager = $inputFilterManager;
         $inputFilterManager->populateFactoryPluginManagers($this);
         return $this;
     }
 
-    /**
-     * @return InputFilterPluginManager
-     */
-    public function getInputFilterManager()
+    public function getInputFilterManager(): InputFilterPluginManager
     {
         if (null === $this->inputFilterManager) {
             $this->inputFilterManager = new InputFilterPluginManager(new ServiceManager());
@@ -137,12 +123,11 @@ class Factory
     /**
      * Factory for input objects
      *
-     * @param  InputSpecification|Traversable|InputProviderInterface $inputSpecification
-     * @throws Exception\InvalidArgumentException
+     * @param InputSpecification|Traversable|InputProviderInterface $inputSpecification
      * @throws Exception\RuntimeException
-     * @return InputInterface|InputFilterInterface
+     * @throws Exception\InvalidArgumentException
      */
-    public function createInput($inputSpecification)
+    public function createInput($inputSpecification): InputFilterInputInterface
     {
         if ($inputSpecification instanceof InputProviderInterface) {
             $inputSpecification = $inputSpecification->getInputSpecification();
@@ -286,11 +271,10 @@ class Factory
      *
      * phpcs:ignore Generic.Files.LineLength.TooLong, SlevomatCodingStandard.Commenting.DocCommentSpacing
      * @param InputFilterSpecification|CollectionSpecification|Traversable|InputFilterProviderInterface $inputFilterSpecification
-     * @return InputFilterInterface
      * @throws Exception\RuntimeException
      * @throws Exception\InvalidArgumentException
      */
-    public function createInputFilter($inputFilterSpecification)
+    public function createInputFilter($inputFilterSpecification): InputFilterInterface
     {
         if ($inputFilterSpecification instanceof InputFilterProviderInterface) {
             $inputFilterSpecification = $inputFilterSpecification->getInputFilterSpecification();
@@ -376,9 +360,8 @@ class Factory
     /**
      * @param  iterable<array-key, FilterInterface|callable|FilterSpecification> $filters
      * @throws Exception\RuntimeException
-     * @return void
      */
-    protected function populateFilters(FilterChain $chain, $filters)
+    protected function populateFilters(FilterChain $chain, iterable $filters): void
     {
         foreach ($filters as $filter) {
             /** @psalm-suppress RedundantConditionGivenDocblockType */
@@ -413,9 +396,8 @@ class Factory
     /**
      * @param  iterable<array-key, ValidatorInterface|ValidatorSpecification> $validators
      * @throws Exception\RuntimeException
-     * @return void
      */
-    protected function populateValidators(ValidatorChain $chain, $validators)
+    protected function populateValidators(ValidatorChain $chain, iterable $validators): void
     {
         foreach ($validators as $validator) {
             if ($validator instanceof ValidatorInterface) {
@@ -454,10 +436,8 @@ class Factory
      * Inject the default filter and validator chains into the input, if present.
      *
      * This ensures custom plugins are made available to the input instance.
-     *
-     * @return void
      */
-    protected function injectDefaultFilterAndValidatorChains(InputInterface $input)
+    protected function injectDefaultFilterAndValidatorChains(InputInterface $input): void
     {
         if ($this->defaultFilterChain) {
             $input->setFilterChain(clone $this->defaultFilterChain);

--- a/src/FileInput.php
+++ b/src/FileInput.php
@@ -27,54 +27,41 @@ use function is_array;
  */
 class FileInput extends Input
 {
-    /** @var bool */
-    protected $isValid = false;
+    protected bool $isValid = false;
 
-    /** @var bool */
-    protected $autoPrependUploadValidator = true;
+    protected bool $autoPrependUploadValidator = true;
 
     private ?FileInputDecoratorInterface $implementation = null;
 
-    /**
-     * @inheritDoc
-     * @param array|UploadedFileInterface $value
-     */
-    public function setValue($value)
+    public function setValue(mixed $value): static
     {
         $this->implementation = $this->createDecoratorImplementation($value);
         parent::setValue($value);
         return $this;
     }
 
-    /** @return $this */
-    public function resetValue()
+    public function resetValue(): static
     {
         $this->implementation = null;
         return parent::resetValue();
     }
 
     /**
-     * @param  bool $value Enable/Disable automatically prepending an Upload validator
+     * @param bool $value Enable/Disable automatically prepending an Upload validator
      * @return $this
      */
-    public function setAutoPrependUploadValidator($value)
+    public function setAutoPrependUploadValidator(bool $value): static
     {
         $this->autoPrependUploadValidator = $value;
         return $this;
     }
 
-    /**
-     * @return bool
-     */
-    public function getAutoPrependUploadValidator()
+    public function getAutoPrependUploadValidator(): bool
     {
         return $this->autoPrependUploadValidator;
     }
 
-    /**
-     * @return mixed
-     */
-    public function getValue()
+    public function getValue(): mixed
     {
         if ($this->implementation === null) {
             return $this->value;
@@ -84,11 +71,8 @@ class FileInput extends Input
 
     /**
      * Checks if the raw input value is an empty file input eg: no file was uploaded
-     *
-     * @param mixed $rawValue
-     * @return bool
      */
-    public function isEmptyFile($rawValue)
+    public function isEmptyFile(mixed $rawValue): bool
     {
         if ($rawValue instanceof UploadedFileInterface) {
             return FileInput\PsrFileInputDecorator::isEmptyFileDecorator($rawValue);
@@ -106,10 +90,9 @@ class FileInput extends Input
     }
 
     /**
-     * @param  mixed $context Extra "context" to provide the validator
-     * @return bool
+     * @param mixed|null $context Extra "context" to provide the validator
      */
-    public function isValid($context = null)
+    public function isValid(mixed $context = null): bool
     {
         $rawValue        = $this->getRawValue();
         $hasValue        = $this->hasValue();
@@ -144,7 +127,7 @@ class FileInput extends Input
     /**
      * @return $this
      */
-    public function merge(InputInterface $input)
+    public function merge(InputInterface $input): static
     {
         parent::merge($input);
         if ($input instanceof FileInput) {
@@ -156,19 +139,13 @@ class FileInput extends Input
     /**
      * No-op, NotEmpty validator does not apply for FileInputs.
      * See also: BaseInputFilter::isValid()
-     *
-     * @return void
      */
-    protected function injectNotEmptyValidator()
+    protected function injectNotEmptyValidator(): void
     {
         $this->notEmptyValidator = true;
     }
 
-    /**
-     * @param mixed $value
-     * @return FileInputDecoratorInterface
-     */
-    private function createDecoratorImplementation($value)
+    private function createDecoratorImplementation(mixed $value): FileInputDecoratorInterface
     {
         // Single PSR-7 instance
         if ($value instanceof UploadedFileInterface) {

--- a/src/FileInput/FileInputDecoratorInterface.php
+++ b/src/FileInput/FileInputDecoratorInterface.php
@@ -15,20 +15,13 @@ interface FileInputDecoratorInterface
 {
     /**
      * Checks if the raw input value is an empty file input eg: no file was uploaded
-     *
-     * @param mixed $rawValue
-     * @return bool
      */
-    public static function isEmptyFileDecorator($rawValue);
+    public static function isEmptyFileDecorator(mixed $rawValue): bool;
+
+    public function getValue(): mixed;
 
     /**
-     * @return mixed
+     * @param mixed|null $context Extra "context" to provide the validator
      */
-    public function getValue();
-
-    /**
-     * @param  mixed $context Extra "context" to provide the validator
-     * @return bool
-     */
-    public function isValid($context = null);
+    public function isValid(mixed $context = null): bool;
 }

--- a/src/FileInput/HttpServerFileInputDecorator.php
+++ b/src/FileInput/HttpServerFileInputDecorator.php
@@ -33,11 +33,8 @@ class HttpServerFileInputDecorator extends FileInput implements FileInputDecorat
 {
     /**
      * Checks if the raw input value is an empty file input eg: no file was uploaded
-     *
-     * @param mixed $rawValue
-     * @return bool
      */
-    public static function isEmptyFileDecorator($rawValue)
+    public static function isEmptyFileDecorator(mixed $rawValue): bool
     {
         if (! is_array($rawValue)) {
             return true;
@@ -58,10 +55,7 @@ class HttpServerFileInputDecorator extends FileInput implements FileInputDecorat
     {
     }
 
-    /**
-     * @return mixed
-     */
-    public function getValue()
+    public function getValue(): mixed
     {
         $value = $this->subject->value;
 
@@ -90,10 +84,9 @@ class HttpServerFileInputDecorator extends FileInput implements FileInputDecorat
     }
 
     /**
-     * @param  mixed $context Extra "context" to provide the validator
-     * @return bool
+     * @param mixed|null $context Extra "context" to provide the validator
      */
-    public function isValid($context = null)
+    public function isValid(mixed $context = null): bool
     {
         $rawValue  = $this->subject->getRawValue();
         $validator = $this->injectUploadValidator($this->subject->getValidatorChain());
@@ -141,10 +134,7 @@ class HttpServerFileInputDecorator extends FileInput implements FileInputDecorat
         return $this->subject->isValid;
     }
 
-    /**
-     * @return ValidatorChain
-     */
-    protected function injectUploadValidator(ValidatorChain $chain)
+    protected function injectUploadValidator(ValidatorChain $chain): ValidatorChain
     {
         if (! $this->subject->autoPrependUploadValidator) {
             return $chain;

--- a/src/FileInput/PsrFileInputDecorator.php
+++ b/src/FileInput/PsrFileInputDecorator.php
@@ -33,11 +33,8 @@ class PsrFileInputDecorator extends FileInput implements FileInputDecoratorInter
 {
     /**
      * Checks if the raw input value is an empty file input eg: no file was uploaded
-     *
-     * @param UploadedFileInterface|array $rawValue
-     * @return bool
      */
-    public static function isEmptyFileDecorator($rawValue)
+    public static function isEmptyFileDecorator(mixed $rawValue): bool
     {
         if (is_array($rawValue)) {
             return self::isEmptyFileDecorator($rawValue[0]);
@@ -53,7 +50,7 @@ class PsrFileInputDecorator extends FileInput implements FileInputDecoratorInter
     /**
      * @return UploadedFileInterface|UploadedFileInterface[]
      */
-    public function getValue()
+    public function getValue(): mixed
     {
         $value = $this->subject->value;
 
@@ -79,10 +76,9 @@ class PsrFileInputDecorator extends FileInput implements FileInputDecoratorInter
     }
 
     /**
-     * @param  mixed $context Extra "context" to provide the validator
-     * @return bool
+     * @param mixed|null $context Extra "context" to provide the validator
      */
-    public function isValid($context = null)
+    public function isValid(mixed $context = null): bool
     {
         $rawValue  = $this->subject->getRawValue();
         $validator = $this->injectUploadValidator($this->subject->getValidatorChain());
@@ -104,10 +100,7 @@ class PsrFileInputDecorator extends FileInput implements FileInputDecoratorInter
         return $this->subject->isValid;
     }
 
-    /**
-     * @return ValidatorChain
-     */
-    protected function injectUploadValidator(ValidatorChain $chain)
+    protected function injectUploadValidator(ValidatorChain $chain): ValidatorChain
     {
         if (! $this->subject->autoPrependUploadValidator) {
             return $chain;

--- a/src/Input.php
+++ b/src/Input.php
@@ -17,144 +17,86 @@ class Input implements
     InputInterface,
     EmptyContextInterface
 {
-    /** @var bool */
-    protected $allowEmpty = false;
+    protected bool $allowEmpty = false;
 
-    /** @var bool */
-    protected $continueIfEmpty = false;
+    protected bool $continueIfEmpty = false;
 
-    /** @var bool */
-    protected $breakOnFailure = false;
+    protected bool $breakOnFailure = false;
 
-    /** @var string|null */
-    protected $errorMessage;
+    protected ?string $errorMessage = null;
 
-    /** @var null|FilterChain */
-    protected $filterChain;
+    protected ?FilterChain $filterChain = null;
 
-    /** @var bool */
-    protected $notEmptyValidator = false;
+    protected bool $notEmptyValidator = false;
 
-    /** @var bool */
-    protected $required = true;
+    protected bool $required = true;
 
-    /** @var null|ValidatorChain */
-    protected $validatorChain;
+    protected ?ValidatorChain $validatorChain = null;
 
-    /** @var mixed */
-    protected $value;
+    protected mixed $value;
 
     /**
      * Flag for distinguish when $value contains the value previously set or the default one.
-     *
-     * @var bool
      */
-    protected $hasValue = false;
+    protected bool $hasValue = false;
 
-    /** @var mixed|null */
-    protected $fallbackValue;
+    protected mixed $fallbackValue;
 
-    /** @var bool */
-    protected $hasFallback = false;
+    protected bool $hasFallback = false;
 
-    /** @param null|string $name */
-    public function __construct(protected $name = null)
+    public function __construct(protected ?string $name = null)
     {
     }
 
-    /**
-     * @param  bool $allowEmpty
-     * @return $this
-     */
-    public function setAllowEmpty($allowEmpty)
+    public function setAllowEmpty(bool $allowEmpty): static
     {
-        $this->allowEmpty = (bool) $allowEmpty;
+        $this->allowEmpty = $allowEmpty;
         return $this;
     }
 
-    /**
-     * @param  bool $breakOnFailure
-     * @return $this
-     */
-    public function setBreakOnFailure($breakOnFailure)
+    public function setBreakOnFailure(bool $breakOnFailure): static
     {
         $this->breakOnFailure = (bool) $breakOnFailure;
         return $this;
     }
 
-    /**
-     * @param bool $continueIfEmpty
-     * @return $this
-     */
-    public function setContinueIfEmpty($continueIfEmpty)
+    public function setContinueIfEmpty(bool $continueIfEmpty): static
     {
         $this->continueIfEmpty = (bool) $continueIfEmpty;
         return $this;
     }
 
-    /**
-     * @param  string|null $errorMessage
-     * @return $this
-     */
-    public function setErrorMessage($errorMessage)
+    public function setErrorMessage(?string $errorMessage): static
     {
-        $this->errorMessage = null === $errorMessage ? null : (string) $errorMessage;
+        $this->errorMessage = $errorMessage ?? null;
         return $this;
     }
 
-    /**
-     * @return $this
-     */
-    public function setFilterChain(FilterChain $filterChain)
+    public function setFilterChain(FilterChain $filterChain): static
     {
         $this->filterChain = $filterChain;
         return $this;
     }
 
-    /**
-     * @param  string $name
-     * @return $this
-     */
-    public function setName($name)
+    public function setName(string $name): static
     {
-        /** @psalm-suppress RedundantCastGivenDocblockType */
-        $this->name = (string) $name;
+        $this->name = $name;
         return $this;
     }
 
-    /**
-     * @param  bool $required
-     * @return $this
-     */
-    public function setRequired($required)
+    public function setRequired(bool $required): static
     {
-        /** @psalm-suppress RedundantCastGivenDocblockType */
-        $this->required = (bool) $required;
+        $this->required = $required;
         return $this;
     }
 
-    /**
-     * @return $this
-     */
-    public function setValidatorChain(ValidatorChain $validatorChain)
+    public function setValidatorChain(ValidatorChain $validatorChain): static
     {
         $this->validatorChain = $validatorChain;
         return $this;
     }
 
-    /**
-     * Set the input value.
-     *
-     * If you want to remove/unset the current value use {@link Input::resetValue()}.
-     *
-     * @see Input::getValue() For retrieve the input value.
-     * @see Input::hasValue() For to know if input value was set.
-     * @see Input::resetValue() For reset the input value to the default state.
-     *
-     * @param  mixed $value
-     * @return $this
-     */
-    public function setValue($value)
+    public function setValue(mixed $value): static
     {
         $this->value    = $value;
         $this->hasValue = true;
@@ -164,111 +106,71 @@ class Input implements
     /**
      * Reset input value to the default state.
      *
-     * @see Input::hasValue() For to know if input value was set.
      * @see Input::setValue() For set a new value.
+     * @see Input::hasValue() For to know if input value was set.
      *
      * @return $this
      */
-    public function resetValue()
+    public function resetValue(): static
     {
         $this->value    = null;
         $this->hasValue = false;
         return $this;
     }
 
-    /**
-     * @param  mixed $value
-     * @return $this
-     */
-    public function setFallbackValue($value)
+    public function setFallbackValue(mixed $value): static
     {
         $this->fallbackValue = $value;
         $this->hasFallback   = true;
         return $this;
     }
 
-    /**
-     * @return bool
-     */
-    public function allowEmpty()
+    public function allowEmpty(): bool
     {
         return $this->allowEmpty;
     }
 
-    /**
-     * @return bool
-     */
-    public function breakOnFailure()
+    public function breakOnFailure(): bool
     {
         return $this->breakOnFailure;
     }
 
-    /**
-     * @return bool
-     */
-    public function continueIfEmpty()
+    public function continueIfEmpty(): bool
     {
         return $this->continueIfEmpty;
     }
 
-    /**
-     * @return string|null
-     */
-    public function getErrorMessage()
+    public function getErrorMessage(): ?string
     {
         return $this->errorMessage;
     }
 
-    /**
-     * @return FilterChain
-     */
-    public function getFilterChain()
+    public function getFilterChain(): ?FilterChain
     {
-        if (! $this->filterChain) {
-            $this->filterChain = new FilterChain();
-        }
         return $this->filterChain;
     }
 
-    /**
-     * @return null|string
-     */
-    public function getName()
+    public function getName(): ?string
     {
         return $this->name;
     }
 
-    /**
-     * @return mixed
-     */
-    public function getRawValue()
+    public function getRawValue(): mixed
     {
         return $this->value;
     }
 
-    /**
-     * @return bool
-     */
-    public function isRequired()
+    public function isRequired(): bool
     {
         return $this->required;
     }
 
-    /**
-     * @return ValidatorChain
-     */
-    public function getValidatorChain()
+    public function getValidatorChain(): ?ValidatorChain
     {
-        if (! $this->validatorChain) {
-            $this->validatorChain = new ValidatorChain();
-        }
         return $this->validatorChain;
     }
 
-    /**
-     * @return mixed
-     */
-    public function getValue()
+    public function getValue(): mixed
     {
         $filter = $this->getFilterChain();
         return $filter->filter($this->value);
@@ -280,44 +182,32 @@ class Input implements
      * This flag used for distinguish when {@link Input::getValue()}
      * will return the value previously set or the default.
      *
-     * @see Input::getValue() For retrieve the input value.
      * @see Input::setValue() For set a new value.
      * @see Input::resetValue() For reset the input value to the default state.
-     *
-     * @return bool
+     * @see Input::getValue() For retrieve the input value.
      */
-    public function hasValue()
+    public function hasValue(): bool
     {
         return $this->hasValue;
     }
 
-    /**
-     * @return mixed
-     */
-    public function getFallbackValue()
+    public function getFallbackValue(): mixed
     {
         return $this->fallbackValue;
     }
 
-    /**
-     * @return bool
-     */
-    public function hasFallback()
+    public function hasFallback(): bool
     {
         return $this->hasFallback;
     }
 
-    /** @return void */
-    public function clearFallbackValue()
+    public function clearFallbackValue(): void
     {
         $this->hasFallback   = false;
         $this->fallbackValue = null;
     }
 
-    /**
-     * @return $this
-     */
-    public function merge(InputInterface $input)
+    public function merge(InputInterface $input): static
     {
         $this->setBreakOnFailure($input->breakOnFailure());
         if ($input instanceof Input) {
@@ -340,10 +230,9 @@ class Input implements
     }
 
     /**
-     * @param  mixed $context Extra "context" to provide the validator
-     * @return bool
+     * @param mixed $context Extra "context" to provide the validator
      */
-    public function isValid($context = null)
+    public function isValid(mixed $context = null): bool
     {
         if (is_array($this->errorMessage)) {
             $this->errorMessage = null;
@@ -401,7 +290,7 @@ class Input implements
     /**
      * @return array<array-key, string>
      */
-    public function getMessages()
+    public function getMessages(): array
     {
         if (null !== $this->errorMessage) {
             return (array) $this->errorMessage;
@@ -412,13 +301,10 @@ class Input implements
         }
 
         $validator = $this->getValidatorChain();
-        return $validator->getMessages();
+        return $validator?->getMessages() ?: [];
     }
 
-    /**
-     * @return void
-     */
-    protected function injectNotEmptyValidator()
+    protected function injectNotEmptyValidator(): void
     {
         if ((! $this->isRequired() && $this->allowEmpty()) || $this->notEmptyValidator) {
             return;
@@ -447,10 +333,8 @@ class Input implements
 
     /**
      * Create and return the validation failure message for required input.
-     *
-     * @return array<string, string>
      */
-    protected function prepareRequiredValidationFailureMessage()
+    protected function prepareRequiredValidationFailureMessage(): ?string
     {
         $chain    = $this->getValidatorChain();
         $notEmpty = $chain->plugin(NotEmpty::class);

--- a/src/Input.php
+++ b/src/Input.php
@@ -171,7 +171,10 @@ class Input implements
     public function getValue(): mixed
     {
         $filter = $this->getFilterChain();
-        return $filter->filter($this->value);
+        if ($filter) {
+            return $filter->filter($this->value);
+        }
+        return $this->value;
     }
 
     /**
@@ -220,10 +223,14 @@ class Input implements
         }
 
         $filterChain = $input->getFilterChain();
-        $this->getFilterChain()->merge($filterChain);
+        if ($filterChain) {
+            $this->getFilterChain()->merge($filterChain);
+        }
 
         $validatorChain = $input->getValidatorChain();
-        $this->getValidatorChain()->merge($validatorChain);
+        if ($validatorChain) {
+            $this->getValidatorChain()->merge($validatorChain);
+        }
         return $this;
     }
 
@@ -272,7 +279,10 @@ class Input implements
         }
 
         $validator = $this->getValidatorChain();
-        $result    = $validator->isValid($value, $context);
+        if ($validator) {
+            return true;
+        }
+        $result = $validator->isValid($value, $context);
         if (! $result && $this->hasFallback()) {
             $this->setValue($this->getFallbackValue());
             $result = true;
@@ -304,6 +314,9 @@ class Input implements
             return;
         }
         $chain = $this->getValidatorChain();
+        if (! $chain) {
+            return;
+        }
 
         // Check if NotEmpty validator is already in chain
         $validators = $chain->getValidators();
@@ -330,7 +343,10 @@ class Input implements
      */
     protected function prepareRequiredValidationFailureMessage(): ?string
     {
-        $chain    = $this->getValidatorChain();
+        $chain = $this->getValidatorChain();
+        if (! $chain) {
+            return null;
+        }
         $notEmpty = $chain->plugin(NotEmpty::class);
 
         foreach ($chain->getValidators() as $validator) {

--- a/src/Input.php
+++ b/src/Input.php
@@ -7,11 +7,9 @@ namespace Laminas\InputFilter;
 use Laminas\Filter\FilterChain;
 use Laminas\ServiceManager\AbstractPluginManager;
 use Laminas\Validator\NotEmpty;
-use Laminas\Validator\Translator\TranslatorInterface;
 use Laminas\Validator\ValidatorChain;
 
 use function class_exists;
-use function is_array;
 
 class Input implements
     InputInterface,
@@ -234,10 +232,6 @@ class Input implements
      */
     public function isValid(mixed $context = null): bool
     {
-        if (is_array($this->errorMessage)) {
-            $this->errorMessage = null;
-        }
-
         $value           = $this->getValue();
         $hasValue        = $this->hasValue();
         $empty           = $value === null || $value === '' || $value === [];
@@ -346,17 +340,6 @@ class Input implements
             }
         }
 
-        /** @psalm-var array<string, string> $templates */
-        $templates  = $notEmpty->getOption('messageTemplates');
-        $message    = $templates[NotEmpty::IS_EMPTY];
-        $translator = $notEmpty->getTranslator();
-
-        if ($translator instanceof TranslatorInterface) {
-            $message = $translator->translate($message, $notEmpty->getTranslatorTextDomain());
-        }
-
-        return [
-            NotEmpty::IS_EMPTY => $message,
-        ];
+        return $notEmpty->getMessages()[NotEmpty::IS_EMPTY] ?? null;
     }
 }

--- a/src/InputFilter.php
+++ b/src/InputFilter.php
@@ -15,15 +15,14 @@ use function is_array;
  */
 class InputFilter extends BaseInputFilter
 {
-    /** @var Factory|null */
-    protected $factory;
+    protected ?Factory $factory;
 
     /**
      * Set factory to use when adding inputs and filters by spec
      *
-     * @return InputFilter
+     * @return $this
      */
-    public function setFactory(Factory $factory)
+    public function setFactory(Factory $factory): static
     {
         $this->factory = $factory;
         return $this;
@@ -33,25 +32,20 @@ class InputFilter extends BaseInputFilter
      * Get factory to use when adding inputs and filters by spec
      *
      * Lazy-loads a Factory instance if none attached.
-     *
-     * @return Factory
      */
-    public function getFactory()
+    public function getFactory(): ?Factory
     {
-        if (null === $this->factory) {
-            $this->factory = new Factory();
-        }
         return $this->factory;
     }
 
     /**
      * Add an input to the input filter
      *
-     * @param  InputSpecification|Traversable|InputInterface|InputFilterInterface $input
-     * @param  array-key|null $name
+     * @param InputFilterInputInterface|iterable|InputSpecification $input
+     * @param array-key|null $name
      * @return $this
      */
-    public function add($input, $name = null)
+    public function add(InputFilterInputInterface|iterable $input, int|string|null $name = null): static
     {
         if (
             is_array($input)

--- a/src/InputFilterAbstractServiceFactory.php
+++ b/src/InputFilterAbstractServiceFactory.php
@@ -4,131 +4,36 @@ declare(strict_types=1);
 
 namespace Laminas\InputFilter;
 
-use Laminas\Filter\FilterChain;
-use Laminas\Filter\FilterPluginManager;
-use Laminas\ServiceManager\AbstractFactoryInterface;
-use Laminas\ServiceManager\ServiceLocatorInterface;
-use Laminas\Validator\ValidatorChain;
-use Laminas\Validator\ValidatorPluginManager;
+use Laminas\ServiceManager\Factory\AbstractFactoryInterface;
 use Psr\Container\ContainerInterface;
 
-use function assert;
 use function is_array;
 
-/** @final */
-class InputFilterAbstractServiceFactory implements AbstractFactoryInterface
+final class InputFilterAbstractServiceFactory implements AbstractFactoryInterface
 {
-    /** @var Factory|null */
-    protected $factory;
-
-    /**
-     * @param string                  $rName
-     * @return InputFilterInterface
-     */
-    public function __invoke(ContainerInterface $services, $rName, ?array $options = null)
+    public function __invoke(ContainerInterface $container, string $requestedName, ?array $options = null): mixed
     {
-        $allConfig = $services->get('config');
-        $config    = $allConfig['input_filter_specs'][$rName];
-        $factory   = $this->getInputFilterFactory($services);
+        $allConfig = $container->get('config');
+        $config    = $allConfig['input_filter_specs'][$requestedName];
+        $factory   = $container->get(Factory::class);
 
         return $factory->createInputFilter($config);
     }
 
-    /**
-     * @param string $rName
-     * @return bool
-     */
-    public function canCreate(ContainerInterface $services, $rName)
+    public function canCreate(ContainerInterface $container, string $requestedName): bool
     {
-        if (! $services->has('config')) {
+        if (! $container->has('config')) {
             return false;
         }
 
-        $config = $services->get('config');
+        $config = $container->get('config');
         if (
-            ! isset($config['input_filter_specs'][$rName])
-            || ! is_array($config['input_filter_specs'][$rName])
+            ! isset($config['input_filter_specs'][$requestedName])
+            || ! is_array($config['input_filter_specs'][$requestedName])
         ) {
             return false;
         }
 
         return true;
-    }
-
-    /**
-     * Determine if we can create a service with name (v2)
-     *
-     * @deprecated This library is no longer compatible with Service manager V2 and this method will be dropped in the
-     *             next major release.
-     *
-     * @param string $name
-     * @param string $requestedName
-     * @return bool
-     */
-    public function canCreateServiceWithName(ServiceLocatorInterface $container, $name, $requestedName)
-    {
-        return $this->canCreate($container, $requestedName);
-    }
-
-    /**
-     * Create the requested service (v2)
-     *
-     * @deprecated This library is no longer compatible with Service manager V2 and this method will be dropped in the
-     *             next major release.
-     *
-     * @param string                  $cName
-     * @param string                  $rName
-     * @return InputFilterInterface
-     */
-    public function createServiceWithName(ServiceLocatorInterface $container, $cName, $rName)
-    {
-        return $this($container, $rName);
-    }
-
-    /**
-     * @return Factory
-     */
-    protected function getInputFilterFactory(ContainerInterface $container)
-    {
-        if ($this->factory instanceof Factory) {
-            return $this->factory;
-        }
-
-        $this->factory  = new Factory();
-        $filterChain    = $this->factory->getDefaultFilterChain();
-        $validatorChain = $this->factory->getDefaultValidatorChain();
-        assert($filterChain instanceof FilterChain);
-        assert($validatorChain instanceof ValidatorChain);
-
-        $filterChain->setPluginManager($this->getFilterPluginManager($container));
-        $validatorChain->setPluginManager($this->getValidatorPluginManager($container));
-
-        $this->factory->setInputFilterManager($container->get(InputFilterPluginManager::class));
-
-        return $this->factory;
-    }
-
-    /**
-     * @return FilterPluginManager
-     */
-    protected function getFilterPluginManager(ContainerInterface $container)
-    {
-        if ($container->has(FilterPluginManager::class)) {
-            return $container->get(FilterPluginManager::class);
-        }
-
-        return new FilterPluginManager($container);
-    }
-
-    /**
-     * @return ValidatorPluginManager
-     */
-    protected function getValidatorPluginManager(ContainerInterface $container)
-    {
-        if ($container->has(ValidatorPluginManager::class)) {
-            return $container->get(ValidatorPluginManager::class);
-        }
-
-        return new ValidatorPluginManager($container);
     }
 }

--- a/src/InputFilterAwareInterface.php
+++ b/src/InputFilterAwareInterface.php
@@ -9,14 +9,12 @@ interface InputFilterAwareInterface
     /**
      * Set input filter
      *
-     * @return InputFilterAwareInterface
+     * @return $this
      */
-    public function setInputFilter(InputFilterInterface $inputFilter);
+    public function setInputFilter(InputFilterInterface $inputFilter): static;
 
     /**
      * Retrieve input filter
-     *
-     * @return InputFilterInterface
      */
-    public function getInputFilter();
+    public function getInputFilter(): InputFilterInterface;
 }

--- a/src/InputFilterAwareTrait.php
+++ b/src/InputFilterAwareTrait.php
@@ -6,15 +6,14 @@ namespace Laminas\InputFilter;
 
 trait InputFilterAwareTrait
 {
-    /** @var InputFilterInterface|null */
-    protected $inputFilter;
+    protected ?InputFilterInterface $inputFilter;
 
     /**
      * Set input filter
      *
-     * @return mixed
+     * @return $this
      */
-    public function setInputFilter(InputFilterInterface $inputFilter)
+    public function setInputFilter(InputFilterInterface $inputFilter): static
     {
         $this->inputFilter = $inputFilter;
 
@@ -23,10 +22,8 @@ trait InputFilterAwareTrait
 
     /**
      * Retrieve input filter
-     *
-     * @return InputFilterInterface
      */
-    public function getInputFilter()
+    public function getInputFilter(): InputFilterInterface
     {
         return $this->inputFilter;
     }

--- a/src/InputFilterInputInterface.php
+++ b/src/InputFilterInputInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\InputFilter;
+
+interface InputFilterInputInterface
+{
+    public function isValid(): bool;
+
+    /**
+     * @return array<array-key, string>
+     */
+    public function getMessages(): array;
+}

--- a/src/InputFilterInterface.php
+++ b/src/InputFilterInterface.php
@@ -96,12 +96,6 @@ interface InputFilterInterface extends Countable
      */
     public function setData($data);
 
-    /**
-     * Is the data set valid?
-     *
-     * @return bool
-     */
-    public function isValid();
 
     /**
      * Provide a list of one or more elements indicating the complete set to validate
@@ -176,13 +170,4 @@ interface InputFilterInterface extends Countable
      */
     public function getRawValues();
 
-    /**
-     * Return a list of validation failure messages
-     *
-     * Should return an associative array of named input/message list pairs.
-     * Pairs should only be returned for inputs that failed validation.
-     *
-     * @return array<array-key, array<array-key, string|array>>
-     */
-    public function getMessages();
 }

--- a/src/InputFilterInterface.php
+++ b/src/InputFilterInterface.php
@@ -47,7 +47,7 @@ use Laminas\Validator\ValidatorInterface; // phpcs:ignore
  *     required_message?: string,
  * }&array<array-key, InputSpecification>
  */
-interface InputFilterInterface extends Countable
+interface InputFilterInterface extends InputFilterInputInterface, Countable
 {
     public const VALIDATE_ALL = 'INPUT_FILTER_ALL';
 

--- a/src/InputFilterInterface.php
+++ b/src/InputFilterInterface.php
@@ -9,7 +9,6 @@ use Laminas\Filter\FilterChain; // phpcs:ignore
 use Laminas\Filter\FilterInterface; // phpcs:ignore
 use Laminas\Validator\ValidatorChain; // phpcs:ignore
 use Laminas\Validator\ValidatorInterface; // phpcs:ignore
-use Traversable;
 
 /**
  * @template TFilteredValues
@@ -55,47 +54,41 @@ interface InputFilterInterface extends Countable
     /**
      * Add an input to the input filter
      *
-     * @param  InputInterface|InputFilterInterface|InputSpecification|Traversable $input
+     * @param iterable|InputFilterInputInterface|InputSpecification $input
      *     Implementations MUST handle at least one of the specified types, and
      *     raise an exception for any they cannot process.
-     * @param  null|array-key $name Name used to retrieve this input
-     * @return InputFilterInterface
+     * @param array-key|null $name Name used to retrieve this input
      * @throws Exception\InvalidArgumentException If unable to handle the input type.
      */
-    public function add($input, $name = null);
+    public function add(InputFilterInputInterface|iterable $input, int|string|null $name = null): InputFilterInterface;
 
     /**
      * Retrieve a named input
      *
-     * @param  array-key $name
-     * @return InputInterface|InputFilterInterface
+     * @param array-key $name
      */
-    public function get($name);
+    public function get(int|string $name): InputFilterInputInterface;
 
     /**
      * Test if an input or input filter by the given name is attached
      *
-     * @param  array-key $name
-     * @return bool
+     * @param array-key $name
      */
-    public function has($name);
+    public function has(int|string $name): bool;
 
     /**
      * Remove a named input
      *
-     * @param  array-key $name
-     * @return InputFilterInterface
+     * @param array-key $name
      */
-    public function remove($name);
+    public function remove(int|string $name): InputFilterInterface;
 
     /**
      * Set data to use when validating and filtering
      *
-     * @param  iterable|null $data
-     * @return InputFilterInterface
+     * @param iterable|null $data
      */
-    public function setData($data);
-
+    public function setData(?iterable $data): InputFilterInterface;
 
     /**
      * Provide a list of one or more elements indicating the complete set to validate
@@ -108,10 +101,9 @@ interface InputFilterInterface extends Countable
      * Implementations should allow passing a single array value, or multiple arguments,
      * each specifying a single input.
      *
-     * @param  array-key|list<array-key> $name
-     * @return InputFilterInterface
+     * @param array-key|list<array-key> $name
      */
-    public function setValidationGroup($name);
+    public function setValidationGroup(array|int|string $name): InputFilterInterface;
 
     /**
      * Return a list of inputs that were invalid.
@@ -121,7 +113,7 @@ interface InputFilterInterface extends Countable
      *
      * @return array<array-key, InputInterface|InputFilterInterface>
      */
-    public function getInvalidInput();
+    public function getInvalidInput(): array;
 
     /**
      * Return a list of inputs that were valid.
@@ -131,15 +123,14 @@ interface InputFilterInterface extends Countable
      *
      * @return array<array-key, InputInterface|InputFilterInterface>
      */
-    public function getValidInput();
+    public function getValidInput(): array;
 
     /**
      * Retrieve a value from a named input
      *
-     * @param  array-key $name
-     * @return mixed
+     * @param array-key $name
      */
-    public function getValue($name);
+    public function getValue(int|string $name): mixed;
 
     /**
      * Return a list of filtered values
@@ -150,15 +141,14 @@ interface InputFilterInterface extends Countable
      * @return array<array-key, mixed>
      * @psalm-return TFilteredValues
      */
-    public function getValues();
+    public function getValues(): array;
 
     /**
      * Retrieve a raw (unfiltered) value from a named input
      *
-     * @param  array-key $name
-     * @return mixed
+     * @param array-key $name
      */
-    public function getRawValue($name);
+    public function getRawValue(int|string $name): mixed;
 
     /**
      * Return a list of unfiltered values
@@ -168,6 +158,5 @@ interface InputFilterInterface extends Countable
      *
      * @return array<array-key, mixed>
      */
-    public function getRawValues();
-
+    public function getRawValues(): array;
 }

--- a/src/InputFilterPluginManager.php
+++ b/src/InputFilterPluginManager.php
@@ -4,18 +4,14 @@ declare(strict_types=1);
 
 namespace Laminas\InputFilter;
 
-use Laminas\Filter\FilterPluginManager;
-use Laminas\ServiceManager\AbstractPluginManager;
-use Laminas\ServiceManager\ConfigInterface;
-use Laminas\ServiceManager\Exception\InvalidServiceException;
+use Closure;
+use Laminas\ServiceManager\AbstractSingleInstancePluginManager;
 use Laminas\ServiceManager\Factory\InvokableFactory;
 use Laminas\ServiceManager\ServiceManager;
 use Laminas\Stdlib\InitializableInterface;
-use Laminas\Validator\ValidatorPluginManager;
 use Psr\Container\ContainerInterface;
 
-use function get_debug_type;
-use function sprintf;
+use function array_replace_recursive;
 
 /**
  * Plugin manager implementation for input filters.
@@ -23,183 +19,92 @@ use function sprintf;
  * @link ServiceManager
  *
  * @psalm-import-type ServiceManagerConfiguration from ServiceManager
- * @template InstanceType of InputFilterInterface|InputInterface
- * @extends AbstractPluginManager<InstanceType>
+ * @extends AbstractSingleInstancePluginManager<InputFilterInterface>
  *
  * @final
  */
-class InputFilterPluginManager extends AbstractPluginManager
+class InputFilterPluginManager extends AbstractSingleInstancePluginManager
 {
-    /**
-     * Default alias of plugins
-     *
-     * @var string[]
-     */
-    protected $aliases = [
-        'inputfilter'         => InputFilter::class,
-        'inputFilter'         => InputFilter::class,
-        'InputFilter'         => InputFilter::class,
-        'collection'          => CollectionInputFilter::class,
-        'Collection'          => CollectionInputFilter::class,
-        'optionalinputfilter' => OptionalInputFilter::class,
-        'optionalInputFilter' => OptionalInputFilter::class,
-        'OptionalInputFilter' => OptionalInputFilter::class,
+    private const DEFAULT_CONFIGURATION = [
+        'factories' => [
+            InputFilter::class           => InvokableFactory::class,
+            CollectionInputFilter::class => InvokableFactory::class,
+            OptionalInputFilter::class   => InvokableFactory::class,
+            // v2 canonical FQCN
+            'laminasinputfilterinputfilter'           => InvokableFactory::class,
+            'laminasinputfiltercollectioninputfilter' => InvokableFactory::class,
+            'laminasinputfilteroptionalinputfilter'   => InvokableFactory::class,
+        ],
+        'aliases'   => [
+            'inputfilter'         => InputFilter::class,
+            'inputFilter'         => InputFilter::class,
+            'InputFilter'         => InputFilter::class,
+            'collection'          => CollectionInputFilter::class,
+            'Collection'          => CollectionInputFilter::class,
+            'optionalinputfilter' => OptionalInputFilter::class,
+            'optionalInputFilter' => OptionalInputFilter::class,
+            'OptionalInputFilter' => OptionalInputFilter::class,
 
-        // Legacy Zend Framework aliases
-        'Zend\InputFilter\InputFilter'           => InputFilter::class,
-        'Zend\InputFilter\CollectionInputFilter' => CollectionInputFilter::class,
-        'Zend\InputFilter\OptionalInputFilter'   => OptionalInputFilter::class,
+            // Legacy Zend Framework aliases
+            'Zend\InputFilter\InputFilter'           => InputFilter::class,
+            'Zend\InputFilter\CollectionInputFilter' => CollectionInputFilter::class,
+            'Zend\InputFilter\OptionalInputFilter'   => OptionalInputFilter::class,
 
-        // v2 normalized FQCNs
-        'zendinputfilterinputfilter'           => InputFilter::class,
-        'zendinputfiltercollectioninputfilter' => CollectionInputFilter::class,
-        'zendinputfilteroptionalinputfilter'   => OptionalInputFilter::class,
+            // v2 normalized FQCNs
+            'zendinputfilterinputfilter'           => InputFilter::class,
+            'zendinputfiltercollectioninputfilter' => CollectionInputFilter::class,
+            'zendinputfilteroptionalinputfilter'   => OptionalInputFilter::class,
+        ],
     ];
 
     /**
-     * Default set of plugins
-     *
-     * @var string[]
+     * Whether to share by default; default to false
      */
-    protected $factories = [
-        InputFilter::class           => InvokableFactory::class,
-        CollectionInputFilter::class => InvokableFactory::class,
-        OptionalInputFilter::class   => InvokableFactory::class,
-        // v2 canonical FQCN
-        'laminasinputfilterinputfilter'           => InvokableFactory::class,
-        'laminasinputfiltercollectioninputfilter' => InvokableFactory::class,
-        'laminasinputfilteroptionalinputfilter'   => InvokableFactory::class,
-    ];
+    protected bool $sharedByDefault = false;
+
+    protected string $instanceOf = InputFilterInputInterface::class;
 
     /**
-     * Whether or not to share by default (v3)
-     *
-     * @var bool
+     * @param ServiceManagerConfiguration $config
      */
-    protected $sharedByDefault = false;
-
-    /**
-     * Whether or not to share by default (v2)
-     *
-     * @deprecated Since 2.15.0 This property will be removed in version 3.0 because
-     *             it is only relevant to ServiceManager version 2.x
-     *
-     * @var bool
-     */
-    protected $shareByDefault = false;
-
-    /**
-     * @param null|ConfigInterface|ContainerInterface $configOrContainer
-     * @param ServiceManagerConfiguration $v3config
-     */
-    public function __construct($configOrContainer = null, array $v3config = [])
+    public function __construct(?ContainerInterface $creationContext = null, array $config = [])
     {
-        $this->initializers[] = $this->populateFactory(...);
-        parent::__construct($configOrContainer, $v3config);
+        /** @var ServiceManagerConfiguration $config */
+        $config = array_replace_recursive(self::DEFAULT_CONFIGURATION, $config);
+        parent::__construct($creationContext, $config);
+
+        $this->configure([
+            'initializers' => [
+                Closure::fromCallable([$this, 'injectFactory']),
+                Closure::fromCallable([$this, 'injectInitializable']),
+            ],
+        ]);
     }
 
     /**
-     * Inject this and populate the factory with filter chain and validator chain
-     *
-     * @param self|InputFilter $containerOrInputFilter
-     * @param InputFilter|null $inputFilter
-     * @return void
+     * @internal
      */
-    public function populateFactory($containerOrInputFilter, $inputFilter = null)
+    protected function injectFactory(ContainerInterface $container, object $inputFilter): void
     {
-        $inputFilter = $inputFilter ?: $containerOrInputFilter;
-
         if (! $inputFilter instanceof InputFilter) {
             return;
         }
 
-        $factory = $inputFilter->getFactory();
+        $factory = $container->get(Factory::class);
         $factory->setInputFilterManager($this);
+        $inputFilter->setFactory($factory);
     }
 
     /**
-     * Populate the filter and validator managers for the default filter/validator chains.
-     *
-     * @return void
+     * @internal
      */
-    public function populateFactoryPluginManagers(Factory $factory)
+    protected function injectInitializable(ContainerInterface $container, object $inputFilter): void
     {
-        /** @psalm-suppress DocblockTypeContradiction */
-        if (! $this->creationContext) {
+        if (! $inputFilter instanceof InitializableInterface) {
             return;
         }
 
-        $filterChain = $factory->getDefaultFilterChain();
-        if ($filterChain !== null && $this->creationContext->has(FilterPluginManager::class)) {
-            $filterChain->setPluginManager($this->creationContext->get(FilterPluginManager::class));
-        }
-
-        $validatorChain = $factory->getDefaultValidatorChain();
-        if ($validatorChain !== null && $this->creationContext->has(ValidatorPluginManager::class)) {
-            $validatorChain->setPluginManager($this->creationContext->get(ValidatorPluginManager::class));
-        }
-    }
-
-    /**
-     * @inheritDoc
-     * @psalm-assert InstanceType $instance
-     * @param mixed $instance
-     */
-    public function validate($instance)
-    {
-        if ($instance instanceof InputFilterInterface || $instance instanceof InputInterface) {
-            // Hook to perform various initialization, when the inputFilter is not created through the factory
-            if ($instance instanceof InitializableInterface) {
-                $instance->init();
-            }
-
-            // we're okay
-            return;
-        }
-
-        throw new InvalidServiceException(sprintf(
-            'Plugin of type %s is invalid; must implement %s or %s',
-            get_debug_type($instance),
-            InputFilterInterface::class,
-            InputInterface::class
-        ));
-    }
-
-    /**
-     * Validate the plugin (v2)
-     *
-     * Checks that the filter loaded is either a valid callback or an instance
-     * of FilterInterface.
-     *
-     * @deprecated Since 2.14.0. This method is only relevant to version 2 of laminas-servicemanager which is no
-     *             longer installable in this library.
-     *
-     * @see validate()
-     *
-     * @param  mixed                      $plugin
-     * @return void
-     * @throws Exception\RuntimeException If invalid.
-     */
-    public function validatePlugin($plugin)
-    {
-        try {
-            $this->validate($plugin);
-        } catch (InvalidServiceException $e) {
-            throw new Exception\RuntimeException($e->getMessage(), $e->getCode(), $e);
-        }
-    }
-
-    /**
-     * @inheritDoc
-     * phpcs:disable Generic.Files.LineLength.TooLong
-     * // Template constraint required or we get mixed added to output. Two templates because union does not work
-     * @template T1 of InputInterface
-     * @template T2 of InputFilterInterface
-     * @param class-string<T1>|class-string<T2>|string $name
-     * @return ($name is class-string<InputInterface> ? T1 : ($name is class-string<InputFilterInterface> ? T2 : InputInterface|InputFilterInterface))
-     */
-    public function get($name, ?array $options = null)
-    {
-        return parent::get($name, $options);
+        // Hook to perform various initialization, when the inputFilter is not created through the factory
+        $inputFilter->init();
     }
 }

--- a/src/InputFilterPluginManagerFactory.php
+++ b/src/InputFilterPluginManagerFactory.php
@@ -4,90 +4,27 @@ declare(strict_types=1);
 
 namespace Laminas\InputFilter;
 
-use ArrayAccess;
-use Laminas\ServiceManager\Config;
-use Laminas\ServiceManager\FactoryInterface;
-use Laminas\ServiceManager\ServiceLocatorInterface;
 use Laminas\ServiceManager\ServiceManager;
 use Psr\Container\ContainerInterface;
-use Psr\Container\ContainerInterface as PsrContainer;
 
 use function assert;
 use function is_array;
 
 /**
- * @link ServiceManager
- *
  * @psalm-import-type ServiceManagerConfiguration from ServiceManager
- *
- * @final
  */
-class InputFilterPluginManagerFactory implements FactoryInterface
+final class InputFilterPluginManagerFactory
 {
-    /**
-     * laminas-servicemanager v2 support for invocation options.
-     *
-     * @var null|ServiceManagerConfiguration
-     */
-    protected $creationOptions;
-
-    /**
-     * @param ContainerInterface|PsrContainer  $container
-     * @param string|null                      $name
-     * @param ServiceManagerConfiguration|null $options
-     * @return InputFilterPluginManager
-     * @psalm-suppress MoreSpecificImplementedParamType,MismatchingDocblockParamType
-     */
-    public function __invoke(ContainerInterface $container, $name = null, ?array $options = null)
+    public function __invoke(ContainerInterface $container): InputFilterPluginManager
     {
-        $pluginManager = new InputFilterPluginManager($container, $options ?? []);
+        $config = $container->has('config') ? $container->get('config') : [];
+        assert(is_array($config));
 
-        // If this is in a laminas-mvc application, the ServiceListener will inject
-        // merged configuration during bootstrap.
-        if ($container->has('ServiceListener')) {
-            return $pluginManager;
-        }
+        /** @psalm-var ServiceManagerConfiguration $inputFilters */
+        $inputFilters = isset($config['input_filters']) && is_array($config['input_filters'])
+            ? $config['input_filters']
+            : [];
 
-        // If we do not have a config service, nothing more to do
-        if (! $container->has('config')) {
-            return $pluginManager;
-        }
-
-        $config = $container->get('config');
-        assert(is_array($config) || $config instanceof ArrayAccess);
-
-        // If we do not have input_filters configuration, nothing more to do
-        if (! isset($config['input_filters']) || ! is_array($config['input_filters'])) {
-            return $pluginManager;
-        }
-
-        /** @psalm-var ServiceManagerConfiguration $config['input_filters'] */
-
-        // Wire service configuration for input_filters
-        (new Config($config['input_filters']))->configureServiceManager($pluginManager);
-
-        return $pluginManager;
-    }
-
-    /**
-     * @param string|null $name
-     * @param string|null $requestedName
-     * @return InputFilterPluginManager
-     * @psalm-suppress MismatchingDocblockParamType
-     */
-    public function createService(ServiceLocatorInterface $container, $name = null, $requestedName = null)
-    {
-        return $this($container, $requestedName ?? InputFilterPluginManager::class, $this->creationOptions);
-    }
-
-    /**
-     * laminas-servicemanager v2 support for invocation options.
-     *
-     * @param ServiceManagerConfiguration $options
-     * @return void
-     */
-    public function setCreationOptions(array $options)
-    {
-        $this->creationOptions = $options;
+        return new InputFilterPluginManager($container, $inputFilters);
     }
 }

--- a/src/InputFilterProviderInterface.php
+++ b/src/InputFilterProviderInterface.php
@@ -15,7 +15,6 @@ interface InputFilterProviderInterface
      * {@link Factory::createInputFilter()}.
      *
      * @psalm-return InputFilterSpecification|CollectionSpecification
-     * @return array
      */
-    public function getInputFilterSpecification();
+    public function getInputFilterSpecification(): array;
 }

--- a/src/InputInterface.php
+++ b/src/InputInterface.php
@@ -7,7 +7,7 @@ namespace Laminas\InputFilter;
 use Laminas\Filter\FilterChain;
 use Laminas\Validator\ValidatorChain;
 
-interface InputInterface
+interface InputInterface extends InputFilterInputInterface
 {
     public function setAllowEmpty(bool $allowEmpty): static;
 

--- a/src/InputInterface.php
+++ b/src/InputInterface.php
@@ -9,109 +9,37 @@ use Laminas\Validator\ValidatorChain;
 
 interface InputInterface
 {
-    /**
-     * @param bool $allowEmpty
-     * @return $this
-     */
-    public function setAllowEmpty($allowEmpty);
+    public function setAllowEmpty(bool $allowEmpty): static;
 
-    /**
-     * @param bool $breakOnFailure
-     * @return $this
-     */
-    public function setBreakOnFailure($breakOnFailure);
+    public function setBreakOnFailure(bool $breakOnFailure): static;
 
-    /**
-     * @param string|null $errorMessage
-     * @return $this
-     */
-    public function setErrorMessage($errorMessage);
+    public function setErrorMessage(?string $errorMessage): static;
 
-    /**
-     * @return $this
-     */
-    public function setFilterChain(FilterChain $filterChain);
+    public function setFilterChain(FilterChain $filterChain): static;
 
-    /**
-     * @param string $name
-     * @return $this
-     */
-    public function setName($name);
+    public function setName(string $name): static;
 
-    /**
-     * @param bool $required
-     * @return $this
-     */
-    public function setRequired($required);
+    public function setRequired(bool $required): static;
 
-    /**
-     * @return $this
-     */
-    public function setValidatorChain(ValidatorChain $validatorChain);
+    public function setValidatorChain(ValidatorChain $validatorChain): static;
 
-    /**
-     * @param mixed $value
-     * @return $this
-     */
-    public function setValue($value);
+    public function setValue(mixed $value): static;
 
-    /**
-     * @return $this
-     */
-    public function merge(InputInterface $input);
+    public function merge(InputInterface $input): InputInterface;
 
-    /**
-     * @return bool
-     */
-    public function allowEmpty();
+    public function allowEmpty(): bool;
 
-    /**
-     * @return bool
-     */
-    public function breakOnFailure();
+    public function breakOnFailure(): bool;
 
-    /**
-     * @return string|null
-     */
-    public function getErrorMessage();
+    public function getErrorMessage(): ?string;
 
-    /**
-     * @return FilterChain
-     */
-    public function getFilterChain();
+    public function getFilterChain(): ?FilterChain;
 
-    /**
-     * @return string
-     */
-    public function getName();
+    public function getName(): ?string;
 
-    /**
-     * @return mixed
-     */
-    public function getRawValue();
+    public function isRequired(): bool;
 
-    /**
-     * @return bool
-     */
-    public function isRequired();
+    public function getValidatorChain(): ?ValidatorChain;
 
-    /**
-     * @return ValidatorChain
-     */
-    public function getValidatorChain();
-
-    /**
-     * @return mixed
-     */
-    public function getValue();
-
-    /**
-     * @return bool
-     */
-    public function isValid();
-
-    /**
-     * @return array<array-key, string>
-     */
-    public function getMessages();
+    public function getValue(): mixed;
 }

--- a/src/InputProviderInterface.php
+++ b/src/InputProviderInterface.php
@@ -14,7 +14,6 @@ interface InputProviderInterface
      * {@link Factory::createInput()}.
      *
      * @psalm-return InputSpecification
-     * @return array
      */
-    public function getInputSpecification();
+    public function getInputSpecification(): array;
 }

--- a/src/Module.php
+++ b/src/Module.php
@@ -30,24 +30,4 @@ class Module
             'input_filters'   => $provider->getInputFilterConfig(),
         ];
     }
-
-    /**
-     * Register a specification for the InputFilterManager with the ServiceListener.
-     *
-     * @param ModuleManager $moduleManager
-     * @return void
-     */
-    public function init($moduleManager)
-    {
-        $event           = $moduleManager->getEvent();
-        $container       = $event->getParam('ServiceManager');
-        $serviceListener = $container->get('ServiceListener');
-
-        $serviceListener->addServiceManager(
-            'InputFilterManager',
-            'input_filters',
-            'Laminas\ModuleManager\Feature\InputFilterProviderInterface',
-            'getInputFilterConfig'
-        );
-    }
 }

--- a/src/Module.php
+++ b/src/Module.php
@@ -4,11 +4,10 @@ declare(strict_types=1);
 
 namespace Laminas\InputFilter;
 
-use Laminas\ModuleManager\ModuleManager;
-use Laminas\ServiceManager\ConfigInterface;
+use Laminas\ServiceManager\ServiceManager;
 
 /**
- * @psalm-import-type ServiceManagerConfigurationType from ConfigInterface
+ * @psalm-import-type ServiceManagerConfiguration from ServiceManager
  * @final
  */
 class Module
@@ -18,11 +17,11 @@ class Module
      *
      * @return array<string, mixed>
      * @psalm-return array{
-     *     service_manager: ServiceManagerConfigurationType,
-     *     input_filters: ServiceManagerConfigurationType,
+     *     service_manager: ServiceManagerConfiguration,
+     *     input_filters: ServiceManagerConfiguration,
      * }
      */
-    public function getConfig()
+    public function getConfig(): array
     {
         $provider = new ConfigProvider();
 

--- a/src/OptionalInputFilter.php
+++ b/src/OptionalInputFilter.php
@@ -26,7 +26,7 @@ class OptionalInputFilter extends InputFilter
      * @return $this
      * @throws Exception\InvalidArgumentException
      */
-    public function setData($data)
+    public function setData(?iterable $data): InputFilterInterface
     {
         parent::setData($this->isEmpty($data) ? [] : $data);
 
@@ -38,7 +38,7 @@ class OptionalInputFilter extends InputFilter
      *
      * {@inheritDoc}
      */
-    public function isValid($context = null)
+    public function isValid(mixed $context = null): bool
     {
         if (! $this->isEmpty($this->data)) {
             return parent::isValid($context);
@@ -53,13 +53,13 @@ class OptionalInputFilter extends InputFilter
      *     which would likely cause failures later on in your program
      * Fallbacks for the inputs are not respected by design
      *
-     * @return TFilteredValues|null
+     * @return TFilteredValues
      */
-    public function getValues()
+    public function getValues(): array
     {
         return ! $this->isEmpty($this->data)
             ? parent::getValues()
-            : null;
+            : [];
     }
 
     private function isEmpty(iterable|null $data): bool

--- a/src/ReplaceableInputInterface.php
+++ b/src/ReplaceableInputInterface.php
@@ -10,9 +10,8 @@ namespace Laminas\InputFilter;
 interface ReplaceableInputInterface
 {
     /**
-     * @param InputInterface $input
-     * @param string $name
+     * @param array-key $name
      * @return self
      */
-    public function replace($input, $name);
+    public function replace(InputFilterInputInterface $input, string|int $name): ReplaceableInputInterface;
 }

--- a/src/UnfilteredDataInterface.php
+++ b/src/UnfilteredDataInterface.php
@@ -12,11 +12,12 @@ interface UnfilteredDataInterface
     /**
      * @return array<array-key, mixed>
      */
-    public function getUnfilteredData();
+
+    public function getUnfilteredData(): array;
 
     /**
      * @param array<array-key, mixed> $data
      * @return $this
      */
-    public function setUnfilteredData($data);
+    public function setUnfilteredData(array $data): static;
 }

--- a/src/UnknownInputsCapableInterface.php
+++ b/src/UnknownInputsCapableInterface.php
@@ -14,15 +14,13 @@ interface UnknownInputsCapableInterface
      * Is the data set has unknown input ?
      *
      * @throws Exception\RuntimeException
-     * @return bool
      */
-    public function hasUnknown();
+    public function hasUnknown(): bool;
 
     /**
      * Return the unknown input
      *
      * @throws Exception\RuntimeException
-     * @return array
      */
-    public function getUnknown();
+    public function getUnknown(): array;
 }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | yes
| New Feature   | yes
| RFC           | no
| QA            | no

### Description

It's only a draft PR. For example tests are not refactored, and not tested. I did the refactor of the package to be compatible with SM4, and updated `laminas-filter` and `laminas-validator` packages.

The most of this PR is the refactored type declarations, and removing of some redundant doc block. 

The factories and plugin managers have been refactored to be compatible with SM4

The `Factory` class must be refactored because of changes in `laminas-filter` and `laminas-validator` package. It affects the input validator and filter chains, so `Factory` now coming from the Container.

This PR is only a question now, if it is a good way, and I can continue this contribution, or I should forget these big refactors :)

