### PR TITLE
Correct ArrayInputTest instantiating test class for special cases

### DIFF
--- a/test/ArrayInputTest.php
+++ b/test/ArrayInputTest.php
@@ -553,7 +553,7 @@ final class ArrayInputTest extends TestCase
 
     public function testRequiredWithoutFallbackAndValueNotSetProvidesAttachedNotEmptyValidatorIsEmptyErrorMessage(): void // phpcs:ignore
     {
-        $input = new Input();
+        $input = new ArrayInput();
         $input->setRequired(true);
 
         $customMessage = [
@@ -812,8 +812,8 @@ final class ArrayInputTest extends TestCase
 
     public function testMergingTwoInputsModifiesTheName(): void
     {
-        $a = new Input('a');
-        $b = new Input('b');
+        $a = new ArrayInput('a');
+        $b = new ArrayInput('b');
         $a->merge($b);
 
         self::assertSame('b', $a->getName());
@@ -821,8 +821,8 @@ final class ArrayInputTest extends TestCase
 
     public function testMergingTwoInputsModifiesErrorMessage(): void
     {
-        $a = new Input('a');
-        $b = new Input('b');
+        $a = new ArrayInput('a');
+        $b = new ArrayInput('b');
         $b->setErrorMessage('Foo');
         $a->merge($b);
 
@@ -831,9 +831,9 @@ final class ArrayInputTest extends TestCase
 
     public function testMergingTwoInputsModifiesBreakOnFailureFlag(): void
     {
-        $a = new Input('a');
+        $a = new ArrayInput('a');
         $a->setBreakOnFailure(false);
-        $b = new Input('b');
+        $b = new ArrayInput('b');
         $b->setBreakOnFailure(true);
         $a->merge($b);
 
@@ -842,9 +842,9 @@ final class ArrayInputTest extends TestCase
 
     public function testMergingTwoInputsModifiesRequiredFlag(): void
     {
-        $a = new Input('a');
+        $a = new ArrayInput('a');
         $a->setRequired(false);
-        $b = new Input('b');
+        $b = new ArrayInput('b');
         $b->setRequired(true);
         $a->merge($b);
 
@@ -853,9 +853,9 @@ final class ArrayInputTest extends TestCase
 
     public function testMergingTwoInputsModifiesAllowEmptyFlag(): void
     {
-        $a = new Input('a');
+        $a = new ArrayInput('a');
         $a->setAllowEmpty(false);
-        $b = new Input('b');
+        $b = new ArrayInput('b');
         $b->setAllowEmpty(true);
         $a->merge($b);
 
@@ -864,9 +864,9 @@ final class ArrayInputTest extends TestCase
 
     public function testMergingTwoInputsCopiesTheValueIfSet(): void
     {
-        $a = new Input('a');
+        $a = new ArrayInput('a');
         $a->setValue('a');
-        $b = new Input('b');
+        $b = new ArrayInput('b');
         $b->setValue('b');
         $a->merge($b);
 
@@ -878,8 +878,8 @@ final class ArrayInputTest extends TestCase
         $filter1 = new ToInt();
         $filter2 = new ToNull();
 
-        $a = new Input('a');
-        $b = new Input('b');
+        $a = new ArrayInput('a');
+        $b = new ArrayInput('b');
 
         $a->getFilterChain()->attach($filter1);
         $b->getFilterChain()->attach($filter2);
@@ -898,8 +898,8 @@ final class ArrayInputTest extends TestCase
         $validator1 = new NotEmptyValidator();
         $validator2 = new NumberComparison(['min' => 1, 'max' => 5]);
 
-        $a = new Input('a');
-        $b = new Input('b');
+        $a = new ArrayInput('a');
+        $b = new ArrayInput('b');
 
         $a->getValidatorChain()->attach($validator1);
         $b->getValidatorChain()->attach($validator2);
@@ -990,7 +990,7 @@ final class ArrayInputTest extends TestCase
      */
     public function testInputMergeWithoutValues(): void
     {
-        $source = new Input();
+        $source = new ArrayInput();
         $source->setContinueIfEmpty(true);
         self::assertFalse($source->hasValue(), 'Source should not have a value');
 
@@ -1010,7 +1010,7 @@ final class ArrayInputTest extends TestCase
      */
     public function testInputMergeWithSourceValue(): void
     {
-        $source = new Input();
+        $source = new ArrayInput();
         $source->setContinueIfEmpty(true);
         $source->setValue(['foo']);
 
@@ -1031,7 +1031,7 @@ final class ArrayInputTest extends TestCase
      */
     public function testInputMergeWithTargetValue(): void
     {
-        $source = new Input();
+        $source = new ArrayInput();
         $source->setContinueIfEmpty(true);
         self::assertFalse($source->hasValue(), 'Source should not have a value');
 


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | yes

### Description

This fixes several cases that do not use the instance created by the setUp method and were instantiating Input rather than ArrayInput