### PR TITLE
Remove use of deprecated NotEmpty->getOption

### DIFF
--- a/test/ArrayInputTest.php
+++ b/test/ArrayInputTest.php
@@ -41,6 +41,9 @@ use const JSON_THROW_ON_ERROR;
 #[CoversClass(ArrayInput::class)]
 final class ArrayInputTest extends TestCase
 {
+    private const EMPTY_ERROR_MESSAGE_KEY = 'isEmpty';
+    private const EMPTY_ERROR_MESSAGE     = 'Value is required and can\'t be empty';
+
     private ArrayInput $input;
 
     protected function setUp(): void
@@ -277,17 +280,12 @@ final class ArrayInputTest extends TestCase
         $message  = $message ?: 'Expected failure message for required input';
         $message .= ';';
 
-        $expectedKey = NotEmptyValidator::IS_EMPTY;
-        $messages    = $input->getMessages();
-        self::assertArrayHasKey($expectedKey, $messages);
+        $messages = $input->getMessages();
 
-        $notEmpty         = new NotEmptyValidator();
-        $messageTemplates = $notEmpty->getOption('messageTemplates');
-        self::assertIsArray($messageTemplates);
-        self::assertArrayHasKey($expectedKey, $messageTemplates);
+        self::assertArrayHasKey(self::EMPTY_ERROR_MESSAGE_KEY, $messages);
         self::assertEquals(
-            $messageTemplates[$expectedKey],
-            $messages[$expectedKey],
+            self::EMPTY_ERROR_MESSAGE,
+            $messages[self::EMPTY_ERROR_MESSAGE_KEY],
             $message . ' missing NotEmpty::IS_EMPTY key and/or contains additional messages'
         );
         self::assertCount(
@@ -488,11 +486,8 @@ final class ArrayInputTest extends TestCase
         $input = $this->createArrayInput();
         $input->setRequired(true);
 
-        $customMessage = [
-            NotEmptyValidator::IS_EMPTY => "Custom message",
-        ];
-
-        $notEmpty = new NotEmptyValidator(['messages' => $customMessage]);
+        $customMessage = [NotEmptyValidator::IS_EMPTY => "Custom message"];
+        $notEmpty      = new NotEmptyValidator(['messages' => $customMessage]);
 
         $input->getValidatorChain()
             ->attach($notEmpty);
@@ -619,7 +614,7 @@ final class ArrayInputTest extends TestCase
 
         self::assertFalse($this->input->isValid());
         $messages = $this->input->getMessages();
-        self::assertArrayHasKey('isEmpty', $messages);
+        self::assertArrayHasKey(self::EMPTY_ERROR_MESSAGE_KEY, $messages);
         self::assertEquals(1, count($validatorChain->getValidators()));
 
         // Assert that NotEmpty validator wasn't added again
@@ -952,18 +947,17 @@ final class ArrayInputTest extends TestCase
          */
         $translator = $this->createMock(TranslatorInterface::class);
         AbstractValidator::setDefaultTranslator($translator);
-        $notEmpty = new NotEmptyValidator();
 
         $translatedMessage = 'some translation';
         $translator->expects(self::atLeastOnce())
             ->method('translate')
-            ->with($notEmpty->getMessageTemplates()[NotEmptyValidator::IS_EMPTY])
+            ->with(self::EMPTY_ERROR_MESSAGE, 'default')
             ->willReturn($translatedMessage);
 
         self::assertFalse($this->input->isValid());
         $messages = $this->input->getMessages();
-        self::assertArrayHasKey('isEmpty', $messages);
-        self::assertSame($translatedMessage, $messages['isEmpty']);
+        self::assertArrayHasKey(self::EMPTY_ERROR_MESSAGE_KEY, $messages);
+        self::assertSame($translatedMessage, $messages[self::EMPTY_ERROR_MESSAGE_KEY]);
     }
 
     /**
@@ -996,7 +990,7 @@ final class ArrayInputTest extends TestCase
         $nonEmptyValues = array_diff_key($allValues, $emptyValues);
 
         $validatorMsg = ['FooValidator' => 'Invalid Value'];
-        $notEmptyMsg  = ['isEmpty' => "Value is required and can't be empty"];
+        $notEmptyMsg  = [self::EMPTY_ERROR_MESSAGE_KEY => "Value is required and can't be empty"];
 
         $validatorNotCall = fn(mixed $value, array|null $context = null): ValidatorInterface =>
         TestHelper::createValidatorMock(null, $value, $context);

--- a/test/CollectionInputFilterTest.php
+++ b/test/CollectionInputFilterTest.php
@@ -38,6 +38,9 @@ use const JSON_THROW_ON_ERROR;
 #[CoversClass(CollectionInputFilter::class)]
 final class CollectionInputFilterTest extends TestCase
 {
+    private const EMPTY_ERROR_MESSAGE_KEY = 'isEmpty';
+    private const EMPTY_ERROR_MESSAGE     = 'Value is required and can\'t be empty';
+
     private CollectionInputFilter $inputFilter;
     private Factory $factory;
 
@@ -208,7 +211,7 @@ final class CollectionInputFilterTest extends TestCase
                     [],
                     [],
                     false,
-                    [['isEmpty' => 'Value is required and can\'t be empty']],
+                    [[self::EMPTY_ERROR_MESSAGE_KEY => self::EMPTY_ERROR_MESSAGE]],
                 ],
             'Required: F, Data: [], Valid: X'
                 => [! $isRequired, null, [], $noValidIf(), [], [], true, []],
@@ -578,11 +581,11 @@ final class CollectionInputFilterTest extends TestCase
 
         self::assertArrayHasKey('phone', $messages[0]);
         self::assertCount(1, $messages[0]['phone']);
-        self::assertContains('Value is required and can\'t be empty', $messages[0]['phone']);
+        self::assertContains(self::EMPTY_ERROR_MESSAGE, $messages[0]['phone']);
 
         self::assertArrayHasKey('phone', $messages[1]);
         self::assertCount(1, $messages[1]['phone']);
-        self::assertNotContains('Value is required and can\'t be empty', $messages[1]['phone']);
+        self::assertNotContains(self::EMPTY_ERROR_MESSAGE, $messages[1]['phone']);
         self::assertContains('The input must contain only digits', $messages[1]['phone']);
         // @codingStandardsIgnoreEnd
     }
@@ -629,7 +632,7 @@ final class CollectionInputFilterTest extends TestCase
         self::assertArrayHasKey('phone', $messages[0]);
         self::assertCount(1, $messages[0]['phone']);
         self::assertContains('CUSTOM ERROR MESSAGE', $messages[0]['phone']);
-        self::assertNotContains('Value is required and can\'t be empty', $messages[0]['phone']);
+        self::assertNotContains(self::EMPTY_ERROR_MESSAGE, $messages[0]['phone']);
 
         self::assertArrayHasKey('phone', $messages[1]);
         self::assertCount(1, $messages[1]['phone']);
@@ -770,22 +773,18 @@ final class CollectionInputFilterTest extends TestCase
         /** @psalm-suppress DeprecatedInterface */
         $translator = $this->createMock(TranslatorInterface::class);
         AbstractValidator::setDefaultTranslator($translator);
-        $notEmpty = new NotEmpty();
 
         $translatedMessage = 'some translation';
-        /** @psalm-suppress DeprecatedMethod */
         $translator->expects(self::atLeastOnce())
             ->method('translate')
-            ->with($notEmpty->getMessageTemplates()[NotEmpty::IS_EMPTY])
+            ->with(self::EMPTY_ERROR_MESSAGE, 'default', null)
             ->willReturn($translatedMessage);
 
         $this->inputFilter->setIsRequired(true);
         $this->inputFilter->setData([]);
 
         self::assertFalse($this->inputFilter->isValid());
-        self::assertEquals([
-            [NotEmpty::IS_EMPTY => $translatedMessage],
-        ], $this->inputFilter->getMessages());
+        self::assertEquals([[self::EMPTY_ERROR_MESSAGE_KEY => $translatedMessage]], $this->inputFilter->getMessages());
     }
 
     public function testSetDataUsingSetDataAndRunningIsValidReturningSameAsOriginalForUnfilteredData(): void
