### PR TITLE
Add FilterChain and ValidatorChain to the Input constructor

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -402,8 +402,6 @@
       <code><![CDATA[getFilters]]></code>
       <code><![CDATA[getPluginManager]]></code>
       <code><![CDATA[getPluginManager]]></code>
-      <code><![CDATA[getPluginManager]]></code>
-      <code><![CDATA[setPluginManager]]></code>
       <code><![CDATA[setPluginManager]]></code>
     </DeprecatedMethod>
     <PossiblyNullReference>
@@ -425,15 +423,7 @@
       <code><![CDATA[plugin]]></code>
     </DeprecatedMethod>
   </file>
-  <file src="test/InputFilterPluginManagerCompatibilityTest.php">
-    <InvalidReturnType>
-      <code><![CDATA[getInstanceOf]]></code>
-    </InvalidReturnType>
-  </file>
   <file src="test/InputFilterPluginManagerTest.php">
-    <DeprecatedMethod>
-      <code><![CDATA[getPluginManager]]></code>
-    </DeprecatedMethod>
     <LessSpecificReturnStatement>
       <code><![CDATA[[
             // Description         => [$serviceName,                  $service,                  $instanceOf]

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -7,15 +7,18 @@ namespace Laminas\InputFilter;
 use Laminas\Filter\FilterChain;
 use Laminas\Filter\FilterInterface;
 use Laminas\Filter\FilterPluginManager;
+use Laminas\ServiceManager\ServiceManager;
 use Laminas\Stdlib\ArrayUtils;
 use Laminas\Validator\ValidatorChain;
 use Laminas\Validator\ValidatorInterface;
 use Laminas\Validator\ValidatorPluginManager;
+use Psr\Container\ContainerInterface;
 use Traversable;
 
 use function assert;
 use function class_exists;
 use function get_debug_type;
+use function is_a;
 use function is_array;
 use function is_callable;
 use function is_int;
@@ -35,8 +38,35 @@ final class Factory
     protected ?FilterChain $defaultFilterChain;
     protected ?ValidatorChain $defaultValidatorChain;
 
+    public static function new(ContainerInterface|null $container = null): self
+    {
+        $container = $container ?? new ServiceManager();
+
+        if ($container->has(self::class)) {
+            return $container->get(self::class);
+        }
+
+        $factory = new Factory(
+            $container->has(FilterPluginManager::class)
+            ? $container->get(FilterPluginManager::class)
+            : new FilterPluginManager($container),
+            $container->has(ValidatorPluginManager::class)
+            ? $container->get(ValidatorPluginManager::class)
+            : new ValidatorPluginManager($container),
+            $container->has(InputFilterPluginManager::class)
+            ? $container->get(InputFilterPluginManager::class)
+            : new InputFilterPluginManager($container),
+        );
+
+        if ($container instanceof ServiceManager) {
+            $container->setService(self::class, $factory);
+        }
+
+        return $factory;
+    }
+
     public function __construct(
-        FilterPluginManager $filterPluginManager,
+        private readonly FilterPluginManager $filterPluginManager,
         private readonly ValidatorPluginManager $validatorPluginManager,
         private readonly InputFilterPluginManager $inputFilterPluginManager
     ) {
@@ -154,7 +184,19 @@ final class Factory
             ));
         }
 
-        $input = $managerInstance ?: new $class();
+        if (is_a($class, Input::class, true)) {
+            $filterChain = new FilterChain();
+            /** @psalm-suppress DeprecatedMethod removal will be done in Service Manager 4 upgrade */
+            $filterChain->setPluginManager($this->filterPluginManager);
+
+            $validatorChain = new ValidatorChain();
+            $validatorChain->setPluginManager($this->validatorPluginManager);
+
+            /** @psalm-suppress UnsafeInstantiation */
+            $input = $managerInstance ?: new $class($filterChain, $validatorChain);
+        } else {
+            $input = $managerInstance ?: new $class();
+        }
 
         if ($input instanceof InputFilterInterface) {
             return $this->createInputFilter($inputSpecification);

--- a/src/Input.php
+++ b/src/Input.php
@@ -28,17 +28,11 @@ class Input implements
     /** @var string|null */
     protected $errorMessage;
 
-    /** @var null|FilterChain */
-    protected $filterChain;
-
     /** @var bool */
     protected $notEmptyValidator = false;
 
     /** @var bool */
     protected $required = true;
-
-    /** @var null|ValidatorChain */
-    protected $validatorChain;
 
     /** @var mixed */
     protected $value;
@@ -56,9 +50,11 @@ class Input implements
     /** @var bool */
     protected $hasFallback = false;
 
-    /** @param null|string $name */
-    public function __construct(protected $name = null)
-    {
+    public function __construct(
+        protected FilterChain $filterChain,
+        protected ValidatorChain $validatorChain,
+        protected ?string $name = null
+    ) {
     }
 
     /**
@@ -218,14 +214,8 @@ class Input implements
         return $this->errorMessage;
     }
 
-    /**
-     * @return FilterChain
-     */
-    public function getFilterChain()
+    public function getFilterChain(): FilterChain
     {
-        if (! $this->filterChain) {
-            $this->filterChain = new FilterChain();
-        }
         return $this->filterChain;
     }
 
@@ -258,9 +248,6 @@ class Input implements
      */
     public function getValidatorChain()
     {
-        if (! $this->validatorChain) {
-            $this->validatorChain = new ValidatorChain();
-        }
         return $this->validatorChain;
     }
 

--- a/test/ArrayInputTest.php
+++ b/test/ArrayInputTest.php
@@ -45,12 +45,17 @@ final class ArrayInputTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->input = new ArrayInput('foo');
+        $this->input = new ArrayInput(TestHelper::createFilterChain(), TestHelper::createValidatorChain(), 'foo');
     }
 
     protected function tearDown(): void
     {
         AbstractValidator::setDefaultTranslator();
+    }
+
+    private function createArrayInput(?string $name = null): ArrayInput
+    {
+        return new ArrayInput(TestHelper::createFilterChain(), TestHelper::createValidatorChain(), $name);
     }
 
     /**
@@ -480,7 +485,7 @@ final class ArrayInputTest extends TestCase
 
     public function testRequiredWithoutFallbackAndValueNotSetProvidesAttachedNotEmptyValidatorIsEmptyErrorMessage(): void // phpcs:ignore
     {
-        $input = new ArrayInput();
+        $input = $this->createArrayInput();
         $input->setRequired(true);
 
         $customMessage = [
@@ -716,8 +721,8 @@ final class ArrayInputTest extends TestCase
 
     public function testMergingTwoInputsModifiesTheName(): void
     {
-        $a = new ArrayInput('a');
-        $b = new ArrayInput('b');
+        $a = $this->createArrayInput('a');
+        $b = $this->createArrayInput('b');
         $a->merge($b);
 
         self::assertSame('b', $a->getName());
@@ -725,8 +730,8 @@ final class ArrayInputTest extends TestCase
 
     public function testMergingTwoInputsModifiesErrorMessage(): void
     {
-        $a = new ArrayInput('a');
-        $b = new ArrayInput('b');
+        $a = $this->createArrayInput('a');
+        $b = $this->createArrayInput('b');
         $b->setErrorMessage('Foo');
         $a->merge($b);
 
@@ -735,9 +740,9 @@ final class ArrayInputTest extends TestCase
 
     public function testMergingTwoInputsModifiesBreakOnFailureFlag(): void
     {
-        $a = new ArrayInput('a');
+        $a = $this->createArrayInput('a');
         $a->setBreakOnFailure(false);
-        $b = new ArrayInput('b');
+        $b = $this->createArrayInput('b');
         $b->setBreakOnFailure(true);
         $a->merge($b);
 
@@ -746,9 +751,9 @@ final class ArrayInputTest extends TestCase
 
     public function testMergingTwoInputsModifiesRequiredFlag(): void
     {
-        $a = new ArrayInput('a');
+        $a = $this->createArrayInput('a');
         $a->setRequired(false);
-        $b = new ArrayInput('b');
+        $b = $this->createArrayInput('b');
         $b->setRequired(true);
         $a->merge($b);
 
@@ -757,9 +762,9 @@ final class ArrayInputTest extends TestCase
 
     public function testMergingTwoInputsModifiesAllowEmptyFlag(): void
     {
-        $a = new ArrayInput('a');
+        $a = $this->createArrayInput('a');
         $a->setAllowEmpty(false);
-        $b = new ArrayInput('b');
+        $b = $this->createArrayInput('b');
         $b->setAllowEmpty(true);
         $a->merge($b);
 
@@ -768,9 +773,9 @@ final class ArrayInputTest extends TestCase
 
     public function testMergingTwoInputsCopiesTheValueIfSet(): void
     {
-        $a = new ArrayInput('a');
+        $a = $this->createArrayInput('a');
         $a->setValue('a');
-        $b = new ArrayInput('b');
+        $b = $this->createArrayInput('b');
         $b->setValue('b');
         $a->merge($b);
 
@@ -782,8 +787,8 @@ final class ArrayInputTest extends TestCase
         $filter1 = new ToInt();
         $filter2 = new ToNull();
 
-        $a = new ArrayInput('a');
-        $b = new ArrayInput('b');
+        $a = $this->createArrayInput('a');
+        $b = $this->createArrayInput('b');
 
         $a->getFilterChain()->attach($filter1);
         $b->getFilterChain()->attach($filter2);
@@ -802,8 +807,8 @@ final class ArrayInputTest extends TestCase
         $validator1 = new NotEmptyValidator();
         $validator2 = new NumberComparison(['min' => 1, 'max' => 5]);
 
-        $a = new ArrayInput('a');
-        $b = new ArrayInput('b');
+        $a = $this->createArrayInput('a');
+        $b = $this->createArrayInput('b');
 
         $a->getValidatorChain()->attach($validator1);
         $b->getValidatorChain()->attach($validator2);
@@ -882,7 +887,7 @@ final class ArrayInputTest extends TestCase
      */
     public function testInputMergeWithoutValues(): void
     {
-        $source = new ArrayInput();
+        $source = $this->createArrayInput();
         $source->setContinueIfEmpty(true);
         self::assertFalse($source->hasValue(), 'Source should not have a value');
 
@@ -902,7 +907,7 @@ final class ArrayInputTest extends TestCase
      */
     public function testInputMergeWithSourceValue(): void
     {
-        $source = new ArrayInput();
+        $source = $this->createArrayInput();
         $source->setContinueIfEmpty(true);
         $source->setValue(['foo']);
 
@@ -923,7 +928,7 @@ final class ArrayInputTest extends TestCase
      */
     public function testInputMergeWithTargetValue(): void
     {
-        $source = new ArrayInput();
+        $source = $this->createArrayInput();
         $source->setContinueIfEmpty(true);
         self::assertFalse($source->hasValue(), 'Source should not have a value');
 

--- a/test/BaseInputFilterTest.php
+++ b/test/BaseInputFilterTest.php
@@ -50,6 +50,11 @@ class BaseInputFilterTest extends TestCase
         $this->inputFilter = new BaseInputFilter($this->factory);
     }
 
+    private function createInput(?string $name = null): Input
+    {
+        return new Input(TestHelper::createFilterChain(), TestHelper::createValidatorChain(), $name);
+    }
+
     public function testInputFilterIsEmptyByDefault(): void
     {
         $filter = $this->inputFilter;
@@ -81,7 +86,7 @@ class BaseInputFilterTest extends TestCase
     public function testReplaceWithInvalidInputTypeThrowsInvalidArgumentException(): void
     {
         $inputFilter = $this->inputFilter;
-        $inputFilter->add(new Input('foo'), 'replace_me');
+        $inputFilter->add($this->createInput('foo'), 'replace_me');
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage(
@@ -98,7 +103,10 @@ class BaseInputFilterTest extends TestCase
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('no input found matching "not exists"');
-        $inputFilter->replace(new Input('foo'), 'not exists');
+        $inputFilter->replace(
+            $this->createInput('foo'),
+            'not exists'
+        );
     }
 
     public function testGetValueThrowExceptionIfInputDoesNotExists(): void
@@ -268,7 +276,7 @@ class BaseInputFilterTest extends TestCase
     {
         $inputFilter = $this->inputFilter;
 
-        $foo = new Input('foo');
+        $foo = $this->createInput('foo');
         $inputFilter->add($foo, 'bas');
 
         $test = $inputFilter->get('bas');
@@ -284,7 +292,7 @@ class BaseInputFilterTest extends TestCase
     ): void {
         $inputFilter    = $this->inputFilter;
         $nameToReplace  = 'replace_me';
-        $inputToReplace = new Input($nameToReplace);
+        $inputToReplace = $this->createInput($nameToReplace);
 
         $inputFilter->add($inputToReplace);
         $currentNumberOfFilters = count($inputFilter);
@@ -402,7 +410,7 @@ class BaseInputFilterTest extends TestCase
         /** @var Input&MockObject $flatInput */
         $flatInput = $this->getMockBuilder(Input::class)
             ->enableProxyingToOriginalMethods()
-            ->setConstructorArgs(['flat'])
+            ->setConstructorArgs([TestHelper::createFilterChain(), TestHelper::createValidatorChain(), 'flat'])
             ->getMock();
         $flatInput->expects(self::once())
             ->method('setValue')
@@ -411,7 +419,7 @@ class BaseInputFilterTest extends TestCase
         /** @var Input&MockObject $resetInput */
         $resetInput = $this->getMockBuilder(Input::class)
             ->enableProxyingToOriginalMethods()
-            ->setConstructorArgs(['notSet'])
+            ->setConstructorArgs([TestHelper::createFilterChain(), TestHelper::createValidatorChain(), 'notSet'])
             ->getMock();
         $resetInput->expects(self::once())
             ->method('resetValue');
@@ -420,8 +428,14 @@ class BaseInputFilterTest extends TestCase
         $filter->add($flatInput);
         $filter->add($resetInput);
         $deepInputFilter = new BaseInputFilter($this->factory);
-        $deepInputFilter->add(new Input(), 'deep-input1');
-        $deepInputFilter->add(new Input(), 'deep-input2');
+        $deepInputFilter->add(
+            $this->createInput(),
+            'deep-input1'
+        );
+        $deepInputFilter->add(
+            $this->createInput(),
+            'deep-input2'
+        );
         $filter->add($deepInputFilter, 'deep');
         $filter->setData($data);
         $filter->setValidationGroup(['deep' => 'deep-input1']);
@@ -568,8 +582,8 @@ class BaseInputFilterTest extends TestCase
     {
         $filter = $this->inputFilter;
 
-        $foo = new Input('foo');
-        $bar = new Input('bar');
+        $foo = $this->createInput('foo');
+        $bar = $this->createInput('bar');
 
         $filter->add($foo);
         $filter->add($bar);
@@ -585,11 +599,11 @@ class BaseInputFilterTest extends TestCase
     {
         $filter = $this->inputFilter;
 
-        $foo1 = new Input('foo');
+        $foo1 = $this->createInput('foo');
         $foo1->setRequired(true);
         $filter->add($foo1);
 
-        $foo2 = new Input('foo');
+        $foo2 = $this->createInput('foo');
         $foo2->setRequired(false);
         $filter->add($foo2);
 
@@ -600,7 +614,7 @@ class BaseInputFilterTest extends TestCase
 
     public function testAddingAnInputFilterWithTheSameNameAsTheInputWillReplace(): void
     {
-        $input  = new Input('a');
+        $input  = $this->createInput('a');
         $filter = new InputFilter($this->factory);
 
         $this->inputFilter->add($input);
@@ -617,10 +631,10 @@ class BaseInputFilterTest extends TestCase
         $inputFilter       = $this->inputFilter;
         $originInputFilter = new BaseInputFilter($this->factory);
 
-        $inputFilter->add(new Input(), 'foo');
-        $inputFilter->add(new Input(), 'bar');
+        $inputFilter->add($this->createInput(), 'foo');
+        $inputFilter->add($this->createInput(), 'bar');
 
-        $originInputFilter->add(new Input(), 'baz');
+        $originInputFilter->add($this->createInput(), 'baz');
 
         $inputFilter->merge($originInputFilter);
 
@@ -639,7 +653,9 @@ class BaseInputFilterTest extends TestCase
         /** @psalm-var BaseInputFilter<array{nested: array{nestedField1: mixed}}> $filter1 */
         $filter1      = new BaseInputFilter($this->factory);
         $nestedFilter = new BaseInputFilter($this->factory);
-        $nestedFilter->add(new Input('nestedField1'));
+        $nestedFilter->add(
+            $this->createInput('nestedField1')
+        );
         $filter1->add($nestedFilter, 'nested');
 
         // non scalar and non null value
@@ -717,7 +733,7 @@ class BaseInputFilterTest extends TestCase
 
         /** @var BaseInputFilter $baseInputFilter */
         $baseInputFilter = (new BaseInputFilter($this->factory))
-            ->add(new Input(), 'bar')
+            ->add($this->createInput(), 'bar')
             ->setData($unfilteredArray);
 
         self::assertSame($unfilteredArray, $baseInputFilter->getUnfilteredData());

--- a/test/CollectionInputFilterTest.php
+++ b/test/CollectionInputFilterTest.php
@@ -285,7 +285,7 @@ final class CollectionInputFilterTest extends TestCase
         $firstCollection = new CollectionInputFilter($factory);
         $firstCollection->setInputFilter($firstInputFilter);
 
-        $someInput         = new Input('input');
+        $someInput         = new Input(TestHelper::createFilterChain(), TestHelper::createValidatorChain(), 'input');
         $secondInputFilter = new InputFilter($factory);
         $secondInputFilter->add($someInput, 'input');
 
@@ -809,7 +809,7 @@ final class CollectionInputFilterTest extends TestCase
         $factory = TestHelper::createInputFilterFactory();
 
         $baseInputFilter = (new BaseInputFilter($factory))
-            ->add(new Input(), 'bar');
+            ->add(new Input(TestHelper::createFilterChain(), TestHelper::createValidatorChain()), 'bar');
 
         $collectionInputFilter = (new CollectionInputFilter($this->factory))->setInputFilter($baseInputFilter);
         $collectionInputFilter->setData($unfilteredArray);

--- a/test/FactoryTest.php
+++ b/test/FactoryTest.php
@@ -17,7 +17,7 @@ use Laminas\InputFilter\InputFilterPluginManager;
 use Laminas\InputFilter\InputFilterProviderInterface;
 use Laminas\InputFilter\InputInterface;
 use Laminas\InputFilter\InputProviderInterface;
-use Laminas\ServiceManager;
+use Laminas\ServiceManager\ServiceManager;
 use Laminas\Validator;
 use Laminas\Validator\NotEmpty;
 use Laminas\Validator\ValidatorPluginManager;
@@ -208,8 +208,6 @@ final class FactoryTest extends TestCase
 
         $factory = $this->createDefaultFactory($pluginManager);
 
-//        $factory->setInputFilterManager($pluginManager);
-
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage(
             sprintf('"%s" can only set to inputs of type "Laminas\InputFilter\Input"', $specificationKey)
@@ -289,7 +287,7 @@ final class FactoryTest extends TestCase
         self::assertInstanceOf(InputInterface::class, $input);
         $inputFilterChain = $input->getFilterChain();
         self::assertNotSame($filterChain, $inputFilterChain);
-        self::assertSame($pluginManager, $inputFilterChain->getPluginManager());
+        self::assertSame($pluginManager, TestHelper::getFilterPluginManagerFromFilterChain($inputFilterChain));
     }
 
     public function testFactoryUsesComposedValidatorChainWhenCreatingNewInputObjects(): void
@@ -316,8 +314,9 @@ final class FactoryTest extends TestCase
         $filterPlugins    = new Filter\FilterPluginManager($smMock);
         $validatorPlugins = new Validator\ValidatorPluginManager($smMock);
         $filterChain      = new Filter\FilterChain();
-        $validatorChain   = new Validator\ValidatorChain();
+        /** @psalm-suppress DeprecatedMethod removal will be done in Service Manager 4 upgrade */
         $filterChain->setPluginManager($filterPlugins);
+        $validatorChain = new Validator\ValidatorChain();
         $validatorChain->setPluginManager($validatorPlugins);
         $factory->setDefaultFilterChain($filterChain);
         $factory->setDefaultValidatorChain($validatorChain);
@@ -478,7 +477,7 @@ final class FactoryTest extends TestCase
     public function testFactoryAcceptsInputInterface(): void
     {
         $factory = $this->createDefaultFactory();
-        $input   = new Input();
+        $input   = new Input(TestHelper::createFilterChain(), TestHelper::createValidatorChain());
 
         $inputFilter = $factory->createInputFilter([
             'foo' => $input,
@@ -505,7 +504,17 @@ final class FactoryTest extends TestCase
 
     public function testFactoryWillCreateInputFilterAndAllInputObjectsFromGivenConfiguration(): void
     {
-        $factory     = $this->createDefaultFactory();
+        $serviceManager           = new ServiceManager();
+        $inputFilterPluginManager = new InputFilterPluginManager($serviceManager);
+        $inputFilterPluginManager->setFactory(
+            CustomInput::class,
+            fn () => new CustomInput(TestHelper::createFilterChain(), TestHelper::createValidatorChain())
+        );
+
+        $serviceManager->setService(InputFilterPluginManager::class, $inputFilterPluginManager);
+
+        $factory = Factory::new($serviceManager);
+
         $inputFilter = $factory->createInputFilter([
             'foo'  => [
                 'name'       => 'foo',
@@ -647,7 +656,9 @@ final class FactoryTest extends TestCase
     {
         $factory = $this->createDefaultFactory();
         $chain   = new Filter\FilterChain();
-        $input   = $factory->createInput([
+        /** @psalm-suppress DeprecatedMethod removal will be done in Service Manager 4 upgrade */
+        $chain->setPluginManager(TestHelper::createFilterPluginManager());
+        $input = $factory->createInput([
             'name'    => 'foo',
             'filters' => $chain,
         ]);
@@ -818,7 +829,7 @@ final class FactoryTest extends TestCase
 
     public function testSetInputFilterManagerWithServiceManager(): void
     {
-        $serviceManager         = new ServiceManager\ServiceManager();
+        $serviceManager         = new ServiceManager();
         $inputFilterManager     = new InputFilterPluginManager($serviceManager);
         $validatorPluginManager = new Validator\ValidatorPluginManager($serviceManager);
         $filterPluginManager    = new Filter\FilterPluginManager($serviceManager);
@@ -911,9 +922,12 @@ final class FactoryTest extends TestCase
 
     public function testSuggestedTypeMayBePluginNameInInputFilterPluginManager(): void
     {
-        $serviceManager = new ServiceManager\ServiceManager();
+        $serviceManager = new ServiceManager();
         $pluginManager  = new InputFilterPluginManager($serviceManager);
-        $pluginManager->setService('bar', new Input('bar'));
+        $pluginManager->setService(
+            'bar',
+            new Input(TestHelper::createFilterChain(), TestHelper::createValidatorChain(), 'bar')
+        );
         $factory = new Factory(
             new FilterPluginManager($serviceManager),
             new ValidatorPluginManager($serviceManager),
@@ -930,14 +944,16 @@ final class FactoryTest extends TestCase
 
     public function testInputFromPluginManagerMayBeFurtherConfiguredWithSpec(): void
     {
-        $serviceManager = new ServiceManager\ServiceManager();
+        $serviceManager = new ServiceManager();
         $pluginManager  = new InputFilterPluginManager($serviceManager);
-        $pluginManager->setService('bar', $barInput = new Input('bar'));
-        $factory = new Factory(
-            new FilterPluginManager($serviceManager),
-            new ValidatorPluginManager($serviceManager),
-            $pluginManager
+        $pluginManager->setService(
+            'bar',
+            $barInput   = new Input(TestHelper::createFilterChain(), TestHelper::createValidatorChain(), 'bar')
         );
+
+        $serviceManager->setService(InputFilterPluginManager::class, $pluginManager);
+
+        $factory = Factory::new($serviceManager);
         self::assertTrue($barInput->isRequired());
 
         $input = $factory->createInput([
@@ -1035,22 +1051,31 @@ final class FactoryTest extends TestCase
 
     public function testWhenCreateInputPullsInputFromThePluginManagerItMustNotOverwriteFilterAndValidatorChains(): void
     {
-        $input          = new Input();
-        $filterChain    = new Filter\FilterChain();
+        $serviceManager      = new ServiceManager();
+        $filterPluginManager = new FilterPluginManager($serviceManager);
+
+        $filterChain = new Filter\FilterChain();
+        /** @psalm-suppress DeprecatedMethod removal will be done in Service Manager 4 upgrade */
+        $filterChain->setPluginManager($filterPluginManager);
+
         $validatorChain = new Validator\ValidatorChain();
+
+        $input = new Input($filterChain, $validatorChain);
         $input->setFilterChain($filterChain);
         $input->setValidatorChain($validatorChain);
 
-        $serviceManager = new ServiceManager\ServiceManager();
-        $pluginManager  = new InputFilterPluginManager($serviceManager);
-        $pluginManager->setService('Some\Test\Input', $input);
+        $inputFilterPluginManager = new InputFilterPluginManager($serviceManager);
+        $inputFilterPluginManager->setService('Some\Test\Input', $input);
 
-        $factory               = new Factory(
+        $factory = new Factory(
             new FilterPluginManager($serviceManager),
             new ValidatorPluginManager($serviceManager),
-            $pluginManager
+            $inputFilterPluginManager
         );
-        $defaultFilterChain    = new Filter\FilterChain();
+
+        $defaultFilterChain = new Filter\FilterChain();
+        /** @psalm-suppress DeprecatedMethod removal will be done in Service Manager 4 upgrade */
+        $defaultFilterChain->setPluginManager($filterPluginManager);
         $defaultValidatorChain = new Validator\ValidatorChain();
         $factory->setDefaultFilterChain($defaultFilterChain);
         $factory->setDefaultValidatorChain($defaultValidatorChain);
@@ -1090,7 +1115,7 @@ final class FactoryTest extends TestCase
 
     protected function createDefaultFactory(?InputFilterPluginManager $inputFilterPluginManager = null): Factory
     {
-        $serviceManager = new ServiceManager\ServiceManager();
+        $serviceManager = new ServiceManager();
 
         $factory = new Factory(
             new FilterPluginManager($serviceManager),

--- a/test/FileInput/FileInputTest.php
+++ b/test/FileInput/FileInputTest.php
@@ -52,7 +52,7 @@ final class FileInputTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->input = new FileInput('foo');
+        $this->input = $this->createFileInput('foo');
         // Upload validator does not work in CLI test environment, disable
         $this->input->setAutoPrependUploadValidator(false);
     }
@@ -60,6 +60,11 @@ final class FileInputTest extends TestCase
     protected function tearDown(): void
     {
         AbstractValidator::setDefaultTranslator();
+    }
+
+    private function createFileInput(?string $name = null): FileInput
+    {
+        return new FileInput(TestHelper::createFilterChain(), TestHelper::createValidatorChain(), $name);
     }
 
     #[DataProvider('validSingleValueProvider')]
@@ -123,7 +128,7 @@ final class FileInputTest extends TestCase
 
     public function testAutoPrependUploadValidatorIsOnByDefault(): void
     {
-        $input = new FileInput('foo');
+        $input = $this->createFileInput('foo');
         self::assertTrue($input->getAutoPrependUploadValidator());
     }
 
@@ -227,7 +232,7 @@ final class FileInputTest extends TestCase
 
     public function testDefaultInjectedUploadValidatorRespectsRelease2Convention(): void
     {
-        $input          = new FileInput('foo');
+        $input          = $this->createFileInput('foo');
         $validatorChain = $input->getValidatorChain();
         $pluginManager  = $validatorChain->getPluginManager();
         $pluginManager->setInvokableClass(UploadValidator::class, TestAsset\FileUploadMock::class);
@@ -241,7 +246,7 @@ final class FileInputTest extends TestCase
      */
     public function testFileInputMerge(): void
     {
-        $source = new FileInput();
+        $source = $this->createFileInput();
         $source->setAutoPrependUploadValidator(true);
 
         $target = $this->input;
@@ -411,7 +416,7 @@ final class FileInputTest extends TestCase
 
     public function testRequiredWithoutFallbackAndValueNotSetProvidesAttachedNotEmptyValidatorIsEmptyErrorMessage(): void // phpcs:ignore
     {
-        $input = new FileInput();
+        $input = $this->createFileInput();
         $input->setRequired(true);
 
         $customMessage = [
@@ -568,8 +573,8 @@ final class FileInputTest extends TestCase
 
     public function testMergingTwoInputsModifiesTheName(): void
     {
-        $a = new FileInput('a');
-        $b = new FileInput('b');
+        $a = $this->createFileInput('a');
+        $b = $this->createFileInput('b');
         $a->merge($b);
 
         self::assertSame('b', $a->getName());
@@ -577,8 +582,8 @@ final class FileInputTest extends TestCase
 
     public function testMergingTwoInputsModifiesErrorMessage(): void
     {
-        $a = new FileInput('a');
-        $b = new FileInput('b');
+        $a = $this->createFileInput('a');
+        $b = $this->createFileInput('b');
         $b->setErrorMessage('Foo');
         $a->merge($b);
 
@@ -587,9 +592,9 @@ final class FileInputTest extends TestCase
 
     public function testMergingTwoInputsModifiesBreakOnFailureFlag(): void
     {
-        $a = new FileInput('a');
+        $a = $this->createFileInput('a');
         $a->setBreakOnFailure(false);
-        $b = new FileInput('b');
+        $b = $this->createFileInput('b');
         $b->setBreakOnFailure(true);
         $a->merge($b);
 
@@ -598,9 +603,9 @@ final class FileInputTest extends TestCase
 
     public function testMergingTwoInputsModifiesRequiredFlag(): void
     {
-        $a = new FileInput('a');
+        $a = $this->createFileInput('a');
         $a->setRequired(false);
-        $b = new FileInput('b');
+        $b = $this->createFileInput('b');
         $b->setRequired(true);
         $a->merge($b);
 
@@ -609,9 +614,9 @@ final class FileInputTest extends TestCase
 
     public function testMergingTwoInputsModifiesAllowEmptyFlag(): void
     {
-        $a = new FileInput('a');
+        $a = $this->createFileInput('a');
         $a->setAllowEmpty(false);
-        $b = new FileInput('b');
+        $b = $this->createFileInput('b');
         $b->setAllowEmpty(true);
         $a->merge($b);
 
@@ -621,9 +626,9 @@ final class FileInputTest extends TestCase
     /** @psalm-suppress InvalidArgument */
     public function testMergingTwoInputsCopiesTheValueIfSet(): void
     {
-        $a = new FileInput('a');
+        $a = $this->createFileInput('a');
         $a->setValue('a');
-        $b = new FileInput('b');
+        $b = $this->createFileInput('b');
         $b->setValue('b');
         $a->merge($b);
 
@@ -635,8 +640,8 @@ final class FileInputTest extends TestCase
         $filter1 = new ToInt();
         $filter2 = new ToNull();
 
-        $a = new FileInput('a');
-        $b = new FileInput('b');
+        $a = $this->createFileInput('a');
+        $b = $this->createFileInput('b');
 
         $a->getFilterChain()->attach($filter1);
         $b->getFilterChain()->attach($filter2);
@@ -655,8 +660,8 @@ final class FileInputTest extends TestCase
         $validator1 = new NotEmptyValidator();
         $validator2 = new NumberComparison(['min' => 1, 'max' => 5]);
 
-        $a = new FileInput('a');
-        $b = new FileInput('b');
+        $a = $this->createFileInput('a');
+        $b = $this->createFileInput('b');
 
         $a->getValidatorChain()->attach($validator1);
         $b->getValidatorChain()->attach($validator2);
@@ -737,7 +742,7 @@ final class FileInputTest extends TestCase
      */
     public function testInputMergeWithoutValues(): void
     {
-        $source = new FileInput();
+        $source = $this->createFileInput();
         $source->setContinueIfEmpty(true);
         self::assertFalse($source->hasValue(), 'Source should not have a value');
 
@@ -757,7 +762,7 @@ final class FileInputTest extends TestCase
      */
     public function testInputMergeWithSourceValue(): void
     {
-        $source = new FileInput();
+        $source = $this->createFileInput();
         $source->setContinueIfEmpty(true);
         $source->setValue(['foo']);
 
@@ -778,7 +783,7 @@ final class FileInputTest extends TestCase
      */
     public function testInputMergeWithTargetValue(): void
     {
-        $source = new FileInput();
+        $source = $this->createFileInput();
         $source->setContinueIfEmpty(true);
         self::assertFalse($source->hasValue(), 'Source should not have a value');
 
@@ -818,18 +823,19 @@ final class FileInputTest extends TestCase
 
     public function testUploadValidatorIsAddedDuringIsValidWhenAutoPrependUploadValidatorIsEnabled(): void
     {
-        $this->input->setAutoPrependUploadValidator(true);
-        self::assertTrue($this->input->getAutoPrependUploadValidator());
-        self::assertTrue($this->input->isRequired());
+        $input = new FileInput(new FilterChain(), new ValidatorChain());
+        $input->setAutoPrependUploadValidator(true);
+        self::assertTrue($input->getAutoPrependUploadValidator());
+        self::assertTrue($input->isRequired());
 
         $uploadedFile = new UploadedFileInterfaceStub(UPLOAD_ERR_NO_FILE);
 
-        $this->input->setValue($uploadedFile);
+        $input->setValue($uploadedFile);
 
-        $validatorChain = $this->input->getValidatorChain();
+        $validatorChain = $input->getValidatorChain();
         self::assertCount(0, $validatorChain->getValidators());
 
-        self::assertFalse($this->input->isValid());
+        self::assertFalse($input->isValid());
         $validators = $validatorChain->getValidators();
         self::assertCount(1, $validators);
         self::assertInstanceOf(Validator\File\UploadFile::class, $validators[0]['instance']);
@@ -858,7 +864,7 @@ final class FileInputTest extends TestCase
      */
     public function testPsrFileInputMerge(): void
     {
-        $source = new FileInput();
+        $source = $this->createFileInput();
         $source->setAutoPrependUploadValidator(true);
 
         $target = $this->input;

--- a/test/InputFilterPluginManagerCompatibilityTest.php
+++ b/test/InputFilterPluginManagerCompatibilityTest.php
@@ -22,7 +22,7 @@ final class InputFilterPluginManagerCompatibilityTest extends TestCase
         $this->markTestSkipped("InputFilterPluginManager accepts multiple instances");
     }
 
-    protected static function getPluginManager(): InputFilterPluginManager
+    protected static function getPluginManager(array $config = []): InputFilterPluginManager
     {
         $serviceManager = new ServiceManager();
         $serviceManager->setService(
@@ -42,8 +42,9 @@ final class InputFilterPluginManagerCompatibilityTest extends TestCase
         return RuntimeException::class;
     }
 
-    protected function getInstanceOf()
+    protected function getInstanceOf(): string
     {
         // InputFilterManager accepts multiple instance types
+        return InputFilterPluginManager::class;
     }
 }

--- a/test/InputFilterPluginManagerFactoryTest.php
+++ b/test/InputFilterPluginManagerFactoryTest.php
@@ -13,7 +13,6 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Depends;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
-use ReflectionObject;
 
 final class InputFilterPluginManagerFactoryTest extends TestCase
 {
@@ -24,10 +23,6 @@ final class InputFilterPluginManagerFactoryTest extends TestCase
 
         $filters = $factory($container, InputFilterPluginManagerFactory::class);
         self::assertInstanceOf(InputFilterPluginManager::class, $filters);
-
-        $r = new ReflectionObject($filters);
-        $p = $r->getProperty('creationContext');
-        self::assertSame($container, $p->getValue($filters));
     }
 
     /** @psalm-return array<string, array{0: class-string}> */

--- a/test/InputFilterPluginManagerTest.php
+++ b/test/InputFilterPluginManagerTest.php
@@ -125,7 +125,7 @@ final class InputFilterPluginManagerTest extends TestCase
         self::assertInstanceOf(FilterChain::class, $defaultFilterChain);
         self::assertSame(
             $filterManager,
-            $defaultFilterChain->getPluginManager(),
+            TestHelper::getFilterPluginManagerFromFilterChain($defaultFilterChain),
             'Factory::getDefaultFilterChain() is not populated with the expected plugin manager'
         );
 

--- a/test/InputFilterTest.php
+++ b/test/InputFilterTest.php
@@ -87,8 +87,8 @@ final class InputFilterTest extends BaseInputFilterTest
 
     public function testInputsWithoutANameYieldMergedInputsWithAnEmptyName(): void
     {
-        $a = new Input();
-        $b = new Input();
+        $a = new Input(TestHelper::createFilterChain(), TestHelper::createValidatorChain());
+        $b = new Input(TestHelper::createFilterChain(), TestHelper::createValidatorChain());
 
         $filter = new InputFilter(
             $this->factory

--- a/test/InputTest.php
+++ b/test/InputTest.php
@@ -39,12 +39,17 @@ final class InputTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->input = new Input('foo');
+        $this->input = $this->createInput('foo');
     }
 
     protected function tearDown(): void
     {
         AbstractValidator::setDefaultTranslator(null);
+    }
+
+    private function createInput(?string $name = null): Input
+    {
+        return new Input(TestHelper::createFilterChain(), TestHelper::createValidatorChain(), $name);
     }
 
     public function assertRequiredValidationErrorMessage(Input $input, string $message = ''): void
@@ -258,7 +263,7 @@ final class InputTest extends TestCase
 
     public function testRequiredWithoutFallbackAndValueNotSetProvidesAttachedNotEmptyValidatorIsEmptyErrorMessage(): void // phpcs:ignore
     {
-        $input = new Input();
+        $input = $this->createInput();
         $input->setRequired(true);
 
         $customMessage = [
@@ -499,8 +504,8 @@ final class InputTest extends TestCase
 
     public function testMergingTwoInputsModifiesTheName(): void
     {
-        $a = new Input('a');
-        $b = new Input('b');
+        $a = $this->createInput('a');
+        $b = $this->createInput('b');
         $a->merge($b);
 
         self::assertSame('b', $a->getName());
@@ -508,8 +513,8 @@ final class InputTest extends TestCase
 
     public function testMergingTwoInputsModifiesErrorMessage(): void
     {
-        $a = new Input('a');
-        $b = new Input('b');
+        $a = $this->createInput('a');
+        $b = $this->createInput('b');
         $b->setErrorMessage('Foo');
         $a->merge($b);
 
@@ -518,9 +523,9 @@ final class InputTest extends TestCase
 
     public function testMergingTwoInputsModifiesBreakOnFailureFlag(): void
     {
-        $a = new Input('a');
+        $a = $this->createInput('a');
         $a->setBreakOnFailure(false);
-        $b = new Input('b');
+        $b = $this->createInput('b');
         $b->setBreakOnFailure(true);
         $a->merge($b);
 
@@ -529,9 +534,9 @@ final class InputTest extends TestCase
 
     public function testMergingTwoInputsModifiesRequiredFlag(): void
     {
-        $a = new Input('a');
+        $a = $this->createInput('a');
         $a->setRequired(false);
-        $b = new Input('b');
+        $b = $this->createInput('b');
         $b->setRequired(true);
         $a->merge($b);
 
@@ -540,9 +545,9 @@ final class InputTest extends TestCase
 
     public function testMergingTwoInputsModifiesAllowEmptyFlag(): void
     {
-        $a = new Input('a');
+        $a = $this->createInput('a');
         $a->setAllowEmpty(false);
-        $b = new Input('b');
+        $b = $this->createInput('b');
         $b->setAllowEmpty(true);
         $a->merge($b);
 
@@ -551,9 +556,9 @@ final class InputTest extends TestCase
 
     public function testMergingTwoInputsCopiesTheValueIfSet(): void
     {
-        $a = new Input('a');
+        $a = $this->createInput('a');
         $a->setValue('a');
-        $b = new Input('b');
+        $b = $this->createInput('b');
         $b->setValue('b');
         $a->merge($b);
 
@@ -565,8 +570,8 @@ final class InputTest extends TestCase
         $filter1 = new ToInt();
         $filter2 = new ToNull();
 
-        $a = new Input('a');
-        $b = new Input('b');
+        $a = $this->createInput('a');
+        $b = $this->createInput('b');
 
         $a->getFilterChain()->attach($filter1);
         $b->getFilterChain()->attach($filter2);
@@ -585,8 +590,8 @@ final class InputTest extends TestCase
         $validator1 = new NotEmptyValidator();
         $validator2 = new NumberComparison(['min' => 1, 'max' => 5]);
 
-        $a = new Input('a');
-        $b = new Input('b');
+        $a = $this->createInput('a');
+        $b = $this->createInput('b');
 
         $a->getValidatorChain()->attach($validator1);
         $b->getValidatorChain()->attach($validator2);
@@ -668,7 +673,7 @@ final class InputTest extends TestCase
      */
     public function testInputMergeWithoutValues(): void
     {
-        $source = new Input();
+        $source = $this->createInput();
         $source->setContinueIfEmpty(true);
         self::assertFalse($source->hasValue(), 'Source should not have a value');
 
@@ -688,7 +693,7 @@ final class InputTest extends TestCase
      */
     public function testInputMergeWithSourceValue(): void
     {
-        $source = new Input();
+        $source = $this->createInput();
         $source->setContinueIfEmpty(true);
         $source->setValue(['foo']);
 
@@ -709,7 +714,7 @@ final class InputTest extends TestCase
      */
     public function testInputMergeWithTargetValue(): void
     {
-        $source = new Input();
+        $source = $this->createInput();
         $source->setContinueIfEmpty(true);
         self::assertFalse($source->hasValue(), 'Source should not have a value');
 

--- a/test/OptionalInputFilterTest.php
+++ b/test/OptionalInputFilterTest.php
@@ -95,7 +95,9 @@ final class OptionalInputFilterTest extends TestCase
     {
         $optionalInputFilter = new OptionalInputFilter(TestHelper::createInputFilterFactory());
 
-        $optionalInputFilter->add(new Input('brand'));
+        $optionalInputFilter->add(
+            new Input(TestHelper::createFilterChain(), TestHelper::createValidatorChain(), 'brand')
+        );
 
         $optionalInputFilter->setData(['model' => 'Golf']);
         self::assertFalse($optionalInputFilter->isValid());
@@ -127,8 +129,12 @@ final class OptionalInputFilterTest extends TestCase
         if (! $this->nestedCarInputFilter) {
             /** @var OptionalInputFilter<array{brand: mixed, model:mixed}> $optionalInputFilter */
             $optionalInputFilter = new OptionalInputFilter($factory);
-            $optionalInputFilter->add(new Input('brand'));
-            $optionalInputFilter->add(new Input('model'));
+            $optionalInputFilter->add(
+                new Input(TestHelper::createFilterChain(), TestHelper::createValidatorChain(), 'brand')
+            );
+            $optionalInputFilter->add(
+                new Input(TestHelper::createFilterChain(), TestHelper::createValidatorChain(), 'model')
+            );
 
             $this->nestedCarInputFilter = new InputFilter($factory);
             $this->nestedCarInputFilter->add($optionalInputFilter, 'car');

--- a/test/TestHelper.php
+++ b/test/TestHelper.php
@@ -13,6 +13,8 @@ use Laminas\Validator\ValidatorChain;
 use Laminas\Validator\ValidatorInterface;
 use Laminas\Validator\ValidatorPluginManager;
 use LaminasTest\InputFilter\TestAsset\ValidatorStub;
+use Psr\Container\ContainerInterface;
+use ReflectionProperty;
 
 final class TestHelper
 {
@@ -21,14 +23,30 @@ final class TestHelper
         $serviceManager = new ServiceManager();
 
         $factory = new Factory(
-            new FilterPluginManager($serviceManager),
-            new ValidatorPluginManager($serviceManager),
+            self::createFilterPluginManager($serviceManager),
+            self::createValidatorPluginManager($serviceManager),
             new InputFilterPluginManager($serviceManager)
         );
 
         $serviceManager->setService(Factory::class, $factory);
 
         return $factory;
+    }
+
+    public static function createFilterPluginManager(ContainerInterface|null $container = null): FilterPluginManager
+    {
+        return new FilterPluginManager($container ?? new ServiceManager());
+    }
+
+    public static function createValidatorPluginManager(
+        ContainerInterface|null $container = null
+    ): ValidatorPluginManager {
+        return new ValidatorPluginManager($container ?? new ServiceManager());
+    }
+
+    public static function getFilterPluginManagerFromFilterChain(FilterChain $filterChain): mixed
+    {
+        return (new ReflectionProperty(FilterChain::class, 'plugins'))->getValue($filterChain);
     }
 
     /** @param array<string, string> $messages */
@@ -41,19 +59,30 @@ final class TestHelper
         return new ValidatorStub($isValid, $value, $context, $messages);
     }
 
-    public static function createValidatorChain(mixed $value, bool $isValid): ValidatorChain
+    public static function createValidatorChain(mixed $value = null, bool $isValid = true): ValidatorChain
     {
-        return (new ValidatorChain())->attach(self::createValidatorMock($isValid, $value));
+        $validatorChain = new ValidatorChain();
+        $validatorChain->setPluginManager(self::createValidatorPluginManager());
+        if ($value !== null) {
+            $validatorChain->attach(self::createValidatorMock($isValid, $value));
+        }
+
+        return $validatorChain;
     }
 
     public static function createFilterChain(): FilterChain
     {
-        return new FilterChain();
+        $filterChain = new FilterChain();
+        /** @psalm-suppress DeprecatedMethod removal will be done in Service Manager 4 upgrade */
+        $filterChain->setPluginManager(self::createFilterPluginManager());
+        return $filterChain;
     }
 
     public static function createFilterChainFixture(mixed $originalValue, mixed $filteredValue): FilterChain
     {
         $filterChain = new FilterChain();
+        /** @psalm-suppress DeprecatedMethod removal will be done in Service Manager 4 upgrade */
+        $filterChain->setPluginManager(self::createFilterPluginManager());
 
         $filterChain->attach(
             fn(mixed $value): mixed => $value === $originalValue ? $filteredValue : $value,
@@ -66,6 +95,8 @@ final class TestHelper
     public static function createFilterChainFixtureFromMap(array $valueMap): FilterChain
     {
         $filterChain = new FilterChain();
+        /** @psalm-suppress DeprecatedMethod removal will be done in Service Manager 4 upgrade */
+        $filterChain->setPluginManager(self::createFilterPluginManager());
 
         foreach ($valueMap as $values) {
             $filterChain->attach(

--- a/test/ValidationGroup/InputFilterCollectionsValidationGroupTest.php
+++ b/test/ValidationGroup/InputFilterCollectionsValidationGroupTest.php
@@ -28,9 +28,9 @@ final class InputFilterCollectionsValidationGroupTest extends TestCase
         $collection = new CollectionInputFilter($factory);
         $collection->setIsRequired(true);
 
-        $first = new Input('first');
+        $first = new Input(TestHelper::createFilterChain(), TestHelper::createValidatorChain(), 'first');
         $first->setRequired(true);
-        $second = new Input('second');
+        $second = new Input(TestHelper::createFilterChain(), TestHelper::createValidatorChain(), 'second');
         $second->setRequired(true);
 
         $nestedFilter = new InputFilter($factory);

--- a/test/ValidationGroup/InputFilterStringValidationGroupTest.php
+++ b/test/ValidationGroup/InputFilterStringValidationGroupTest.php
@@ -18,13 +18,13 @@ final class InputFilterStringValidationGroupTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $first = new Input('first');
+        $first = new Input(TestHelper::createFilterChain(), TestHelper::createValidatorChain(), 'first');
         $first->setRequired(true);
         $first->getValidatorChain()->attach(new StringLength(['min' => 5]));
-        $second = new Input('second');
+        $second = new Input(TestHelper::createFilterChain(), TestHelper::createValidatorChain(), 'second');
         $second->setRequired(true);
         $second->getValidatorChain()->attach(new StringLength(['min' => 5]));
-        $third = new Input('third');
+        $third = new Input(TestHelper::createFilterChain(), TestHelper::createValidatorChain(), 'third');
         $third->setRequired(true);
         $third->getValidatorChain()->attach(new StringLength(['min' => 5]));
 


### PR DESCRIPTION
Raised as draft as #143 will need to be merged first to avoid conflict

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | yes
| New Feature   | no
| RFC           | yes
| QA            | yes

### Description

This is required in laminas/laminas-filter v3 to construct the default FilterChain
