### PR TITLE
Replace InputFilterPluginManagerFactory deprecated interface

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -257,22 +257,6 @@
       <code><![CDATA[$shareByDefault]]></code>
     </PossiblyUnusedProperty>
   </file>
-  <file src="src/InputFilterPluginManagerFactory.php">
-    <DeprecatedClass>
-      <code><![CDATA[new Config($config['input_filters'])]]></code>
-    </DeprecatedClass>
-    <DeprecatedInterface>
-      <code><![CDATA[InputFilterPluginManagerFactory]]></code>
-    </DeprecatedInterface>
-    <PossiblyUnusedMethod>
-      <code><![CDATA[setCreationOptions]]></code>
-    </PossiblyUnusedMethod>
-    <UnusedPsalmSuppress>
-      <code><![CDATA[MismatchingDocblockParamType]]></code>
-      <code><![CDATA[MismatchingDocblockParamType]]></code>
-      <code><![CDATA[MoreSpecificImplementedParamType]]></code>
-    </UnusedPsalmSuppress>
-  </file>
   <file src="src/InputInterface.php">
     <PossiblyUnusedReturnValue>
       <code><![CDATA[$this]]></code>

--- a/src/InputFilterPluginManagerFactory.php
+++ b/src/InputFilterPluginManagerFactory.php
@@ -4,13 +4,9 @@ declare(strict_types=1);
 
 namespace Laminas\InputFilter;
 
-use ArrayAccess;
-use Laminas\ServiceManager\Config;
-use Laminas\ServiceManager\FactoryInterface;
-use Laminas\ServiceManager\ServiceLocatorInterface;
+use Laminas\ServiceManager\Factory\FactoryInterface;
 use Laminas\ServiceManager\ServiceManager;
 use Psr\Container\ContainerInterface;
-use Psr\Container\ContainerInterface as PsrContainer;
 
 use function assert;
 use function is_array;
@@ -19,34 +15,18 @@ use function is_array;
  * @link ServiceManager
  *
  * @psalm-import-type ServiceManagerConfiguration from ServiceManager
- *
- * @final
+ * @psalm-internal Laminas\InputFilter
+ * @psalm-internal LaminasTest\InputFilter
  */
-class InputFilterPluginManagerFactory implements FactoryInterface
+final class InputFilterPluginManagerFactory implements FactoryInterface
 {
-    /**
-     * laminas-servicemanager v2 support for invocation options.
-     *
-     * @var null|ServiceManagerConfiguration
-     */
-    protected $creationOptions;
-
-    /**
-     * @param ContainerInterface|PsrContainer  $container
-     * @param string|null                      $name
-     * @param ServiceManagerConfiguration|null $options
-     * @return InputFilterPluginManager
-     * @psalm-suppress MoreSpecificImplementedParamType,MismatchingDocblockParamType
-     */
-    public function __invoke(ContainerInterface $container, $name = null, ?array $options = null)
-    {
+    /** @param string|null $requestedName */
+    public function __invoke(
+        ContainerInterface $container,
+        $requestedName = null,
+        ?array $options = null
+    ): InputFilterPluginManager {
         $pluginManager = new InputFilterPluginManager($container, $options ?? []);
-
-        // If this is in a laminas-mvc application, the ServiceListener will inject
-        // merged configuration during bootstrap.
-        if ($container->has('ServiceListener')) {
-            return $pluginManager;
-        }
 
         // If we do not have a config service, nothing more to do
         if (! $container->has('config')) {
@@ -54,7 +34,7 @@ class InputFilterPluginManagerFactory implements FactoryInterface
         }
 
         $config = $container->get('config');
-        assert(is_array($config) || $config instanceof ArrayAccess);
+        assert(is_array($config));
 
         // If we do not have input_filters configuration, nothing more to do
         if (! isset($config['input_filters']) || ! is_array($config['input_filters'])) {
@@ -62,32 +42,8 @@ class InputFilterPluginManagerFactory implements FactoryInterface
         }
 
         /** @psalm-var ServiceManagerConfiguration $config['input_filters'] */
-
-        // Wire service configuration for input_filters
-        (new Config($config['input_filters']))->configureServiceManager($pluginManager);
+        $pluginManager->configure($config['input_filters']);
 
         return $pluginManager;
-    }
-
-    /**
-     * @param string|null $name
-     * @param string|null $requestedName
-     * @return InputFilterPluginManager
-     * @psalm-suppress MismatchingDocblockParamType
-     */
-    public function createService(ServiceLocatorInterface $serviceLocator, $name = null, $requestedName = null)
-    {
-        return $this($serviceLocator, $requestedName ?? InputFilterPluginManager::class, $this->creationOptions);
-    }
-
-    /**
-     * laminas-servicemanager v2 support for invocation options.
-     *
-     * @param ServiceManagerConfiguration $options
-     * @return void
-     */
-    public function setCreationOptions(array $options)
-    {
-        $this->creationOptions = $options;
     }
 }

--- a/test/InputFilterPluginManagerFactoryTest.php
+++ b/test/InputFilterPluginManagerFactoryTest.php
@@ -68,12 +68,12 @@ final class InputFilterPluginManagerFactoryTest extends TestCase
         ];
 
         $container = $this->createMock(ServiceLocatorInterface::class);