@@ -870,7 +869,7 @@ final class CollectionInputFilterTest extends TestCase
         $inputFilter->setData([]);
 
         self::assertFalse($inputFilter->isValid());
-        self::assertEquals([['isEmpty' => 'Value is required and can\'t be empty']], $inputFilter->getMessages());
+        self::assertEquals([[self::EMPTY_ERROR_MESSAGE_KEY => self::EMPTY_ERROR_MESSAGE]], $inputFilter->getMessages());
     }
 
     public function testSettingCustomValidationMessageViaFactory(): void
@@ -890,7 +889,7 @@ final class CollectionInputFilterTest extends TestCase
         $inputFilter->setData([]);
 
         self::assertFalse($inputFilter->isValid());
-        self::assertEquals([['isEmpty' => $customMessage]], $inputFilter->getMessages());
+        self::assertEquals([[self::EMPTY_ERROR_MESSAGE_KEY => $customMessage]], $inputFilter->getMessages());
     }
 
     public function testSetIsRequiredValidationMessage(): void
@@ -901,6 +900,6 @@ final class CollectionInputFilterTest extends TestCase
         $this->inputFilter->setData([]);
 
         self::assertFalse($this->inputFilter->isValid());
-        self::assertEquals([['isEmpty' => $customMessage]], $this->inputFilter->getMessages());
+        self::assertEquals([[self::EMPTY_ERROR_MESSAGE_KEY => $customMessage]], $this->inputFilter->getMessages());
     }
 }

