### PR TITLE
Replace mocked ValidatorChain with instance in unit tests

### DIFF
--- a/test/ArrayInputTest.php
+++ b/test/ArrayInputTest.php
@@ -239,47 +239,9 @@ final class ArrayInputTest extends TestCase
         return $filterChain;
     }
 
-    /**
-     * @param list<list<mixed>> $valueMap
-     * @param string[] $messages
-     * @return ValidatorChain&MockObject
-     */
-    protected function createValidatorChainMock(array $valueMap = [], array $messages = [])
+    protected function createValidatorChain(mixed $value, bool $isValid): ValidatorChain
     {
-        // ArrayInput validates per each array value
-        $valueMap = array_map(
-            static function ($values) {
-                if (is_array($values[0])) {
-                    /** @psalm-suppress MixedAssignment */
-                    $values[0] = current($values[0]);
-                }
-                return $values;
-            },
-            $valueMap,
-        );
-
-        /** @var ValidatorChain&MockObject $validatorChain */
-        $validatorChain = $this->createMock(ValidatorChain::class);
-
-        if (empty($valueMap)) {
-            $validatorChain->expects(self::never())
-                ->method('isValid');
-        } else {
-            $validatorChain->expects(self::atLeastOnce())
-                ->method('isValid')
-                ->willReturnMap($valueMap);
-        }
-
-        $validatorChain->method('getMessages')
-            ->willReturn($messages);
-
-        return $validatorChain;
-    }
-
-    /** @return string[] */
-    protected function getDummyValue(bool $raw = true)
-    {
-        return $raw ? ['foo'] : ['filtered'];
+        return (new ValidatorChain())->attach(self::createValidatorMock($isValid, $value));
     }
 
     public function testAnArrayInputViaInputFilterIsAcceptable(): void
