### PR TITLE
Add NotEmpty message translation test for CollectionInputFilter

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="6.11.0@4ed53b7ccebc09ef60ec4c9e464bf8a01bfd35b0">
+<files psalm-version="6.12.1@e71404b0465be25cf7f8a631b298c01c5ddd864f">
   <file src="src/ArrayInput.php">
     <DeprecatedProperty>
       <code><![CDATA[$this->value]]></code>
@@ -451,36 +451,6 @@
       <code><![CDATA[getName]]></code>
       <code><![CDATA[getName]]></code>
     </PossiblyUndefinedMethod>
-  </file>
-  <file src="test/CollectionInputFilterTest.php">
-    <InvalidArgument>
-      <code><![CDATA[$errorMessage]]></code>
-    </InvalidArgument>
-    <InvalidReturnStatement>
-      <code><![CDATA[[
-            // Description => [$required, $count, $data, $inputFilter, $expectedRaw, $expectedValues, $expectedValid, $expectedMessages]
-            'Required: T, Count: N, Valid: T'  => [  $isRequired, null, $colRaw, $validIF()  , $colRaw, $colFiltered, true , []],
-            'Required: T, Count: N, Valid: F'  => [  $isRequired, null, $colRaw, $invalidIF(), $colRaw, $colFiltered, false, $colMessages],
-            'Required: T, Count: +1, Valid: F' => [  $isRequired,    2, $colRaw, $invalidIF(), $colRaw, $colFiltered, false, $colMessages],
-            'Required: F, Count: N, Valid: T'  => [! $isRequired, null, $colRaw, $validIF()  , $colRaw, $colFiltered, true , []],
-            'Required: F, Count: N, Valid: F'  => [! $isRequired, null, $colRaw, $invalidIF(), $colRaw, $colFiltered, false, $colMessages],
-            'Required: F, Count: +1, Valid: F' => [! $isRequired,    2, $colRaw, $invalidIF(), $colRaw, $colFiltered, false, $colMessages],
-            'Required: T, Data: [], Valid: X'  => [  $isRequired, null, []     , $noValidIF(), []     , []          , false, [['isEmpty' => 'Value is required and can\'t be empty']]],
-            'Required: F, Data: [], Valid: X'  => [! $isRequired, null, []     , $noValidIF(), []     , []          , true , []],
-        ]]]></code>
-    </InvalidReturnStatement>
-    <InvalidReturnType>
-      <code><![CDATA[array<string, array{
-     *     0: bool,
-     *     1: null|int,
-     *     2: array,
-     *     3: BaseInputFilter&MockObject,
-     *     4: array,
-     *     5: array,
-     *     6: bool,
-     *     7: array
-     * }>]]></code>
-    </InvalidReturnType>
   </file>
   <file src="test/FactoryTest.php">
     <DeprecatedConstant>

--- a/test/CollectionInputFilterTest.php
+++ b/test/CollectionInputFilterTest.php
@@ -1,4 +1,6 @@
-<?php // phpcs:disable WebimpressCodingStandard.NamingConventions.ValidVariableName.NotCamelCaps
+<?php
+
+declare(strict_types=1);
 
 namespace LaminasTest\InputFilter;
 
@@ -12,9 +14,11 @@ use Laminas\InputFilter\Factory;
 use Laminas\InputFilter\Input;
 use Laminas\InputFilter\InputFilter;
 use Laminas\InputFilter\InputFilterInterface;
+use Laminas\Validator\AbstractValidator;
 use Laminas\Validator\Digits;
 use Laminas\Validator\NotEmpty;
 use Laminas\Validator\NumberComparison;
+use Laminas\Validator\Translator\TranslatorInterface;
 use LaminasTest\InputFilter\TestAsset\InputFilterInterfaceStub;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -39,6 +43,11 @@ final class CollectionInputFilterTest extends TestCase
     protected function setUp(): void
     {
         $this->inputFilter = new CollectionInputFilter();
+    }
+
+    protected function tearDown(): void
+    {
+        AbstractValidator::setDefaultTranslator();
     }
 
     public function testSetInputFilterWithInvalidTypeThrowsInvalidArgumentException(): void
@@ -140,7 +149,7 @@ final class CollectionInputFilterTest extends TestCase
      *     0: bool,
      *     1: null|int,
      *     2: array,
-     *     3: BaseInputFilter&MockObject,
+     *     3: BaseInputFilter,
      *     4: array,
      *     5: array,
      *     6: bool,
@@ -157,32 +166,44 @@ final class CollectionInputFilterTest extends TestCase
         ];
         $colRaw       = [$dataRaw];
         $colFiltered  = [$dataFiltered];
-        $errorMessage = [
-            'fooInput' => 'fooError',
-        ];
+        $errorMessage = ['error_type' => ['fooInput' => 'fooError']];
         $colMessages  = [$errorMessage];
 
-        $invalidIF  = fn(): BaseInputFilter =>
+        $invalidIf  = fn(): BaseInputFilter =>
             new InputFilterInterfaceStub(false, $dataRaw, $dataFiltered, $errorMessage);
-        $validIF    = fn(): BaseInputFilter =>
+        $validIf    = fn(): BaseInputFilter =>
             new InputFilterInterfaceStub(true, $dataRaw, $dataFiltered);