--- a/test/FileInput/FileInputTest.php
+++ b/test/FileInput/FileInputTest.php
@@ -48,6 +48,9 @@ use const UPLOAD_ERR_OK;
 #[CoversClass(PsrFileInputHandler::class)]
 final class FileInputTest extends TestCase
 {
+    private const EMPTY_ERROR_MESSAGE_KEY = 'isEmpty';
+    private const EMPTY_ERROR_MESSAGE     = 'Value is required and can\'t be empty';
+
     protected FileInput $input;
 
     protected function setUp(): void
@@ -266,17 +269,11 @@ final class FileInputTest extends TestCase
         $message  = $message ?: 'Expected failure message for required input';
         $message .= ';';
 
-        $expectedKey = NotEmptyValidator::IS_EMPTY;
-        $messages    = $input->getMessages();
-        self::assertArrayHasKey($expectedKey, $messages);
-
-        $notEmpty         = new NotEmptyValidator();
-        $messageTemplates = $notEmpty->getOption('messageTemplates');
-        self::assertIsArray($messageTemplates);
-        self::assertArrayHasKey($expectedKey, $messageTemplates);
+        $messages = $input->getMessages();
+        self::assertArrayHasKey(self::EMPTY_ERROR_MESSAGE_KEY, $messages);
         self::assertEquals(
-            $messageTemplates[$expectedKey],
-            $messages[$expectedKey],
+            self::EMPTY_ERROR_MESSAGE,
+            $messages[self::EMPTY_ERROR_MESSAGE_KEY],
             $message . ' missing NotEmpty::IS_EMPTY key and/or contains additional messages'
         );
         self::assertCount(
@@ -419,9 +416,7 @@ final class FileInputTest extends TestCase
         $input = $this->createFileInput();
         $input->setRequired(true);
 
-        $customMessage = [
-            NotEmptyValidator::IS_EMPTY => "Custom message",
-        ];
+        $customMessage = [NotEmptyValidator::IS_EMPTY => "Custom message"];
 
         $input->getValidatorChain()->attach(new NotEmptyValidator(['messages' => $customMessage]));
 
@@ -807,18 +802,17 @@ final class FileInputTest extends TestCase
          */
         $translator = $this->createMock(TranslatorInterface::class);
         AbstractValidator::setDefaultTranslator($translator);
-        $notEmpty = new NotEmptyValidator();
 
         $translatedMessage = 'some translation';
         $translator->expects(self::atLeastOnce())
             ->method('translate')
-            ->with($notEmpty->getMessageTemplates()[NotEmptyValidator::IS_EMPTY])
+            ->with(self::EMPTY_ERROR_MESSAGE, 'default', null)
             ->willReturn($translatedMessage);
 
         self::assertFalse($this->input->isValid());
         $messages = $this->input->getMessages();
-        self::assertArrayHasKey('isEmpty', $messages);
-        self::assertSame($translatedMessage, $messages['isEmpty']);
+        self::assertArrayHasKey(self::EMPTY_ERROR_MESSAGE_KEY, $messages);
+        self::assertSame($translatedMessage, $messages[self::EMPTY_ERROR_MESSAGE_KEY]);
     }
 
     public function testUploadValidatorIsAddedDuringIsValidWhenAutoPrependUploadValidatorIsEnabled(): void

--- a/test/InputTest.php
+++ b/test/InputTest.php
@@ -35,6 +35,9 @@ use const JSON_THROW_ON_ERROR;
  */
 final class InputTest extends TestCase
 {
+    private const EMPTY_ERROR_MESSAGE_KEY = 'isEmpty';
+    private const EMPTY_ERROR_MESSAGE     = 'Value is required and can\'t be empty';
+
     protected Input $input;
 
     protected function setUp(): void
@@ -57,17 +60,11 @@ final class InputTest extends TestCase
         $message  = $message ?: 'Expected failure message for required input';
         $message .= ';';
 
-        $expectedKey = NotEmptyValidator::IS_EMPTY;
-        $messages    = $input->getMessages();
-        self::assertArrayHasKey($expectedKey, $messages);
-
-        $notEmpty         = new NotEmptyValidator();
-        $messageTemplates = $notEmpty->getOption('messageTemplates');
-        self::assertIsArray($messageTemplates);
-        self::assertArrayHasKey($expectedKey, $messageTemplates);
+        $messages = $input->getMessages();
+        self::assertArrayHasKey(self::EMPTY_ERROR_MESSAGE_KEY, $messages);
         self::assertEquals(
-            $messageTemplates[$expectedKey],
-            $messages[$expectedKey],
+            self::EMPTY_ERROR_MESSAGE,
+            $messages[self::EMPTY_ERROR_MESSAGE_KEY],
             $message . ' missing NotEmpty::IS_EMPTY key and/or contains additional messages'
         );
         self::assertCount(
@@ -266,11 +263,8 @@ final class InputTest extends TestCase
         $input = $this->createInput();
         $input->setRequired(true);
 
-        $customMessage = [
-            NotEmptyValidator::IS_EMPTY => "Custom message",
-        ];
-
-        $notEmpty = new NotEmptyValidator(['messages' => $customMessage]);
+        $customMessage = [NotEmptyValidator::IS_EMPTY => "Custom message"];
+        $notEmpty      = new NotEmptyValidator(['messages' => $customMessage]);
 
         $input->getValidatorChain()
             ->attach($notEmpty);
@@ -402,7 +396,7 @@ final class InputTest extends TestCase
 
         self::assertFalse($this->input->isValid());
         $messages = $this->input->getMessages();
-        self::assertArrayHasKey('isEmpty', $messages);
+        self::assertArrayHasKey(self::EMPTY_ERROR_MESSAGE_KEY, $messages);
         self::assertEquals(1, count($validatorChain->getValidators()));
 
         // Assert that NotEmpty validator wasn't added again
@@ -738,18 +732,17 @@ final class InputTest extends TestCase
          */
         $translator = $this->createMock(TranslatorInterface::class);
         AbstractValidator::setDefaultTranslator($translator);
-        $notEmpty = new NotEmptyValidator();
 
         $translatedMessage = 'some translation';
         $translator->expects(self::atLeastOnce())
             ->method('translate')
-            ->with($notEmpty->getMessageTemplates()[NotEmptyValidator::IS_EMPTY])
+            ->with(self::EMPTY_ERROR_MESSAGE, 'default', null)
             ->willReturn($translatedMessage);
 
         self::assertFalse($this->input->isValid());
         $messages = $this->input->getMessages();
-        self::assertArrayHasKey('isEmpty', $messages);
-        self::assertSame($translatedMessage, $messages['isEmpty']);
+        self::assertArrayHasKey(self::EMPTY_ERROR_MESSAGE_KEY, $messages);
+        self::assertSame($translatedMessage, $messages[self::EMPTY_ERROR_MESSAGE_KEY]);
     }
 
     /**
@@ -808,7 +801,7 @@ final class InputTest extends TestCase
         $nonEmptyValues = array_diff_key($allValues, $emptyValues);
 
         $validatorMsg = ['FooValidator' => 'Invalid Value'];
-        $notEmptyMsg  = ['isEmpty' => "Value is required and can't be empty"];
+        $notEmptyMsg  = [self::EMPTY_ERROR_MESSAGE_KEY => "Value is required and can't be empty"];
 
         $validatorNotCall = fn(mixed $value, array|null $context = null): ValidatorInterface =>
             TestHelper::createValidatorMock(null, $value, $context);


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | yes
| QA            | yes

### Description

Remove use of deprecated NotEmpty->getOption for compatibility with laminas/laminas-validator v3.

NotEmpty is still required in some tests to ensure default injection is handled correctly
