### PR TITLE
Loosen coupling of `CollectionInputFilter` with `NotEmpty` validator

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -50,13 +50,6 @@
     </UnusedPsalmSuppress>
   </file>
   <file src="src/CollectionInputFilter.php">
-    <DeprecatedInterface>
-      <code><![CDATA[$notEmptyValidator->getTranslator()]]></code>
-    </DeprecatedInterface>
-    <DeprecatedMethod>
-      <code><![CDATA[getOption]]></code>
-      <code><![CDATA[getTranslatorTextDomain]]></code>
-    </DeprecatedMethod>
     <ImplementedParamTypeMismatch>
       <code><![CDATA[$name]]></code>
       <code><![CDATA[$name]]></code>
@@ -435,7 +428,6 @@
     </DeprecatedConstant>
     <DeprecatedMethod>
       <code><![CDATA[getFilters]]></code>
-      <code><![CDATA[getMessageTemplates]]></code>
       <code><![CDATA[getPluginManager]]></code>
       <code><![CDATA[getPluginManager]]></code>
       <code><![CDATA[getPluginManager]]></code>

--- a/src/CollectionInputFilter.php
+++ b/src/CollectionInputFilter.php
@@ -37,9 +37,7 @@ class CollectionInputFilter extends InputFilter
 
     /** @var BaseInputFilter|null */
     protected $inputFilter;
-
-    /** @var NotEmpty|null */
-    protected $notEmptyValidator;
+    private ?string $emptyErrorMessage = null;
 
     /**
      * Set the input filter to use when looping the data
@@ -85,13 +83,23 @@ class CollectionInputFilter extends InputFilter
 
     /**
      * Set if the collection can be empty
-     *
-     * @param bool $isRequired
-     * @return $this
      */
-    public function setIsRequired($isRequired)
+    public function setIsRequired(bool $isRequired): static
     {
         $this->isRequired = $isRequired;
+
+        return $this;
+    }
+
+    /**
+     * Set a custom error message for the collection being empty.
+     * If not called, CollectionInputFilter will default to the NotEmpty validators IS_EMPTY message
+     *
+     * @param non-empty-string $message
+     */
+    public function setIsRequiredValidationMessage(string $message): static
+    {
+        $this->emptyErrorMessage = $message;
 
         return $this;
     }
@@ -171,38 +179,6 @@ class CollectionInputFilter extends InputFilter
     }
 
     /**
-     * Retrieve the NotEmpty validator to use for failed "required" validations.
-     *
-     * This validator will be used to produce a validation failure message in
-     * cases where the collection is empty but required.
-     *
-     * @return NotEmpty
-     */
-    public function getNotEmptyValidator()
-    {
-        if ($this->notEmptyValidator === null) {
-            $this->notEmptyValidator = new NotEmpty();
-        }
-
-        return $this->notEmptyValidator;
-    }
-
-    /**
-     * Set the NotEmpty validator to use for failed "required" validations.
-     *
-     * This validator will be used to produce a validation failure message in
-     * cases where the collection is empty but required.
-     *
-     * @return $this
-     */
-    public function setNotEmptyValidator(NotEmpty $notEmptyValidator)
-    {
-        $this->notEmptyValidator = $notEmptyValidator;
-
-        return $this;
-    }
-
-    /**
      * @inheritDoc
      */
     public function isValid($context = null)
@@ -212,7 +188,7 @@ class CollectionInputFilter extends InputFilter
         $valid                    = true;
 
         if ($this->getCount() < 1 && $this->isRequired) {
-            $this->collectionMessages[] = $this->prepareRequiredValidationFailureMessage();
+            $this->collectionMessages[] = $this->getEmptyValidationErrorMessages();
             $valid                      = false;
         }
 
@@ -337,21 +313,17 @@ class CollectionInputFilter extends InputFilter
         return $unknownInputs;
     }
 
