### PR TITLE
Replace mocked FilterChain with instance in unit tests

### DIFF
--- a/test/ArrayInputTest.php
+++ b/test/ArrayInputTest.php
@@ -26,7 +26,6 @@ use PHPUnit\Framework\TestCase;
 use stdClass;
 
 use function array_diff_key;
-use function array_map;
 use function array_merge;
 use function array_pop;
 use function count;
@@ -208,36 +207,6 @@ final class ArrayInputTest extends TestCase
         ];
     }
 
-    /**
-     * @param list<list<mixed>> $valueMap
-     */
-    protected function createFilterChainMock(array $valueMap = []): FilterChain&MockObject
-    {
-        // ArrayInput filters per each array value
-        $valueMap = array_map(
-            static function ($values) {
-                if (is_array($values[0])) {
-                    /** @psalm-suppress MixedAssignment */
-                    $values[0] = current($values[0]);
-                }
-                if (is_array($values[1])) {
-                    /** @psalm-suppress MixedAssignment */
-                    $values[1] = current($values[1]);
-                }
-                return $values;
-            },
-            $valueMap,
-        );
-
-        /** @var FilterChain&MockObject $filterChain */
-        $filterChain = $this->createMock(FilterChain::class);
-
-        $filterChain->method('filter')
-            ->willReturnMap($valueMap);
-
-        return $filterChain;
-    }
-
     public function testAnArrayInputViaInputFilterIsAcceptable(): void
     {
         $factory = TestHelper::createInputFilterFactory();
@@ -346,7 +315,7 @@ final class ArrayInputTest extends TestCase
 
     public function testCanInjectFilterChain(): void
     {
-        $filterChain = $this->createMock(FilterChain::class);
+        $filterChain = TestHelper::createFilterChain();
 
         $this->input->setFilterChain($filterChain);
         self::assertSame($filterChain, $this->input->getFilterChain());
@@ -594,7 +563,7 @@ final class ArrayInputTest extends TestCase
         $valueRaw      = ['foo'];
         $valueFiltered = ['filtered'];
 
-        $filterChain = $this->createFilterChainMock([[$valueRaw, $valueFiltered]]);
+        $filterChain = TestHelper::createFilterChainFixture($valueRaw[0], $valueFiltered[0]);
 
         $this->input->setFilterChain($filterChain);
         $this->input->setValue($valueRaw);
@@ -606,9 +575,7 @@ final class ArrayInputTest extends TestCase
     {
         $valueRaw = 'foo';
 
-        $filterChain = $this->createMock(FilterChain::class);
-
-        $this->input->setFilterChain($filterChain);
+        $this->input->setFilterChain(TestHelper::createFilterChain());
         $this->input->setValue($valueRaw);
 
         self::assertEquals($valueRaw, $this->input->getRawValue());
@@ -619,7 +586,7 @@ final class ArrayInputTest extends TestCase
         $valueRaw      = ['foo'];
         $valueFiltered = ['filtered'];
 
-        $filterChain = $this->createFilterChainMock([[$valueRaw, $valueFiltered]]);
+        $filterChain = TestHelper::createFilterChainFixture($valueRaw[0], $valueFiltered[0]);
 
         $this->input->setAllowEmpty(true);
         $this->input->setFilterChain($filterChain);
@@ -687,7 +654,10 @@ final class ArrayInputTest extends TestCase
     #[DataProvider('emptyValueProvider')]
     public function testDoNotInjectNotEmptyValidatorIfAnywhereInChain(mixed $raw, mixed $filtered): void
     {
-        $filterChain    = $this->createFilterChainMock([[$raw, $filtered]]);
+        $filterChain    = TestHelper::createFilterChainFixture(
+            is_array($raw) ? $raw[0] : $raw,
+            is_array($filtered) ? count($filtered) > 0 ? $filtered[0] : null : $filtered
+        );
         $validatorChain = $this->input->getValidatorChain();
 
         $this->input->setRequired(true);
@@ -909,20 +879,15 @@ final class ArrayInputTest extends TestCase
         $source->method('breakOnFailure')->willReturn(true);
         $source->method('isRequired')->willReturn(true);
         $source->method('getRawValue')->willReturn('foo');
-        $source->method('getFilterChain')->willReturn($this->createMock(FilterChain::class));
+        $source->method('getFilterChain')->willReturn(TestHelper::createFilterChain());
         $source->method('getValidatorChain')->willReturn(new ValidatorChain());
-
-        $targetFilterChain = $this->createMock(FilterChain::class);
-        $targetFilterChain->expects(TestCase::once())
-            ->method('merge')
-            ->with($source->getFilterChain());
 
         $target = $this->input;
         $target->setName('fooInput');
         $target->setErrorMessage('fooErrorMessage');
         $target->setBreakOnFailure(false);
         $target->setRequired(false);
-        $target->setFilterChain($targetFilterChain);
+        $target->setFilterChain(TestHelper::createFilterChain());
         $target->setValidatorChain(new ValidatorChain());
 
         $return = $target->merge($source);

--- a/test/FileInput/HttpServerFileInputDecoratorTest.php
+++ b/test/FileInput/HttpServerFileInputDecoratorTest.php
@@ -64,7 +64,7 @@ final class HttpServerFileInputDecoratorTest extends TestCase
         $this->input->setValue($value);
 
         $newValue = ['tmp_name' => 'foo'];
-        $this->input->setFilterChain($this->createFilterChainMock([[$value, $newValue]]));
+        $this->input->setFilterChain(TestHelper::createFilterChainFixture($value, $newValue));
 
         self::assertEquals($value, $this->input->getValue());
         self::assertTrue(
@@ -85,7 +85,7 @@ final class HttpServerFileInputDecoratorTest extends TestCase
 
         $newValue      = ['tmp_name' => 'new'];
         $filteredValue = [$newValue, $newValue, $newValue];
-        $this->input->setFilterChain($this->createFilterChainMock([
+        $this->input->setFilterChain(TestHelper::createFilterChainFixtureFromMap([
             [$values[0], $newValue],
             [$values[1], $newValue],
             [$values[2], $newValue],
@@ -108,7 +108,7 @@ final class HttpServerFileInputDecoratorTest extends TestCase
         $this->input->setValue($value);
 
         $newValue = ['tmp_name' => 'new'];
-        $this->input->setFilterChain($this->createFilterChainMock([[$value, $newValue]]));
+        $this->input->setFilterChain(TestHelper::createFilterChainFixture($value, $newValue));
 
         self::assertEquals($value, $this->input->getRawValue());
     }
@@ -124,7 +124,7 @@ final class HttpServerFileInputDecoratorTest extends TestCase
         $this->input->setValue($badValue);
 
         $filteredValue = ['tmp_name' => 'new'];
-        $this->input->setFilterChain($this->createFilterChainMock([[$badValue, $filteredValue]]));
+        $this->input->setFilterChain(TestHelper::createFilterChainFixture($badValue, $filteredValue));
         $this->input->setValidatorChain(TestHelper::createValidatorChain($badValue, false));
 
         self::assertFalse($this->input->isValid());
@@ -485,7 +485,7 @@ final class HttpServerFileInputDecoratorTest extends TestCase
 
     public function testCanInjectFilterChain(): void
     {
-        $chain = $this->createFilterChainMock();
+        $chain = TestHelper::createFilterChain();
         $this->input->setFilterChain($chain);
         self::assertSame($chain, $this->input->getFilterChain());
     }
@@ -689,7 +689,7 @@ final class HttpServerFileInputDecoratorTest extends TestCase
     #[DataProvider('emptyValueProvider')]
     public function testDoNotInjectNotEmptyValidatorIfAnywhereInChain(mixed $raw, mixed $filtered): void
     {
-        $filterChain    = $this->createFilterChainMock([[$raw, $filtered]]);
+        $filterChain    = TestHelper::createFilterChainFixture($raw, $filtered);
         $validatorChain = $this->input->getValidatorChain();
 
         $this->input->setRequired(true);
@@ -910,20 +910,15 @@ final class HttpServerFileInputDecoratorTest extends TestCase
         $source->method('breakOnFailure')->willReturn(true);
         $source->method('isRequired')->willReturn(true);
         $source->method('getRawValue')->willReturn($sourceRawValue);
-        $source->method('getFilterChain')->willReturn($this->createFilterChainMock());
+        $source->method('getFilterChain')->willReturn(TestHelper::createFilterChain());
         $source->method('getValidatorChain')->willReturn(new ValidatorChain());
-
-        $targetFilterChain = $this->createFilterChainMock();
-        $targetFilterChain->expects(TestCase::once())
-            ->method('merge')
-            ->with($source->getFilterChain());
 
         $target = $this->input;
         $target->setName('fooInput');
         $target->setErrorMessage('fooErrorMessage');
         $target->setBreakOnFailure(false);
         $target->setRequired(false);
-        $target->setFilterChain($targetFilterChain);
+        $target->setFilterChain(TestHelper::createFilterChain());
         $target->setValidatorChain(new ValidatorChain());
 
         $return = $target->merge($source);
@@ -1049,20 +1044,5 @@ final class HttpServerFileInputDecoratorTest extends TestCase
                 ],
             ]
         );
-    }
-
-    /**
-     * @param list<list<mixed>> $valueMap
-     * @return FilterChain&MockObject
-     */
-    public function createFilterChainMock(array $valueMap = [])
-    {
-        /** @var FilterChain&MockObject $filterChain */
-        $filterChain = $this->createMock(FilterChain::class);
-
-        $filterChain->method('filter')
-            ->willReturnMap($valueMap);
-
-        return $filterChain;
     }
 }

--- a/test/FileInput/PsrFileInputDecoratorTest.php
+++ b/test/FileInput/PsrFileInputDecoratorTest.php
@@ -71,12 +71,7 @@ final class PsrFileInputDecoratorTest extends TestCase
 
         $filteredUpload = $this->createMock(UploadedFileInterface::class);
 
-        $this->input->setFilterChain($this->createFilterChainMock([
-            [
-                $upload,
-                $filteredUpload,
-            ],
-        ]));
+        $this->input->setFilterChain(TestHelper::createFilterChainFixture($upload, $filteredUpload));
 
         self::assertEquals($upload, $this->input->getValue());
         self::assertTrue(
@@ -103,7 +98,7 @@ final class PsrFileInputDecoratorTest extends TestCase
             $filteredValues[] = $this->createMock(UploadedFileInterface::class);
         }
 
-        $this->input->setFilterChain($this->createFilterChainMock([
+        $this->input->setFilterChain(TestHelper::createFilterChainFixtureFromMap([
             [$values[0], $filteredValues[0]],
             [$values[1], $filteredValues[1]],
             [$values[2], $filteredValues[2]],
@@ -128,7 +123,7 @@ final class PsrFileInputDecoratorTest extends TestCase
         $this->input->setValue($value);
 
         $filteredValue = $this->createMock(UploadedFileInterface::class);
-        $this->input->setFilterChain($this->createFilterChainMock([[$value, $filteredValue]]));
+        $this->input->setFilterChain(TestHelper::createFilterChainFixture($value, $filteredValue));
 
         self::assertEquals($value, $this->input->getRawValue());
     }
@@ -143,7 +138,7 @@ final class PsrFileInputDecoratorTest extends TestCase
 
         $this->input->setValue($badValue);
 
-        $this->input->setFilterChain($this->createFilterChainMock([[$badValue, $filteredValue]]));
+        $this->input->setFilterChain(TestHelper::createFilterChainFixture($badValue, $filteredValue));
         $this->input->setValidatorChain(TestHelper::createValidatorChain($badValue, false));
 
         self::assertFalse($this->input->isValid());
@@ -447,7 +442,7 @@ final class PsrFileInputDecoratorTest extends TestCase
 
     public function testCanInjectFilterChain(): void
     {
-        $chain = $this->createFilterChainMock();
+        $chain = TestHelper::createFilterChain();
         $this->input->setFilterChain($chain);
         self::assertSame($chain, $this->input->getFilterChain());
     }
@@ -652,7 +647,7 @@ final class PsrFileInputDecoratorTest extends TestCase
     #[DataProvider('emptyValueProvider')]
     public function testDoNotInjectNotEmptyValidatorIfAnywhereInChain(mixed $raw, mixed $filtered): void
     {
-        $filterChain    = $this->createFilterChainMock([[$raw, $filtered]]);
+        $filterChain    = TestHelper::createFilterChainFixture($raw, $filtered);
         $validatorChain = $this->input->getValidatorChain();
 
         $this->input->setRequired(true);
@@ -875,20 +870,15 @@ final class PsrFileInputDecoratorTest extends TestCase
         $source->method('breakOnFailure')->willReturn(true);
         $source->method('isRequired')->willReturn(true);
         $source->method('getRawValue')->willReturn('foo');
-        $source->method('getFilterChain')->willReturn($this->createFilterChainMock());
+        $source->method('getFilterChain')->willReturn(TestHelper::createFilterChain());
         $source->method('getValidatorChain')->willReturn(new ValidatorChain());
-
-        $targetFilterChain = $this->createFilterChainMock();
-        $targetFilterChain->expects(TestCase::once())
-            ->method('merge')
-            ->with($source->getFilterChain());
 
         $target = $this->input;
         $target->setName('fooInput');
         $target->setErrorMessage('fooErrorMessage');
         $target->setBreakOnFailure(false);
         $target->setRequired(false);
-        $target->setFilterChain($targetFilterChain);
+        $target->setFilterChain(TestHelper::createFilterChain());
         $target->setValidatorChain(new ValidatorChain());
 
         $return = $target->merge($source);
@@ -1011,20 +1001,5 @@ final class PsrFileInputDecoratorTest extends TestCase
                 ],
             ]
         );
-    }
-
-    /**
-     * @param list<list<mixed>> $valueMap
-     * @return FilterChain&MockObject
-     */
-    public function createFilterChainMock(array $valueMap = [])
-    {
-        /** @var FilterChain&MockObject $filterChain */
-        $filterChain = $this->createMock(FilterChain::class);
-
-        $filterChain->method('filter')
-            ->willReturnMap($valueMap);
-
-        return $filterChain;
     }
 }

--- a/test/InputTest.php
+++ b/test/InputTest.php
@@ -91,7 +91,7 @@ final class InputTest extends TestCase
 
     public function testCanInjectFilterChain(): void
     {
-        $chain = $this->createFilterChainMock();
+        $chain = TestHelper::createFilterChain();
         $this->input->setFilterChain($chain);
         self::assertSame($chain, $this->input->getFilterChain());
     }
@@ -342,7 +342,7 @@ final class InputTest extends TestCase
         $valueRaw      = 'foo';
         $valueFiltered = 'filtered';
 
-        $filterChain = $this->createFilterChainMock([[$valueRaw, $valueFiltered]]);
+        $filterChain = TestHelper::createFilterChainFixture($valueRaw, $valueFiltered);
 
         $this->input->setFilterChain($filterChain);
         $this->input->setValue($valueRaw);
@@ -354,9 +354,7 @@ final class InputTest extends TestCase
     {
         $valueRaw = 'foo';
 
-        $filterChain = $this->createFilterChainMock();
-
-        $this->input->setFilterChain($filterChain);
+        $this->input->setFilterChain(TestHelper::createFilterChain());
         $this->input->setValue($valueRaw);
 
         self::assertEquals($valueRaw, $this->input->getRawValue());
@@ -367,7 +365,7 @@ final class InputTest extends TestCase
         $valueRaw      = 'foo';
         $valueFiltered = 'filtered';
 
-        $filterChain = $this->createFilterChainMock([[$valueRaw, $valueFiltered]]);
+        $filterChain = TestHelper::createFilterChainFixture($valueRaw, $valueFiltered);
 
         $this->input->setAllowEmpty(true);
         $this->input->setFilterChain($filterChain);
@@ -429,7 +427,7 @@ final class InputTest extends TestCase
     #[DataProvider('emptyValueProvider')]
     public function testDoNotInjectNotEmptyValidatorIfAnywhereInChain(mixed $raw, mixed $filtered): void
     {
-        $filterChain    = $this->createFilterChainMock([[$raw, $filtered]]);
+        $filterChain    = TestHelper::createFilterChainFixture($raw, $filtered);
         $validatorChain = $this->input->getValidatorChain();
 
         $this->input->setRequired(true);
@@ -642,14 +640,10 @@ final class InputTest extends TestCase
         $source->method('breakOnFailure')->willReturn(true);
         $source->method('isRequired')->willReturn(true);
         $source->method('getRawValue')->willReturn('foo');
-        $source->method('getFilterChain')->willReturn($this->createFilterChainMock());
+        $source->method('getFilterChain')->willReturn(TestHelper::createFilterChain());
         $source->method('getValidatorChain')->willReturn(new ValidatorChain());
 
-        $targetFilterChain = $this->createFilterChainMock();
-        $targetFilterChain->expects(TestCase::once())
-            ->method('merge')
-            ->with($source->getFilterChain());
-
+        $targetFilterChain    = TestHelper::createFilterChain();
         $targetValidatorChain = new ValidatorChain();
 
         $target = $this->input;
@@ -968,21 +962,6 @@ final class InputTest extends TestCase
                 'filtered' => new stdClass(),
             ],
         ];
-    }
-
-    /**
-     * @param list<list<mixed>> $valueMap
-     * @return FilterChain&MockObject
-     */
-    public function createFilterChainMock(array $valueMap = [])
-    {
-        /** @var FilterChain&MockObject $filterChain */
-        $filterChain = $this->createMock(FilterChain::class);
-
-        $filterChain->method('filter')
-            ->willReturnMap($valueMap);
-
-        return $filterChain;
     }
 
     protected function createNonEmptyValidatorMock(

--- a/test/TestHelper.php
+++ b/test/TestHelper.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace LaminasTest\InputFilter;
 
+use Laminas\Filter\FilterChain;
 use Laminas\Filter\FilterPluginManager;
 use Laminas\InputFilter\Factory;
 use Laminas\InputFilter\InputFilterPluginManager;
@@ -30,9 +31,7 @@ final class TestHelper
         return $factory;
     }
 
-    /**
-     * @param array<string, string> $messages
-     */
+    /** @param array<string, string> $messages */
     public static function createValidatorMock(
         ?bool $isValid,
         mixed $value = 'not-set',
@@ -45,5 +44,35 @@ final class TestHelper
     public static function createValidatorChain(mixed $value, bool $isValid): ValidatorChain
     {
         return (new ValidatorChain())->attach(self::createValidatorMock($isValid, $value));
+    }
+
+    public static function createFilterChain(): FilterChain
+    {
+        return new FilterChain();
+    }
+
+    public static function createFilterChainFixture(mixed $originalValue, mixed $filteredValue): FilterChain
+    {
+        $filterChain = new FilterChain();
+
+        $filterChain->attach(
+            fn(mixed $value): mixed => $value === $originalValue ? $filteredValue : $value,
+        );
+
+        return $filterChain;
+    }
+
+    /** @param array<int, array<mixed, mixed>> $valueMap */
+    public static function createFilterChainFixtureFromMap(array $valueMap): FilterChain
+    {
+        $filterChain = new FilterChain();
+
+        foreach ($valueMap as $values) {
+            $filterChain->attach(
+                fn(mixed $value): mixed => $value === $values[0] ? $values[1] : $value,
+            );
+        }
+
+        return $filterChain;
     }
 }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation |no
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | yes
| QA            | yes

### Description

FilterChain is final and from laminas-filter v3 onwards this is enforced preventing mocking in unit tests.

This replaces the mocks with instances, and reduces some test setup duplication