@@ -398,7 +360,7 @@ final class ArrayInputTest extends TestCase
 
     public function testCanInjectValidatorChain(): void
     {
-        $validatorChain = $this->createMock(ValidatorChain::class);
+        $validatorChain = new ValidatorChain();
 
         $this->input->setValidatorChain($validatorChain);
         self::assertSame($validatorChain, $this->input->getValidatorChain());
@@ -478,7 +440,7 @@ final class ArrayInputTest extends TestCase
         $input->setContinueIfEmpty(true);
 
         $input->setRequired($required);
-        $input->setValidatorChain($this->createValidatorChainMock([[$originalValue, null, $isValid]]));
+        $input->setValidatorChain($this->createValidatorChain($originalValue[0], $isValid));
         $input->setFallbackValue($fallbackValue);
         $input->setValue($originalValue);
 
@@ -504,7 +466,7 @@ final class ArrayInputTest extends TestCase
         $input->setContinueIfEmpty(true);
 
         $input->setRequired($required);
-        $input->setValidatorChain($this->createValidatorChainMock());
+        $input->setValidatorChain(new ValidatorChain());
         $input->setFallbackValue($fallbackValue);
 
         self::assertTrue(
@@ -627,7 +589,7 @@ final class ArrayInputTest extends TestCase
 
     public function testValueMayBeInjected(): void
     {
-        $valueRaw = $this->getDummyValue();
+        $valueRaw = 'foo';
 
         $this->input->setValue($valueRaw);
         self::assertEquals($valueRaw, $this->input->getValue());
@@ -635,8 +597,8 @@ final class ArrayInputTest extends TestCase
 
     public function testRetrievingValueFiltersTheValue(): void
     {
-        $valueRaw      = $this->getDummyValue();
-        $valueFiltered = $this->getDummyValue(false);
+        $valueRaw      = ['foo'];
+        $valueFiltered = ['filtered'];
 
         $filterChain = $this->createFilterChainMock([[$valueRaw, $valueFiltered]]);
 
@@ -648,7 +610,7 @@ final class ArrayInputTest extends TestCase
 
     public function testCanRetrieveRawValue(): void
     {
-        $valueRaw = $this->getDummyValue();
+        $valueRaw = 'foo';
 
         $filterChain = $this->createMock(FilterChain::class);
 
@@ -660,16 +622,14 @@ final class ArrayInputTest extends TestCase
 
     public function testValidationOperatesOnFilteredValue(): void
     {
-        $valueRaw      = $this->getDummyValue();
-        $valueFiltered = $this->getDummyValue(false);
+        $valueRaw      = ['foo'];
+        $valueFiltered = ['filtered'];
 
         $filterChain = $this->createFilterChainMock([[$valueRaw, $valueFiltered]]);
 
-        $validatorChain = $this->createValidatorChainMock([[$valueFiltered, null, true]]);
-
         $this->input->setAllowEmpty(true);
         $this->input->setFilterChain($filterChain);
-        $this->input->setValidatorChain($validatorChain);
+        $this->input->setValidatorChain($this->createValidatorChain($valueFiltered[0], true));
         $this->input->setValue($valueRaw);
 
         self::assertTrue(
@@ -949,26 +909,19 @@ final class ArrayInputTest extends TestCase
 
     public function testMerge(): void
     {
-        $sourceRawValue = $this->getDummyValue();
-
         $source = $this->createMock(InputInterface::class);
         $source->method('getName')->willReturn('bazInput');
         $source->method('getErrorMessage')->willReturn('bazErrorMessage');
         $source->method('breakOnFailure')->willReturn(true);
         $source->method('isRequired')->willReturn(true);
-        $source->method('getRawValue')->willReturn($sourceRawValue);
+        $source->method('getRawValue')->willReturn('foo');
         $source->method('getFilterChain')->willReturn($this->createMock(FilterChain::class));
-        $source->method('getValidatorChain')->willReturn($this->createMock(ValidatorChain::class));
+        $source->method('getValidatorChain')->willReturn(new ValidatorChain());
 
         $targetFilterChain = $this->createMock(FilterChain::class);
         $targetFilterChain->expects(TestCase::once())
             ->method('merge')
             ->with($source->getFilterChain());
-
-        $targetValidatorChain = $this->createMock(ValidatorChain::class);
-        $targetValidatorChain->expects(TestCase::once())
-            ->method('merge')
-            ->with($source->getValidatorChain());
 
         $target = $this->input;
         $target->setName('fooInput');
@@ -976,7 +929,7 @@ final class ArrayInputTest extends TestCase
         $target->setBreakOnFailure(false);
         $target->setRequired(false);
         $target->setFilterChain($targetFilterChain);
-        $target->setValidatorChain($targetValidatorChain);
+        $target->setValidatorChain(new ValidatorChain());
 
         $return = $target->merge($source);
         self::assertSame($target, $return, 'merge() must return it self');
@@ -985,7 +938,7 @@ final class ArrayInputTest extends TestCase
         self::assertEquals('bazErrorMessage', $target->getErrorMessage(), 'getErrorMessage() value not match');
         self::assertTrue($target->breakOnFailure(), 'breakOnFailure() value not match');
         self::assertTrue($target->isRequired(), 'isRequired() value not match');
-        self::assertEquals($sourceRawValue, $target->getRawValue(), 'getRawValue() value not match');
+        self::assertEquals('foo', $target->getRawValue(), 'getRawValue() value not match');
         self::assertTrue($target->hasValue(), 'hasValue() value not match');
     }
 

--- a/test/ArrayInputTest.php
+++ b/test/ArrayInputTest.php
@@ -18,7 +18,6 @@ use Laminas\Validator\NumberComparison;
 use Laminas\Validator\Translator\TranslatorInterface;
 use Laminas\Validator\ValidatorChain;
 use Laminas\Validator\ValidatorInterface;
-use LaminasTest\InputFilter\TestAsset\ValidatorStub;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
@@ -239,14 +238,9 @@ final class ArrayInputTest extends TestCase
         return $filterChain;
     }
 
-    protected function createValidatorChain(mixed $value, bool $isValid): ValidatorChain
-    {
-        return (new ValidatorChain())->attach(self::createValidatorMock($isValid, $value));
-    }
-
     public function testAnArrayInputViaInputFilterIsAcceptable(): void
     {
-        $factory = FactoryTestHelper::createInputFilterFactory();
+        $factory = TestHelper::createInputFilterFactory();
 
         $inputFilter = new InputFilter($factory);
         $inputFilter->add([
@@ -284,7 +278,7 @@ final class ArrayInputTest extends TestCase
     #[DataProvider('nonArrayInput')]
     public function testNonArrayInputViaInputFilterIsUnacceptable(mixed $value): void
     {
-        $factory = FactoryTestHelper::createInputFilterFactory();
+        $factory = TestHelper::createInputFilterFactory();
 
         $inputFilter = new InputFilter($factory);
         $inputFilter->add([
@@ -440,7 +434,7 @@ final class ArrayInputTest extends TestCase
         $input->setContinueIfEmpty(true);
 
         $input->setRequired($required);
-        $input->setValidatorChain($this->createValidatorChain($originalValue[0], $isValid));
+        $input->setValidatorChain(TestHelper::createValidatorChain($originalValue[0], $isValid));
         $input->setFallbackValue($fallbackValue);
         $input->setValue($originalValue);
 
@@ -566,7 +560,7 @@ final class ArrayInputTest extends TestCase
 
         // Validator should not to be called
         $input->getValidatorChain()
-            ->attach(self::createValidatorMock(null, null));
+            ->attach(TestHelper::createValidatorMock(null, null));
         self::assertTrue(
             $input->isValid(),
             'isValid() should be return always true when is not required, and no data is set. Detail: '
@@ -629,7 +623,7 @@ final class ArrayInputTest extends TestCase
 
         $this->input->setAllowEmpty(true);
         $this->input->setFilterChain($filterChain);
-        $this->input->setValidatorChain($this->createValidatorChain($valueFiltered[0], true));
+        $this->input->setValidatorChain(TestHelper::createValidatorChain($valueFiltered[0], true));
         $this->input->setValue($valueRaw);
 
         self::assertTrue(
@@ -711,7 +705,7 @@ final class ArrayInputTest extends TestCase
 
         $notEmptyMock->method('getMessages')->willReturn([]);
 
-        $validatorChain->attach(self::createValidatorMock(true));
+        $validatorChain->attach(TestHelper::createValidatorMock(true));
         $validatorChain->attach($notEmptyMock);
 
         self::assertFalse($this->input->isValid());
@@ -1059,11 +1053,11 @@ final class ArrayInputTest extends TestCase
         $notEmptyMsg  = ['isEmpty' => "Value is required and can't be empty"];
 
         $validatorNotCall = fn(mixed $value, array|null $context = null): ValidatorInterface =>
-        self::createValidatorMock(null, $value, $context);
+        TestHelper::createValidatorMock(null, $value, $context);
         $validatorInvalid = fn(mixed $value, array|null $context = null): ValidatorInterface =>
-        self::createValidatorMock(false, $value, $context, $validatorMsg);
+        TestHelper::createValidatorMock(false, $value, $context, $validatorMsg);
         $validatorValid   = fn(mixed $value, array|null $context = null): ValidatorInterface =>
-        self::createValidatorMock(true, $value, $context);
+        TestHelper::createValidatorMock(true, $value, $context);
 
         $dataTemplates = [
             'Required: T; AEmpty: T; CIEmpty: T; Validator: T'
@@ -1122,15 +1116,5 @@ final class ArrayInputTest extends TestCase
         }
 
         return $dataSets;
-    }
-
-    /** @param array<string, string> $messages */
-    protected static function createValidatorMock(
-        bool|null $isValid,
-        mixed $value = 'not-set',
-        array|null $context = null,
-        array $messages = []
-    ): ValidatorInterface {
-        return new ValidatorStub($isValid, $value, $context, $messages);
     }
 }

--- a/test/BaseInputFilterTest.php
+++ b/test/BaseInputFilterTest.php
@@ -45,7 +45,7 @@ class BaseInputFilterTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->factory = FactoryTestHelper::createInputFilterFactory();
+        $this->factory = TestHelper::createInputFilterFactory();
 
         $this->inputFilter = new BaseInputFilter($this->factory);
     }
@@ -955,7 +955,7 @@ class BaseInputFilterTest extends TestCase
         array $getMessages = []
     ): InputFilterInterfaceStub {
         return new InputFilterInterfaceStub(
-            FactoryTestHelper::createInputFilterFactory(),
+            TestHelper::createInputFilterFactory(),
             $isValid,
             $getRawValues,
             $getValues,

--- a/test/CollectionInputFilterTest.php
+++ b/test/CollectionInputFilterTest.php
@@ -39,7 +39,7 @@ final class CollectionInputFilterTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->factory = FactoryTestHelper::createInputFilterFactory();
+        $this->factory = TestHelper::createInputFilterFactory();
 
         $this->inputFilter = new CollectionInputFilter($this->factory);
     }
@@ -167,16 +167,16 @@ final class CollectionInputFilterTest extends TestCase
 
         $invalidIF  = fn(): BaseInputFilter =>
             new InputFilterInterfaceStub(
-                FactoryTestHelper::createInputFilterFactory(),
+                TestHelper::createInputFilterFactory(),
                 false,
                 $dataRaw,
                 $dataFiltered,
                 $errorMessage
             );
         $validIF    = fn(): BaseInputFilter =>
-            new InputFilterInterfaceStub(FactoryTestHelper::createInputFilterFactory(), true, $dataRaw, $dataFiltered);
+            new InputFilterInterfaceStub(TestHelper::createInputFilterFactory(), true, $dataRaw, $dataFiltered);
         $noValidIF  = fn(): BaseInputFilter =>
-            new InputFilterInterfaceStub(FactoryTestHelper::createInputFilterFactory(), null, $dataRaw, $dataFiltered);
+            new InputFilterInterfaceStub(TestHelper::createInputFilterFactory(), null, $dataRaw, $dataFiltered);
         $isRequired = true;
 
         // @phpcs:disable Generic.Files.LineLength.TooLong,WebimpressCodingStandard.Arrays.Format.SingleLineSpaceBefore,WebimpressCodingStandard.WhiteSpace.CommaSpacing.SpaceBeforeComma
@@ -257,7 +257,7 @@ final class CollectionInputFilterTest extends TestCase
     #[DataProvider('dataNestingCollection')]
     public function testNestingCollectionCountCached(?int $count, bool $isValid): void
     {
-        $factory = FactoryTestHelper::createInputFilterFactory();
+        $factory = TestHelper::createInputFilterFactory();
 
         $firstInputFilter = new InputFilter($factory);
 
@@ -313,7 +313,7 @@ final class CollectionInputFilterTest extends TestCase
      */
     public static function inputFilterProvider(): array
     {
-        $factory = FactoryTestHelper::createInputFilterFactory();
+        $factory = TestHelper::createInputFilterFactory();
 
         $baseInputFilter = new BaseInputFilter($factory);
 
@@ -410,7 +410,7 @@ final class CollectionInputFilterTest extends TestCase
 
     public function testGetUnknownWhenAllFieldsAreKnownReturnsAnEmptyArray(): void
     {
-        $factory = FactoryTestHelper::createInputFilterFactory();
+        $factory = TestHelper::createInputFilterFactory();
 
         $inputFilter = new InputFilter($factory);
         $inputFilter->add([
@@ -617,7 +617,7 @@ final class CollectionInputFilterTest extends TestCase
 
     public function testDuplicatedErrorMessages(): void
     {
-        $factory = FactoryTestHelper::createInputFilterFactory();
+        $factory = TestHelper::createInputFilterFactory();
 
         $inputFilter = $factory->createInputFilter(
             [
@@ -792,7 +792,7 @@ final class CollectionInputFilterTest extends TestCase
             ],
         ];
 
-        $factory = FactoryTestHelper::createInputFilterFactory();
+        $factory = TestHelper::createInputFilterFactory();
 
         $baseInputFilter = (new BaseInputFilter($factory))
             ->add(new Input(), 'bar');

--- a/test/FileInput/HttpServerFileInputDecoratorTest.php
+++ b/test/FileInput/HttpServerFileInputDecoratorTest.php
@@ -18,7 +18,7 @@ use Laminas\Validator\NumberComparison;
 use Laminas\Validator\Translator\TranslatorInterface;
 use Laminas\Validator\ValidatorChain;
 use Laminas\Validator\ValidatorInterface;
-use LaminasTest\InputFilter\TestAsset\ValidatorStub;
+use LaminasTest\InputFilter\TestHelper;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
@@ -125,7 +125,7 @@ final class HttpServerFileInputDecoratorTest extends TestCase
 
         $filteredValue = ['tmp_name' => 'new'];
         $this->input->setFilterChain($this->createFilterChainMock([[$badValue, $filteredValue]]));
-        $this->input->setValidatorChain($this->createValidatorChain($badValue, false));
+        $this->input->setValidatorChain(TestHelper::createValidatorChain($badValue, false));
 
         self::assertFalse($this->input->isValid());
         self::assertEquals($badValue, $this->input->getValue());
@@ -210,7 +210,7 @@ final class HttpServerFileInputDecoratorTest extends TestCase
             'type'     => '',
             'error'    => UPLOAD_ERR_NO_FILE,
         ];
-        $this->input->setValidatorChain($this->createValidatorChain($expectedNormalizedValue, false));
+        $this->input->setValidatorChain(TestHelper::createValidatorChain($expectedNormalizedValue, false));
         self::assertFalse($this->input->isValid());
     }
 
@@ -227,7 +227,7 @@ final class HttpServerFileInputDecoratorTest extends TestCase
             'type'     => '',
             'error'    => UPLOAD_ERR_NO_FILE,
         ];
-        $this->input->setValidatorChain($this->createValidatorChain($expectedNormalizedValue, false));
+        $this->input->setValidatorChain(TestHelper::createValidatorChain($expectedNormalizedValue, false));
         self::assertFalse($this->input->isValid());
     }
 
@@ -334,11 +334,11 @@ final class HttpServerFileInputDecoratorTest extends TestCase
 
         // phpcs:disable Generic.Formatting.MultipleStatementAlignment.NotSame
         $validatorNotCall = fn(mixed $value, array|null $context = null): ValidatorInterface =>
-        self::createValidatorMock(null, $value, $context);
+        TestHelper::createValidatorMock(null, $value, $context);
         $validatorInvalid = fn(mixed $value, array|null $context = null): ValidatorInterface =>
-        self::createValidatorMock(false, $value, $context, $validatorMsg);
+        TestHelper::createValidatorMock(false, $value, $context, $validatorMsg);
         $validatorValid = fn(mixed $value, array|null $context = null): ValidatorInterface =>
-        self::createValidatorMock(true, $value, $context);
+        TestHelper::createValidatorMock(true, $value, $context);
 
         $dataTemplates = [
             'Required: T; AEmpty: T; CIEmpty: T; Validator: T'
@@ -641,7 +641,7 @@ final class HttpServerFileInputDecoratorTest extends TestCase
 
         // Validator should not to be called
         $input->getValidatorChain()
-            ->attach(self::createValidatorMock(null, null));
+            ->attach(TestHelper::createValidatorMock(null, null));
         self::assertTrue(
             $input->isValid(),
             'isValid() should be return always true when is not required, and no data is set. Detail: '
@@ -704,7 +704,7 @@ final class HttpServerFileInputDecoratorTest extends TestCase
 
         $notEmptyMock->method('getMessages')->willReturn([]);
 
-        $validatorChain->attach(self::createValidatorMock(true));
+        $validatorChain->attach(TestHelper::createValidatorMock(true));
         $validatorChain->attach($notEmptyMock);
 
         self::assertFalse($this->input->isValid());
@@ -1064,20 +1064,5 @@ final class HttpServerFileInputDecoratorTest extends TestCase
             ->willReturnMap($valueMap);
 
         return $filterChain;
-    }
-
-    protected function createValidatorChain(mixed $value, bool $isValid): ValidatorChain
-    {
-        return (new ValidatorChain())->attach(self::createValidatorMock($isValid, $value));
-    }
-
-    /** @param array<string, string> $messages */
-    protected static function createValidatorMock(
-        bool|null $isValid,
-        mixed $value = 'not-set',
-        array|null $context = null,
-        array $messages = []
-    ): ValidatorInterface {
-        return new ValidatorStub($isValid, $value, $context, $messages);
     }
 }

--- a/test/FileInput/HttpServerFileInputDecoratorTest.php
+++ b/test/FileInput/HttpServerFileInputDecoratorTest.php
@@ -125,7 +125,7 @@ final class HttpServerFileInputDecoratorTest extends TestCase
 
         $filteredValue = ['tmp_name' => 'new'];
         $this->input->setFilterChain($this->createFilterChainMock([[$badValue, $filteredValue]]));
-        $this->input->setValidatorChain($this->createValidatorChainMock([[$badValue, null, false]]));
+        $this->input->setValidatorChain($this->createValidatorChain($badValue, false));
 
         self::assertFalse($this->input->isValid());
         self::assertEquals($badValue, $this->input->getValue());
@@ -210,7 +210,7 @@ final class HttpServerFileInputDecoratorTest extends TestCase
             'type'     => '',
             'error'    => UPLOAD_ERR_NO_FILE,
         ];
-        $this->input->setValidatorChain($this->createValidatorChainMock([[$expectedNormalizedValue, null, false]]));
+        $this->input->setValidatorChain($this->createValidatorChain($expectedNormalizedValue, false));
         self::assertFalse($this->input->isValid());
     }
 
@@ -227,7 +227,7 @@ final class HttpServerFileInputDecoratorTest extends TestCase
             'type'     => '',
             'error'    => UPLOAD_ERR_NO_FILE,
         ];
-        $this->input->setValidatorChain($this->createValidatorChainMock([[$expectedNormalizedValue, null, false]]));
+        $this->input->setValidatorChain($this->createValidatorChain($expectedNormalizedValue, false));
         self::assertFalse($this->input->isValid());
     }
 
@@ -492,7 +492,7 @@ final class HttpServerFileInputDecoratorTest extends TestCase
 
     public function testCanInjectValidatorChain(): void
     {
-        $chain = $this->createValidatorChainMock();
+        $chain = new ValidatorChain();
         $this->input->setValidatorChain($chain);
         self::assertSame($chain, $this->input->getValidatorChain());
     }
@@ -911,17 +911,12 @@ final class HttpServerFileInputDecoratorTest extends TestCase
         $source->method('isRequired')->willReturn(true);
         $source->method('getRawValue')->willReturn($sourceRawValue);
         $source->method('getFilterChain')->willReturn($this->createFilterChainMock());
-        $source->method('getValidatorChain')->willReturn($this->createValidatorChainMock());
+        $source->method('getValidatorChain')->willReturn(new ValidatorChain());
 
         $targetFilterChain = $this->createFilterChainMock();
         $targetFilterChain->expects(TestCase::once())
             ->method('merge')
             ->with($source->getFilterChain());
-
-        $targetValidatorChain = $this->createValidatorChainMock();
-        $targetValidatorChain->expects(TestCase::once())
-            ->method('merge')
-            ->with($source->getValidatorChain());
 
         $target = $this->input;
         $target->setName('fooInput');
@@ -929,7 +924,7 @@ final class HttpServerFileInputDecoratorTest extends TestCase
         $target->setBreakOnFailure(false);
         $target->setRequired(false);
         $target->setFilterChain($targetFilterChain);
-        $target->setValidatorChain($targetValidatorChain);
+        $target->setValidatorChain(new ValidatorChain());
 
         $return = $target->merge($source);
         self::assertSame($target, $return, 'merge() must return it self');
@@ -1071,28 +1066,9 @@ final class HttpServerFileInputDecoratorTest extends TestCase
         return $filterChain;
     }
 
-    /**
-     * @param list<list<mixed>> $valueMap
-     * @param string[] $messages
-     */
-    protected function createValidatorChainMock(array $valueMap = [], $messages = []): ValidatorChain&MockObject
+    protected function createValidatorChain(mixed $value, bool $isValid): ValidatorChain
     {
-        /** @var ValidatorChain&MockObject $validatorChain */
-        $validatorChain = $this->createMock(ValidatorChain::class);
-
-        if (empty($valueMap)) {
-            $validatorChain->expects(self::never())
-                ->method('isValid');
-        } else {
-            $validatorChain->expects(self::atLeastOnce())
-                ->method('isValid')
-                ->willReturnMap($valueMap);
-        }
-
-        $validatorChain->method('getMessages')
-            ->willReturn($messages);
-
-        return $validatorChain;
+        return (new ValidatorChain())->attach(self::createValidatorMock($isValid, $value));
     }
 
     /** @param array<string, string> $messages */

--- a/test/FileInput/PsrFileInputDecoratorTest.php
+++ b/test/FileInput/PsrFileInputDecoratorTest.php
@@ -19,7 +19,7 @@ use Laminas\Validator\Translator\TranslatorInterface;
 use Laminas\Validator\ValidatorChain;
 use Laminas\Validator\ValidatorInterface;
 use LaminasTest\InputFilter\TestAsset\UploadedFileInterfaceStub;
-use LaminasTest\InputFilter\TestAsset\ValidatorStub;
+use LaminasTest\InputFilter\TestHelper;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
@@ -144,7 +144,7 @@ final class PsrFileInputDecoratorTest extends TestCase
         $this->input->setValue($badValue);
 
         $this->input->setFilterChain($this->createFilterChainMock([[$badValue, $filteredValue]]));
-        $this->input->setValidatorChain($this->createValidatorChain($badValue, false));
+        $this->input->setValidatorChain(TestHelper::createValidatorChain($badValue, false));
 
         self::assertFalse($this->input->isValid());
         self::assertEquals($badValue, $this->input->getValue());
@@ -315,11 +315,11 @@ final class PsrFileInputDecoratorTest extends TestCase
         $validatorMsg = ['FooValidator' => 'Invalid Value'];
 
         $validatorNotCall = fn(mixed $value, array|null $context = null): ValidatorInterface =>
-        self::createValidatorMock(null, $value, $context);
+        TestHelper::createValidatorMock(null, $value, $context);
         $validatorInvalid = fn(mixed $value, array|null $context = null): ValidatorInterface =>
-        self::createValidatorMock(false, $value, $context, $validatorMsg);
+        TestHelper::createValidatorMock(false, $value, $context, $validatorMsg);
         $validatorValid   = fn(mixed $value, array|null $context = null): ValidatorInterface =>
-        self::createValidatorMock(true, $value, $context);
+        TestHelper::createValidatorMock(true, $value, $context);
 
         $dataTemplates = [
             'Required: T; AEmpty: T; CIEmpty: T; Validator: T'
@@ -603,7 +603,7 @@ final class PsrFileInputDecoratorTest extends TestCase
 
         // Validator should not to be called
         $input->getValidatorChain()
-            ->attach(self::createValidatorMock(null, null));
+            ->attach(TestHelper::createValidatorMock(null, null));
         self::assertTrue(
             $input->isValid(),
             'isValid() should be return always true when is not required, and no data is set. Detail: '
@@ -668,7 +668,7 @@ final class PsrFileInputDecoratorTest extends TestCase
 
         $notEmptyMock->method('getMessages')->willReturn([]);
 
-        $validatorChain->attach(self::createValidatorMock(true));
+        $validatorChain->attach(TestHelper::createValidatorMock(true));
         $validatorChain->attach($notEmptyMock);
 
         self::assertFalse($this->input->isValid());
@@ -1026,20 +1026,5 @@ final class PsrFileInputDecoratorTest extends TestCase
             ->willReturnMap($valueMap);
 
         return $filterChain;
-    }
-
-    protected function createValidatorChain(mixed $value, bool $isValid): ValidatorChain
-    {
-        return (new ValidatorChain())->attach(self::createValidatorMock($isValid, $value));
-    }
-
-    /** @param array<string, string> $messages */
-    protected static function createValidatorMock(
-        bool|null $isValid,
-        mixed $value = 'not-set',
-        array|null $context = null,
-        array $messages = []
-    ): ValidatorInterface {
-        return new ValidatorStub($isValid, $value, $context, $messages);
     }
 }

--- a/test/FileInput/PsrFileInputDecoratorTest.php
+++ b/test/FileInput/PsrFileInputDecoratorTest.php
@@ -144,7 +144,7 @@ final class PsrFileInputDecoratorTest extends TestCase
         $this->input->setValue($badValue);
 
         $this->input->setFilterChain($this->createFilterChainMock([[$badValue, $filteredValue]]));
-        $this->input->setValidatorChain($this->createValidatorChainMock([[$badValue, null, false]]));
+        $this->input->setValidatorChain($this->createValidatorChain($badValue, false));
 
         self::assertFalse($this->input->isValid());
         self::assertEquals($badValue, $this->input->getValue());
@@ -401,13 +401,6 @@ final class PsrFileInputDecoratorTest extends TestCase
         ];
     }
 
-    protected function getDummyValue(): UploadedFileInterface&MockObject
-    {
-        $upload = $this->createMock(UploadedFileInterface::class);
-        $upload->method('getError')->willReturn(UPLOAD_ERR_OK);
-        return $upload;
-    }
-
     public function assertRequiredValidationErrorMessage(Input $input, string $message = ''): void
     {
         $message  = $message ?: 'Expected failure message for required input';
@@ -461,7 +454,7 @@ final class PsrFileInputDecoratorTest extends TestCase
 
     public function testCanInjectValidatorChain(): void
     {
-        $chain = $this->createValidatorChainMock();
+        $chain = new ValidatorChain();
         $this->input->setValidatorChain($chain);
         self::assertSame($chain, $this->input->getValidatorChain());
     }
@@ -639,7 +632,7 @@ final class PsrFileInputDecoratorTest extends TestCase
 
     public function testValueMayBeInjected(): void
     {
-        $valueRaw = $this->getDummyValue();
+        $valueRaw = ['foo'];
 
         $this->input->setValue($valueRaw);
         self::assertEquals($valueRaw, $this->input->getValue());
@@ -876,26 +869,19 @@ final class PsrFileInputDecoratorTest extends TestCase
 
     public function testMerge(): void
     {
-        $sourceRawValue = $this->getDummyValue();
-
         $source = $this->createMock(InputInterface::class);
         $source->method('getName')->willReturn('bazInput');
         $source->method('getErrorMessage')->willReturn('bazErrorMessage');
         $source->method('breakOnFailure')->willReturn(true);
         $source->method('isRequired')->willReturn(true);
-        $source->method('getRawValue')->willReturn($sourceRawValue);
+        $source->method('getRawValue')->willReturn('foo');
         $source->method('getFilterChain')->willReturn($this->createFilterChainMock());
-        $source->method('getValidatorChain')->willReturn($this->createValidatorChainMock());
+        $source->method('getValidatorChain')->willReturn(new ValidatorChain());
 
         $targetFilterChain = $this->createFilterChainMock();
         $targetFilterChain->expects(TestCase::once())
             ->method('merge')
             ->with($source->getFilterChain());
-
-        $targetValidatorChain = $this->createValidatorChainMock();
-        $targetValidatorChain->expects(TestCase::once())
-            ->method('merge')
-            ->with($source->getValidatorChain());
 
         $target = $this->input;
         $target->setName('fooInput');
@@ -903,7 +889,7 @@ final class PsrFileInputDecoratorTest extends TestCase
         $target->setBreakOnFailure(false);
         $target->setRequired(false);
         $target->setFilterChain($targetFilterChain);
-        $target->setValidatorChain($targetValidatorChain);
+        $target->setValidatorChain(new ValidatorChain());
 
         $return = $target->merge($source);
         self::assertSame($target, $return, 'merge() must return it self');
@@ -912,7 +898,7 @@ final class PsrFileInputDecoratorTest extends TestCase
         self::assertEquals('bazErrorMessage', $target->getErrorMessage(), 'getErrorMessage() value not match');
         self::assertTrue($target->breakOnFailure(), 'breakOnFailure() value not match');
         self::assertTrue($target->isRequired(), 'isRequired() value not match');
-        self::assertEquals($sourceRawValue, $target->getRawValue(), 'getRawValue() value not match');
+        self::assertEquals('foo', $target->getRawValue(), 'getRawValue() value not match');
         self::assertTrue($target->hasValue(), 'hasValue() value not match');
     }
 
@@ -1042,29 +1028,9 @@ final class PsrFileInputDecoratorTest extends TestCase
         return $filterChain;
     }
 
-    /**
-     * @param list<list<mixed>> $valueMap
-     * @param string[] $messages
-     * @return ValidatorChain&MockObject
-     */
-    protected function createValidatorChainMock(array $valueMap = [], $messages = [])
+    protected function createValidatorChain(mixed $value, bool $isValid): ValidatorChain
     {
-        /** @var ValidatorChain&MockObject $validatorChain */
-        $validatorChain = $this->createMock(ValidatorChain::class);
-
-        if (empty($valueMap)) {
-            $validatorChain->expects(self::never())
-                ->method('isValid');
-        } else {
-            $validatorChain->expects(self::atLeastOnce())
-                ->method('isValid')
-                ->willReturnMap($valueMap);
-        }
-
-        $validatorChain->method('getMessages')
-            ->willReturn($messages);
-
-        return $validatorChain;
+        return (new ValidatorChain())->attach(self::createValidatorMock($isValid, $value));
     }
 
     /** @param array<string, string> $messages */

--- a/test/InputFilterAwareTraitTest.php
+++ b/test/InputFilterAwareTraitTest.php
@@ -19,7 +19,7 @@ final class InputFilterAwareTraitTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->factory = FactoryTestHelper::createInputFilterFactory();
+        $this->factory = TestHelper::createInputFilterFactory();
     }
 
     public function testSetInputFilter(): void

--- a/test/InputFilterFactoryTest.php
+++ b/test/InputFilterFactoryTest.php
@@ -24,7 +24,7 @@ final class InputFilterFactoryTest extends TestCase
         $container->expects(self::once())
             ->method('get')
             ->with(Factory::class)
-            ->willReturn(FactoryTestHelper::createInputFilterFactory());
+            ->willReturn(TestHelper::createInputFilterFactory());
 
         $factory = new InputFilterFactory();
 

--- a/test/InputFilterPluginManagerTest.php
+++ b/test/InputFilterPluginManagerTest.php
@@ -147,7 +147,7 @@ final class InputFilterPluginManagerTest extends TestCase
      */
     public static function serviceProvider(): array
     {
-        $inputFilterInterfaceMock = new InputFilterInterfaceStub(FactoryTestHelper::createInputFilterFactory());
+        $inputFilterInterfaceMock = new InputFilterInterfaceStub(TestHelper::createInputFilterFactory());
         $inputInterfaceMock       = new InputInterfaceStub('foo', true);
 
         // phpcs:disable Generic.Files.LineLength.TooLong

--- a/test/InputFilterTest.php
+++ b/test/InputFilterTest.php
@@ -20,7 +20,7 @@ final class InputFilterTest extends BaseInputFilterTest
 
     protected function setUp(): void
     {
-        $this->factory = FactoryTestHelper::createInputFilterFactory();
+        $this->factory = TestHelper::createInputFilterFactory();
 
         $this->inputFilter = new InputFilter($this->factory);
     }
@@ -41,7 +41,7 @@ final class InputFilterTest extends BaseInputFilterTest
         ];
         $inputSpecificationAsTraversable = new ArrayIterator($inputSpecificationAsArray);
 
-        $inputSpecificationResult = FactoryTestHelper::createInputFilterFactory()->createInput([
+        $inputSpecificationResult = TestHelper::createInputFilterFactory()->createInput([
             'name' => 'inputFoo',
         ]);
 

--- a/test/InputTest.php
+++ b/test/InputTest.php
@@ -13,7 +13,6 @@ use Laminas\Validator\NumberComparison;
 use Laminas\Validator\Translator\TranslatorInterface;
 use Laminas\Validator\ValidatorChain;
 use Laminas\Validator\ValidatorInterface;
-use LaminasTest\InputFilter\TestAsset\ValidatorStub;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -178,7 +177,7 @@ final class InputTest extends TestCase
         $input->setContinueIfEmpty(true);
 
         $input->setRequired($required);
-        $input->setValidatorChain($this->createValidatorChain($originalValue, $isValid));
+        $input->setValidatorChain(TestHelper::createValidatorChain($originalValue, $isValid));
         $input->setFallbackValue($fallbackValue);
         $input->setValue($originalValue);
 
@@ -304,7 +303,7 @@ final class InputTest extends TestCase
 
         // Validator should not to be called
         $input->getValidatorChain()
-            ->attach(self::createValidatorMock(null, null));
+            ->attach(TestHelper::createValidatorMock(null, null));
         self::assertTrue(
             $input->isValid(),
             'isValid() should be return always true when is not required, and no data is set. Detail: '
@@ -372,7 +371,7 @@ final class InputTest extends TestCase
 
         $this->input->setAllowEmpty(true);
         $this->input->setFilterChain($filterChain);
-        $this->input->setValidatorChain($this->createValidatorChain($valueFiltered, true));
+        $this->input->setValidatorChain(TestHelper::createValidatorChain($valueFiltered, true));
         $this->input->setValue($valueRaw);
 
         self::assertTrue(
@@ -439,7 +438,7 @@ final class InputTest extends TestCase
 
         $notEmptyMock = $this->createNonEmptyValidatorMock($filtered);
 
-        $validatorChain->attach(self::createValidatorMock(true));
+        $validatorChain->attach(TestHelper::createValidatorMock(true));
         $validatorChain->attach($notEmptyMock);
 
         self::assertFalse($this->input->isValid());
@@ -815,11 +814,11 @@ final class InputTest extends TestCase
         $notEmptyMsg  = ['isEmpty' => "Value is required and can't be empty"];
 
         $validatorNotCall = fn(mixed $value, array|null $context = null): ValidatorInterface =>
-            self::createValidatorMock(null, $value, $context);
+            TestHelper::createValidatorMock(null, $value, $context);
         $validatorInvalid = fn(mixed $value, array|null $context = null): ValidatorInterface =>
-            self::createValidatorMock(false, $value, $context, $validatorMsg);
+            TestHelper::createValidatorMock(false, $value, $context, $validatorMsg);
         $validatorValid   = fn(mixed $value, array|null $context = null): ValidatorInterface =>
-            self::createValidatorMock(true, $value, $context);
+            TestHelper::createValidatorMock(true, $value, $context);
 
         $dataTemplates = [
             'Required: T; AEmpty: T; CIEmpty: T; Validator: T'
@@ -984,21 +983,6 @@ final class InputTest extends TestCase
             ->willReturnMap($valueMap);
 
         return $filterChain;
-    }
-
-    protected function createValidatorChain(mixed $value, bool $isValid): ValidatorChain
-    {
-        return (new ValidatorChain())->attach(self::createValidatorMock($isValid, $value));
-    }
-
-    /** @param array<string, string> $messages */
-    protected static function createValidatorMock(
-        bool|null $isValid,
-        mixed $value = 'not-set',
-        array|null $context = null,
-        array $messages = []
-    ): ValidatorInterface {
-        return new ValidatorStub($isValid, $value, $context, $messages);
     }
 
     protected function createNonEmptyValidatorMock(

--- a/test/InputTest.php
+++ b/test/InputTest.php
@@ -99,7 +99,7 @@ final class InputTest extends TestCase
 
     public function testCanInjectValidatorChain(): void
     {
-        $chain = $this->createValidatorChainMock();
+        $chain = new ValidatorChain();
         $this->input->setValidatorChain($chain);
         self::assertSame($chain, $this->input->getValidatorChain());
     }
@@ -178,7 +178,7 @@ final class InputTest extends TestCase
         $input->setContinueIfEmpty(true);
 
         $input->setRequired($required);
-        $input->setValidatorChain($this->createValidatorChainMock([[$originalValue, null, $isValid]]));
+        $input->setValidatorChain($this->createValidatorChain($originalValue, $isValid));
         $input->setFallbackValue($fallbackValue);
         $input->setValue($originalValue);
 
@@ -204,7 +204,7 @@ final class InputTest extends TestCase
         $input->setContinueIfEmpty(true);
 
         $input->setRequired($required);
-        $input->setValidatorChain($this->createValidatorChainMock());
+        $input->setValidatorChain(new ValidatorChain());
         $input->setFallbackValue($fallbackValue);
 
         self::assertTrue(
@@ -332,7 +332,7 @@ final class InputTest extends TestCase
 
     public function testValueMayBeInjected(): void
     {
-        $valueRaw = $this->getDummyValue();
+        $valueRaw = 'foo';
 
         $this->input->setValue($valueRaw);
         self::assertEquals($valueRaw, $this->input->getValue());
@@ -340,8 +340,8 @@ final class InputTest extends TestCase
 
     public function testRetrievingValueFiltersTheValue(): void
     {
-        $valueRaw      = $this->getDummyValue();
-        $valueFiltered = $this->getDummyValue(false);
+        $valueRaw      = 'foo';
+        $valueFiltered = 'filtered';
 
         $filterChain = $this->createFilterChainMock([[$valueRaw, $valueFiltered]]);
 
@@ -353,7 +353,7 @@ final class InputTest extends TestCase
 
     public function testCanRetrieveRawValue(): void
     {
-        $valueRaw = $this->getDummyValue();
+        $valueRaw = 'foo';
 
         $filterChain = $this->createFilterChainMock();
 
@@ -365,16 +365,14 @@ final class InputTest extends TestCase
 
     public function testValidationOperatesOnFilteredValue(): void
     {
-        $valueRaw      = $this->getDummyValue();
-        $valueFiltered = $this->getDummyValue(false);
+        $valueRaw      = 'foo';
+        $valueFiltered = 'filtered';
 
         $filterChain = $this->createFilterChainMock([[$valueRaw, $valueFiltered]]);
 
-        $validatorChain = $this->createValidatorChainMock([[$valueFiltered, null, true]]);
-
         $this->input->setAllowEmpty(true);
         $this->input->setFilterChain($filterChain);
-        $this->input->setValidatorChain($validatorChain);
+        $this->input->setValidatorChain($this->createValidatorChain($valueFiltered, true));
         $this->input->setValue($valueRaw);
 
         self::assertTrue(
@@ -639,26 +637,21 @@ final class InputTest extends TestCase
 
     public function testMerge(): void
     {
-        $sourceRawValue = $this->getDummyValue();
-
         $source = $this->createMock(InputInterface::class);
         $source->method('getName')->willReturn('bazInput');
         $source->method('getErrorMessage')->willReturn('bazErrorMessage');
         $source->method('breakOnFailure')->willReturn(true);
         $source->method('isRequired')->willReturn(true);
-        $source->method('getRawValue')->willReturn($sourceRawValue);
+        $source->method('getRawValue')->willReturn('foo');
         $source->method('getFilterChain')->willReturn($this->createFilterChainMock());
-        $source->method('getValidatorChain')->willReturn($this->createValidatorChainMock());
+        $source->method('getValidatorChain')->willReturn(new ValidatorChain());
 
         $targetFilterChain = $this->createFilterChainMock();
         $targetFilterChain->expects(TestCase::once())
             ->method('merge')
             ->with($source->getFilterChain());
 
-        $targetValidatorChain = $this->createValidatorChainMock();
-        $targetValidatorChain->expects(TestCase::once())
-            ->method('merge')
-            ->with($source->getValidatorChain());
+        $targetValidatorChain = new ValidatorChain();
 
         $target = $this->input;
         $target->setName('fooInput');
@@ -675,7 +668,7 @@ final class InputTest extends TestCase
         self::assertEquals('bazErrorMessage', $target->getErrorMessage(), 'getErrorMessage() value not match');
         self::assertTrue($target->breakOnFailure(), 'breakOnFailure() value not match');
         self::assertTrue($target->isRequired(), 'isRequired() value not match');
-        self::assertEquals($sourceRawValue, $target->getRawValue(), 'getRawValue() value not match');
+        self::assertEquals('foo', $target->getRawValue(), 'getRawValue() value not match');
         self::assertTrue($target->hasValue(), 'hasValue() value not match');
     }
 
@@ -993,29 +986,9 @@ final class InputTest extends TestCase
         return $filterChain;
     }
 
-    /**
-     * @param list<list<mixed>> $valueMap
-     * @param string[] $messages
-     * @return ValidatorChain&MockObject
-     */
-    protected function createValidatorChainMock(array $valueMap = [], $messages = [])
+    protected function createValidatorChain(mixed $value, bool $isValid): ValidatorChain
     {
-        /** @var ValidatorChain&MockObject $validatorChain */
-        $validatorChain = $this->createMock(ValidatorChain::class);
-
-        if (empty($valueMap)) {
-            $validatorChain->expects(self::never())
-                ->method('isValid');
-        } else {
-            $validatorChain->expects(self::atLeastOnce())
-                ->method('isValid')
-                ->willReturnMap($valueMap);
-        }
-
-        $validatorChain->method('getMessages')
-            ->willReturn($messages);
-
-        return $validatorChain;
+        return (new ValidatorChain())->attach(self::createValidatorMock($isValid, $value));
     }
 
     /** @param array<string, string> $messages */
@@ -1040,11 +1013,5 @@ final class InputTest extends TestCase
         $notEmptyMock->method('getMessages')->willReturn([]);
 
         return $notEmptyMock;
-    }
-
-    /** @return string */
-    protected function getDummyValue(bool $raw = true)
-    {
-        return $raw ? 'foo' : 'filtered';
     }
 }

--- a/test/OptionalInputFilterTest.php
+++ b/test/OptionalInputFilterTest.php
@@ -93,7 +93,7 @@ final class OptionalInputFilterTest extends TestCase
      */
     public function testIteratorBehavesTheSameAsArray(): void
     {
-        $optionalInputFilter = new OptionalInputFilter(FactoryTestHelper::createInputFilterFactory());
+        $optionalInputFilter = new OptionalInputFilter(TestHelper::createInputFilterFactory());
 
         $optionalInputFilter->add(new Input('brand'));
 
@@ -122,7 +122,7 @@ final class OptionalInputFilterTest extends TestCase
 
     protected function getNestedCarInputFilter(): InputFilter
     {
-        $factory = FactoryTestHelper::createInputFilterFactory();
+        $factory = TestHelper::createInputFilterFactory();
 
         if (! $this->nestedCarInputFilter) {
             /** @var OptionalInputFilter<array{brand: mixed, model:mixed}> $optionalInputFilter */

--- a/test/TestHelper.php
+++ b/test/TestHelper.php
@@ -8,9 +8,12 @@ use Laminas\Filter\FilterPluginManager;
 use Laminas\InputFilter\Factory;
 use Laminas\InputFilter\InputFilterPluginManager;
 use Laminas\ServiceManager\ServiceManager;
+use Laminas\Validator\ValidatorChain;
+use Laminas\Validator\ValidatorInterface;
 use Laminas\Validator\ValidatorPluginManager;
+use LaminasTest\InputFilter\TestAsset\ValidatorStub;
 
-final class FactoryTestHelper
+final class TestHelper
 {
     public static function createInputFilterFactory(): Factory
     {
@@ -25,5 +28,22 @@ final class FactoryTestHelper
         $serviceManager->setService(Factory::class, $factory);
 
         return $factory;
+    }
+
+    /**
+     * @param array<string, string> $messages
+     */
+    public static function createValidatorMock(
+        ?bool $isValid,
+        mixed $value = 'not-set',
+        ?array $context = null,
+        array $messages = []
+    ): ValidatorInterface {
+        return new ValidatorStub($isValid, $value, $context, $messages);
+    }
+
+    public static function createValidatorChain(mixed $value, bool $isValid): ValidatorChain
+    {
+        return (new ValidatorChain())->attach(self::createValidatorMock($isValid, $value));
     }
 }

--- a/test/ValidationGroup/InputFilterCollectionsValidationGroupTest.php
+++ b/test/ValidationGroup/InputFilterCollectionsValidationGroupTest.php
@@ -8,7 +8,7 @@ use Laminas\InputFilter\CollectionInputFilter;
 use Laminas\InputFilter\Exception\RuntimeException;
 use Laminas\InputFilter\Input;
 use Laminas\InputFilter\InputFilter;
-use LaminasTest\InputFilter\FactoryTestHelper;
+use LaminasTest\InputFilter\TestHelper;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
@@ -23,7 +23,7 @@ final class InputFilterCollectionsValidationGroupTest extends TestCase
     {
         parent::setUp();
 
-        $factory = FactoryTestHelper::createInputFilterFactory();
+        $factory = TestHelper::createInputFilterFactory();
 
         $collection = new CollectionInputFilter($factory);
         $collection->setIsRequired(true);

--- a/test/ValidationGroup/InputFilterStringValidationGroupTest.php
+++ b/test/ValidationGroup/InputFilterStringValidationGroupTest.php
@@ -8,7 +8,7 @@ use Laminas\InputFilter\Exception\InvalidArgumentException;
 use Laminas\InputFilter\Input;
 use Laminas\InputFilter\InputFilter;
 use Laminas\Validator\StringLength;
-use LaminasTest\InputFilter\FactoryTestHelper;
+use LaminasTest\InputFilter\TestHelper;
 use PHPUnit\Framework\TestCase;
 
 final class InputFilterStringValidationGroupTest extends TestCase
@@ -28,7 +28,7 @@ final class InputFilterStringValidationGroupTest extends TestCase
         $third->setRequired(true);
         $third->getValidatorChain()->attach(new StringLength(['min' => 5]));
 
-        $this->inputFilter = new InputFilter(FactoryTestHelper::createInputFilterFactory());
+        $this->inputFilter = new InputFilter(TestHelper::createInputFilterFactory());
         $this->inputFilter->add($first);
         $this->inputFilter->add($second);
         $this->inputFilter->add($third);


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | yes
| QA            | yes

### Description

ValidatorChain is final and from laminas-validator v3 onwards this is enforced preventing mocking in unit tests.

This replaces the mocks with instances, and removes some code from `createValidatorChainMock` that handles cases the tests do not use