-    /**
-     * @return array<string, string>
-     */
-    protected function prepareRequiredValidationFailureMessage()
+    /** @return array<string, string> */
+    private function getEmptyValidationErrorMessages(): array
     {
-        $notEmptyValidator = $this->getNotEmptyValidator();
-        /** @var array<string, string> $templates */
-        $templates  = $notEmptyValidator->getOption('messageTemplates');
-        $message    = $templates[NotEmpty::IS_EMPTY];
-        $translator = $notEmptyValidator->getTranslator();
+        $options = $this->emptyErrorMessage === null
+            ? []
+            : ['messages' => [NotEmpty::IS_EMPTY => $this->emptyErrorMessage]];
 
-        return [
-            NotEmpty::IS_EMPTY => $translator
-                ? $translator->translate($message, $notEmptyValidator->getTranslatorTextDomain())
-                : $message,
-        ];
+        $validator = $this->factory->getValidatorPluginManager()->build(NotEmpty::class, $options);
+
+        $validator->isValid(null);
+
+        return $validator->getMessages();
     }
 }

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -37,7 +37,7 @@ final class Factory
 
     public function __construct(
         FilterPluginManager $filterPluginManager,
-        ValidatorPluginManager $validatorPluginManager,
+        private readonly ValidatorPluginManager $validatorPluginManager,
         private readonly InputFilterPluginManager $inputFilterPluginManager
     ) {
         $this->defaultFilterChain = new FilterChain();
@@ -306,7 +306,7 @@ final class Factory
                 $inputFilter->setIsRequired($inputFilterSpecification['required']);
             }
             if (isset($inputFilterSpecification['required_message'])) {
-                $inputFilter->getNotEmptyValidator()->setMessage($inputFilterSpecification['required_message']);
+                $inputFilter->setIsRequiredValidationMessage($inputFilterSpecification['required_message']);
             }
             return $inputFilter;
         }
@@ -468,5 +468,10 @@ final class Factory
                 ? $validatorChain->setPluginManager($this->defaultValidatorChain->getPluginManager())
                 : $input->setValidatorChain(clone $this->defaultValidatorChain);
         }
+    }
+
+    public function getValidatorPluginManager(): ValidatorPluginManager
+    {
+        return $this->validatorPluginManager;
     }
 }

--- a/src/Input.php
+++ b/src/Input.php
@@ -463,8 +463,9 @@ class Input implements
         }
 
         /** @psalm-var array<string, string> $templates */