-        $container->method('has')
-            ->willReturnMap([
-                ['ServiceListener', false],
-                ['config', true],
-            ]);
-        $container->method('get')
+        $container->expects(self::once())
+            ->method('has')
+            ->with('config')
+            ->willReturn(true);
+        $container->expects(self::once())
+            ->method('get')
             ->with('config')
             ->willReturn($config);
 
@@ -87,32 +87,13 @@ final class InputFilterPluginManagerFactoryTest extends TestCase
         self::assertSame($inputFilter, $inputFilters->get('test-too'));
     }
 
-    public function testDoesNotConfigureInputFilterServicesWhenServiceListenerPresent(): void
+    public function testDoesNotConfigureInputFilterServicesWhenConfigServiceNotPresent(): void
     {
         $container = $this->createMock(ServiceLocatorInterface::class);
         $container->expects(self::once())
             ->method('has')
-            ->with('ServiceListener')
-            ->willReturn(true);
-
-        $container->expects(self::never())->method('get');
-
-        $factory      = new InputFilterPluginManagerFactory();
-        $inputFilters = $factory($container);
-
-        self::assertInstanceOf(InputFilterPluginManager::class, $inputFilters);
-        self::assertFalse($inputFilters->has('test'));
-        self::assertFalse($inputFilters->has('test-too'));
-    }
-
-    public function testDoesNotConfigureInputFilterServicesWhenConfigServiceNotPresent(): void
-    {
-        $container = $this->createMock(ServiceLocatorInterface::class);
-        $container->method('has')
-            ->willReturnMap([
-                ['ServiceListener', false],
-                ['config', false],
-            ]);
+            ->with('config')
+            ->willReturn(false);
         $container->expects(self::never())->method('get');
 
         $factory      = new InputFilterPluginManagerFactory();
@@ -124,11 +105,10 @@ final class InputFilterPluginManagerFactoryTest extends TestCase
     public function testDoesNotConfigureInputFilterServicesWhenConfigServiceDoesNotContainInputFiltersConfig(): void
     {
         $container = $this->createMock(ServiceLocatorInterface::class);
-        $container->method('has')
-            ->willReturnMap([
-                ['ServiceListener', false],
-                ['config', true],
-            ]);
+        $container->expects(self::once())
+            ->method('has')
+            ->with('config')
+            ->willReturn(true);
         $container->expects(self::once())
             ->method('get')
             ->with('config')


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | yes
| New Feature   | no
| RFC           | yes
| QA            | no

### Description

Replace the deprecated Laminas\ServiceManager\ServiceLocatorInterface with Laminas\ServiceManager\Factory\FactoryInterface