### PR TITLE
Simplify Input->prepareRequiredValidationFailureMessage

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -191,10 +191,6 @@
     </MoreSpecificImplementedParamType>
   </file>
   <file src="src/Input.php">
-    <DeprecatedMethod>
-      <code><![CDATA[getOption]]></code>
-      <code><![CDATA[getTranslatorTextDomain]]></code>
-    </DeprecatedMethod>
     <DocblockTypeContradiction>
       <code><![CDATA[is_array($this->errorMessage)]]></code>
     </DocblockTypeContradiction>
@@ -204,18 +200,9 @@
     <InvalidPropertyAssignmentValue>
       <code><![CDATA[$this->prepareRequiredValidationFailureMessage()]]></code>
     </InvalidPropertyAssignmentValue>
-    <MixedArgument>
-      <code><![CDATA[$notEmpty->getTranslatorTextDomain()]]></code>
-    </MixedArgument>
     <MixedAssignment>
-      <code><![CDATA[$translator]]></code>
       <code><![CDATA[$value]]></code>
     </MixedAssignment>
-    <PossiblyUndefinedMethod>
-      <code><![CDATA[getOption]]></code>
-      <code><![CDATA[getTranslator]]></code>
-      <code><![CDATA[getTranslatorTextDomain]]></code>
-    </PossiblyUndefinedMethod>
     <RedundantCastGivenDocblockType>
       <code><![CDATA[(bool) $allowEmpty]]></code>
       <code><![CDATA[(bool) $breakOnFailure]]></code>

--- a/src/Input.php
+++ b/src/Input.php
@@ -7,7 +7,6 @@ namespace Laminas\InputFilter;
 use Laminas\Filter\FilterChain;
 use Laminas\ServiceManager\AbstractPluginManager;
 use Laminas\Validator\NotEmpty;
-use Laminas\Validator\Translator\TranslatorInterface;
 use Laminas\Validator\ValidatorChain;
 
 use function class_exists;
@@ -453,7 +452,7 @@ class Input implements
     protected function prepareRequiredValidationFailureMessage()
     {
         $chain    = $this->getValidatorChain();
-        $notEmpty = $chain->plugin(NotEmpty::class);
+        $notEmpty = null;
 
         foreach ($chain->getValidators() as $validator) {
             if ($validator['instance'] instanceof NotEmpty) {
@@ -462,18 +461,10 @@ class Input implements
             }
         }
 
-        /** @psalm-var array<string, string> $templates */
-        $templates = $notEmpty->getOption('messageTemplates');
-        $message   = $templates[NotEmpty::IS_EMPTY];
-        /** @psalm-suppress DeprecatedInterface */
-        $translator = $notEmpty->getTranslator();
+        $validator = $notEmpty ?: $chain->plugin(NotEmpty::class);
 
-        if ($translator instanceof TranslatorInterface) {
-            $message = $translator->translate($message, $notEmpty->getTranslatorTextDomain());
-        }
+        $validator->isValid(null);
 
-        return [
-            NotEmpty::IS_EMPTY => $message,
-        ];
+        return $validator->getMessages();
     }
 }

--- a/test/FileInput/HttpServerFileInputDecoratorTest.php
+++ b/test/FileInput/HttpServerFileInputDecoratorTest.php
@@ -594,21 +594,14 @@ final class HttpServerFileInputDecoratorTest extends TestCase
 
     public function testRequiredWithoutFallbackAndValueNotSetProvidesAttachedNotEmptyValidatorIsEmptyErrorMessage(): void // phpcs:ignore
     {
-        $input = new Input();
+        $input = new FileInput();
         $input->setRequired(true);
 
         $customMessage = [
             NotEmptyValidator::IS_EMPTY => "Custom message",
         ];
 
-        $notEmpty = $this->createMock(NotEmptyValidator::class);
-        $notEmpty->expects(self::once())
-            ->method('getOption')
-            ->with('messageTemplates')
-            ->willReturn($customMessage);
-
-        $input->getValidatorChain()
-            ->attach($notEmpty);
+        $input->getValidatorChain()->attach(new NotEmptyValidator(['messages' => $customMessage]));
 
         self::assertFalse(
             $input->isValid(),

--- a/test/FileInput/PsrFileInputDecoratorTest.php
+++ b/test/FileInput/PsrFileInputDecoratorTest.php
@@ -551,21 +551,14 @@ final class PsrFileInputDecoratorTest extends TestCase
 
     public function testRequiredWithoutFallbackAndValueNotSetProvidesAttachedNotEmptyValidatorIsEmptyErrorMessage(): void // phpcs:ignore
     {
-        $input = new Input();
+        $input = new FileInput();
         $input->setRequired(true);
 
         $customMessage = [
             NotEmptyValidator::IS_EMPTY => "Custom message",
         ];
 
-        $notEmpty = $this->createMock(NotEmptyValidator::class);
-        $notEmpty->expects(self::once())
-            ->method('getOption')
-            ->with('messageTemplates')
-            ->willReturn($customMessage);
-
-        $input->getValidatorChain()
-            ->attach($notEmpty);
+        $input->getValidatorChain()->attach(new NotEmptyValidator(['messages' => $customMessage]));
 
         self::assertFalse(
             $input->isValid(),


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | yes
| QA            | yes

### Description

In Input->prepareRequiredValidationFailureMessage, use the logic in NotEmpty to build the error message and translate it where necessary, rather than extracting the message templates and translator from NotEmpty.

This makes prepareRequiredValidationFailureMessage less brittle to chages to NotEmpty internals, and removes deprecations for laminas-validator v3