-        $templates  = $notEmpty->getOption('messageTemplates');
-        $message    = $templates[NotEmpty::IS_EMPTY];
+        $templates = $notEmpty->getOption('messageTemplates');
+        $message   = $templates[NotEmpty::IS_EMPTY];
+        /** @psalm-suppress DeprecatedInterface */
         $translator = $notEmpty->getTranslator();
 
         if ($translator instanceof TranslatorInterface) {

--- a/test/CollectionInputFilterTest.php
+++ b/test/CollectionInputFilterTest.php
@@ -186,19 +186,33 @@ final class CollectionInputFilterTest extends TestCase
             new InputFilterInterfaceStub(TestHelper::createInputFilterFactory(), null, $dataRaw, $dataFiltered);
         $isRequired = true;
 
-        // @phpcs:disable Generic.Files.LineLength.TooLong,WebimpressCodingStandard.Arrays.Format.SingleLineSpaceBefore,WebimpressCodingStandard.WhiteSpace.CommaSpacing.SpaceBeforeComma
         return [
-            // Description => [$required, $count, $data, $inputFilter, $expectedRaw, $expectedValues, $expectedValid, $expectedMessages]
-            'Required: T, Count: N, Valid: T'  => [  $isRequired, null, $colRaw, $validIf()  , $colRaw, $colFiltered, true , []],
-            'Required: T, Count: N, Valid: F'  => [  $isRequired, null, $colRaw, $invalidIf(), $colRaw, $colFiltered, false, $colMessages],
-            'Required: T, Count: +1, Valid: F' => [  $isRequired,    2, $colRaw, $invalidIf(), $colRaw, $colFiltered, false, $colMessages],
-            'Required: F, Count: N, Valid: T'  => [! $isRequired, null, $colRaw, $validIf()  , $colRaw, $colFiltered, true , []],
-            'Required: F, Count: N, Valid: F'  => [! $isRequired, null, $colRaw, $invalidIf(), $colRaw, $colFiltered, false, $colMessages],
-            'Required: F, Count: +1, Valid: F' => [! $isRequired,    2, $colRaw, $invalidIf(), $colRaw, $colFiltered, false, $colMessages],
-            'Required: T, Data: [], Valid: X'  => [  $isRequired, null, []     , $noValidIf(), []     , []          , false, [['isEmpty' => 'Value is required and can\'t be empty']]],
-            'Required: F, Data: [], Valid: X'  => [! $isRequired, null, []     , $noValidIf(), []     , []          , true , []],
+            'Required: T, Count: N, Valid: T'
+                => [$isRequired, null, $colRaw, $validIf(), $colRaw, $colFiltered, true, []],
+            'Required: T, Count: N, Valid: F'
+                => [$isRequired, null, $colRaw, $invalidIf(), $colRaw, $colFiltered, false, $colMessages],
+            'Required: T, Count: +1, Valid: F'
+                => [$isRequired,    2, $colRaw, $invalidIf(), $colRaw, $colFiltered, false, $colMessages],
+            'Required: F, Count: N, Valid: T'
+                => [! $isRequired, null, $colRaw, $validIf(), $colRaw, $colFiltered, true, []],
+            'Required: F, Count: N, Valid: F'
+                => [! $isRequired, null, $colRaw, $invalidIf(), $colRaw, $colFiltered, false, $colMessages],
+            'Required: F, Count: +1, Valid: F'
+                => [! $isRequired,    2, $colRaw, $invalidIf(), $colRaw, $colFiltered, false, $colMessages],
+            'Required: T, Data: [], Valid: X'
+                => [
+                    $isRequired,
+                    null,
+                    [],
+                    $noValidIf(),
+                    [],
+                    [],
+                    false,
+                    [['isEmpty' => 'Value is required and can\'t be empty']],
+                ],
+            'Required: F, Data: [], Valid: X'
+                => [! $isRequired, null, [], $noValidIf(), [], [], true, []],
         ];
-        // @phpcs:enable Generic.Files.LineLength.TooLong,WebimpressCodingStandard.Arrays.Format.SingleLineSpaceBefore,WebimpressCodingStandard.WhiteSpace.CommaSpacing.SpaceBeforeComma
     }
 
     public function testSetValidationGroupUsingFormStyle(): void
@@ -751,36 +765,6 @@ final class CollectionInputFilterTest extends TestCase
         ], $inputFilter->getMessages());
     }
 
-    public function testLazyLoadsANotEmptyValidatorWhenNoneProvided(): void
-    {
-        self::assertInstanceOf(NotEmpty::class, $this->inputFilter->getNotEmptyValidator());
-    }
-
-    public function testAllowsComposingANotEmptyValidator(): void
-    {
-        $notEmptyValidator = new NotEmpty();
-        $this->inputFilter->setNotEmptyValidator($notEmptyValidator);
-        self::assertSame($notEmptyValidator, $this->inputFilter->getNotEmptyValidator());
-    }
-
-    public function testUsesMessageFromComposedNotEmptyValidatorWhenRequiredButCollectionIsEmpty(): void
-    {
-        $message           = 'this is the validation message';
-        $notEmptyValidator = new NotEmpty();
-        $notEmptyValidator->setMessage($message);
-
-        $this->inputFilter->setIsRequired(true);
-        $this->inputFilter->setNotEmptyValidator($notEmptyValidator);
-
-        $this->inputFilter->setData([]);
-
-        self::assertFalse($this->inputFilter->isValid());
-
-        self::assertEquals([
-            [NotEmpty::IS_EMPTY => $message],
-        ], $this->inputFilter->getMessages());
-    }
-
     public function testNotEmptyMessageIsTranslated(): void
     {
         /** @psalm-suppress DeprecatedInterface */
@@ -796,8 +780,6 @@ final class CollectionInputFilterTest extends TestCase
             ->willReturn($translatedMessage);
 
         $this->inputFilter->setIsRequired(true);
-        $this->inputFilter->setNotEmptyValidator($notEmpty);
-
         $this->inputFilter->setData([]);
 
         self::assertFalse($this->inputFilter->isValid());
@@ -872,5 +854,53 @@ final class CollectionInputFilterTest extends TestCase
                 JSON_THROW_ON_ERROR
             )
         );