-        $noValidIF  = fn(): BaseInputFilter =>
+        $noValidIf  = fn(): BaseInputFilter =>
             new InputFilterInterfaceStub(null, $dataRaw, $dataFiltered);
         $isRequired = true;
 
-        // @phpcs:disable Generic.Files.LineLength.TooLong,WebimpressCodingStandard.Arrays.Format.SingleLineSpaceBefore,WebimpressCodingStandard.WhiteSpace.CommaSpacing.SpaceBeforeComma
         return [
-            // Description => [$required, $count, $data, $inputFilter, $expectedRaw, $expectedValues, $expectedValid, $expectedMessages]
-            'Required: T, Count: N, Valid: T'  => [  $isRequired, null, $colRaw, $validIF()  , $colRaw, $colFiltered, true , []],
-            'Required: T, Count: N, Valid: F'  => [  $isRequired, null, $colRaw, $invalidIF(), $colRaw, $colFiltered, false, $colMessages],
-            'Required: T, Count: +1, Valid: F' => [  $isRequired,    2, $colRaw, $invalidIF(), $colRaw, $colFiltered, false, $colMessages],
-            'Required: F, Count: N, Valid: T'  => [! $isRequired, null, $colRaw, $validIF()  , $colRaw, $colFiltered, true , []],
-            'Required: F, Count: N, Valid: F'  => [! $isRequired, null, $colRaw, $invalidIF(), $colRaw, $colFiltered, false, $colMessages],
-            'Required: F, Count: +1, Valid: F' => [! $isRequired,    2, $colRaw, $invalidIF(), $colRaw, $colFiltered, false, $colMessages],
-            'Required: T, Data: [], Valid: X'  => [  $isRequired, null, []     , $noValidIF(), []     , []          , false, [['isEmpty' => 'Value is required and can\'t be empty']]],
-            'Required: F, Data: [], Valid: X'  => [! $isRequired, null, []     , $noValidIF(), []     , []          , true , []],
+            'Required: T, Count: N, Valid: T'
+                => [$isRequired, null, $colRaw, $validIf(), $colRaw, $colFiltered, true, []],
+            'Required: T, Count: N, Valid: F'
+                => [$isRequired, null, $colRaw, $invalidIf(), $colRaw, $colFiltered, false, $colMessages],
+            'Required: T, Count: +1, Valid: F'
+                => [$isRequired,    2, $colRaw, $invalidIf(), $colRaw, $colFiltered, false, $colMessages],
+            'Required: F, Count: N, Valid: T'
+                => [! $isRequired, null, $colRaw, $validIf(), $colRaw, $colFiltered, true, []],
+            'Required: F, Count: N, Valid: F'
+                => [! $isRequired, null, $colRaw, $invalidIf(), $colRaw, $colFiltered, false, $colMessages],
+            'Required: F, Count: +1, Valid: F'
+                => [! $isRequired,    2, $colRaw, $invalidIf(), $colRaw, $colFiltered, false, $colMessages],
+            'Required: T, Data: [], Valid: X'
+                => [
+                    $isRequired,
+                    null,
+                    [],
+                    $noValidIf(),
+                    [],
+                    [],
+                    false,
+                    [['isEmpty' => 'Value is required and can\'t be empty']],
+                ],
+            'Required: F, Data: [], Valid: X'
+                => [! $isRequired, null, [], $noValidIf(), [], [], true, []],
         ];
-        // @phpcs:enable Generic.Files.LineLength.TooLong,WebimpressCodingStandard.Arrays.Format.SingleLineSpaceBefore,WebimpressCodingStandard.WhiteSpace.CommaSpacing.SpaceBeforeComma
     }
 
     public function testSetValidationGroupUsingFormStyle(): void
@@ -758,6 +779,31 @@ final class CollectionInputFilterTest extends TestCase
 
         self::assertEquals([
             [NotEmpty::IS_EMPTY => $message],
+        ], $this->inputFilter->getMessages());
+    }
+
+    public function testNotEmptyMessageIsTranslated(): void
+    {
+        /** @psalm-suppress DeprecatedInterface */
+        $translator = $this->createMock(TranslatorInterface::class);
+        AbstractValidator::setDefaultTranslator($translator);
+        $notEmpty = new NotEmpty();
+
+        $translatedMessage = 'some translation';
+        /** @psalm-suppress DeprecatedMethod */
+        $translator->expects(self::atLeastOnce())
+            ->method('translate')
+            ->with($notEmpty->getMessageTemplates()[NotEmpty::IS_EMPTY])
+            ->willReturn($translatedMessage);
+
+        $this->inputFilter->setIsRequired(true);
+        $this->inputFilter->setNotEmptyValidator($notEmpty);
+
+        $this->inputFilter->setData([]);
+
+        self::assertFalse($this->inputFilter->isValid());
+        self::assertEquals([
+            [NotEmpty::IS_EMPTY => $translatedMessage],
         ], $this->inputFilter->getMessages());
     }
 


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | yes

### Description

Add CollectionInputFilterTest->testNotEmptyMessageIsTranslated to help ensure future changes to not break this functionality