+    }
+
+    public function testDefaultValidationMessageViaFactory(): void
+    {
+        $factory = TestHelper::createInputFilterFactory();
+
+        $inputFilter = $factory->createInputFilter(
+            [
+                'type'     => CollectionInputFilter::class,
+                'required' => true,
+            ]
+        );
+
+        $inputFilter->setData([]);
+
+        self::assertFalse($inputFilter->isValid());
+        self::assertEquals([['isEmpty' => 'Value is required and can\'t be empty']], $inputFilter->getMessages());
+    }
+
+    public function testSettingCustomValidationMessageViaFactory(): void
+    {
+        $customMessage = 'Custom required message';
+
+        $factory = TestHelper::createInputFilterFactory();
+
+        $inputFilter = $factory->createInputFilter(
+            [
+                'type'             => CollectionInputFilter::class,
+                'required'         => true,
+                'required_message' => $customMessage,
+            ]
+        );
+
+        $inputFilter->setData([]);
+
+        self::assertFalse($inputFilter->isValid());
+        self::assertEquals([['isEmpty' => $customMessage]], $inputFilter->getMessages());
+    }
+
+    public function testSetIsRequiredValidationMessage(): void
+    {
+        $customMessage = 'Custom required message';
+        $this->inputFilter->setIsRequired(true);
+        $this->inputFilter->setIsRequiredValidationMessage($customMessage);
+        $this->inputFilter->setData([]);
+
+        self::assertFalse($this->inputFilter->isValid());
+        self::assertEquals([['isEmpty' => $customMessage]], $this->inputFilter->getMessages());
     }
 }

--- a/test/FactoryTest.php
+++ b/test/FactoryTest.php
@@ -19,6 +19,7 @@ use Laminas\InputFilter\InputInterface;
 use Laminas\InputFilter\InputProviderInterface;
 use Laminas\ServiceManager;
 use Laminas\Validator;
+use Laminas\Validator\NotEmpty;
 use Laminas\Validator\ValidatorPluginManager;
 use LaminasTest\InputFilter\TestAsset\CustomInput;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -1074,16 +1075,17 @@ final class FactoryTest extends TestCase
             'type'             => CollectionInputFilter::class,
             'required'         => true,
             'required_message' => $message,
-            'inputfilter'      => new InputFilter($factory),
-            'count'            => 3,
+            'count'            => 0,
         ]);
 
         self::assertInstanceOf(CollectionInputFilter::class, $inputFilter);
 
-        $notEmptyValidator = $inputFilter->getNotEmptyValidator();
-        $messageTemplates  = $notEmptyValidator->getMessageTemplates();
-        self::assertArrayHasKey(Validator\NotEmpty::IS_EMPTY, $messageTemplates);
-        self::assertSame($message, $messageTemplates[Validator\NotEmpty::IS_EMPTY]);
+        self::assertFalse($inputFilter->isValid());
+        self::assertSame([[NotEmpty::IS_EMPTY => $message]], $inputFilter->getMessages());
+
+        $inputFilter->setIsRequired(false);
+        self::assertTrue($inputFilter->isValid());
+        self::assertSame([], $inputFilter->getMessages());
     }
 
     protected function createDefaultFactory(?InputFilterPluginManager $inputFilterPluginManager = null): Factory


### PR DESCRIPTION
- Make getNotEmptyValidator private and add public setIsRequiredValidationMessage method
- Remove deprecated getOption method call in prepareRequiredValidationFailureMessage

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | yes
| New Feature   | no
| RFC           | yes
| QA            | yes

### Description

The call to `$notEmptyValidator->getOption('messageTemplates')` in CollectionInputFilter will need replacing to enable moving to ServiceManager v4. We could replace this with a call to `getMessageTemplates` but this is also deprecated. A direct call to the validator with an invalid value should achive the same results without CollectionInputFilter needing to understand the internals of the NotEmpty validator.