### PR TITLE
Refactor `Factory::createInput()`

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -46,7 +46,6 @@
     </TooManyArguments>
     <UnusedPsalmSuppress>
       <code><![CDATA[RedundantConditionGivenDocblockType]]></code>
-      <code><![CDATA[RedundantConditionGivenDocblockType]]></code>
     </UnusedPsalmSuppress>
   </file>
   <file src="src/CollectionInputFilter.php">
@@ -101,47 +100,19 @@
     <DeprecatedConstant>
       <code><![CDATA[FilterChain::DEFAULT_PRIORITY]]></code>
     </DeprecatedConstant>
-    <DeprecatedMethod>
-      <code><![CDATA[setPluginManager]]></code>
-    </DeprecatedMethod>
     <MixedArgument>
       <code><![CDATA[$inputFilterSpecification['count']]]></code>
       <code><![CDATA[$inputFilterSpecification['input_filter']]]></code>
       <code><![CDATA[$inputFilterSpecification['required']]]></code>
       <code><![CDATA[$inputFilterSpecification['required_message']]]></code>
       <code><![CDATA[$key]]></code>
-      <code><![CDATA[$name]]></code>
-      <code><![CDATA[$priority]]></code>
       <code><![CDATA[$value]]></code>
       <code><![CDATA[$value['type']]]></code>
     </MixedArgument>
-    <MixedArgumentTypeCoercion>
-      <code><![CDATA[$filter]]></code>
-      <code><![CDATA[$inputSpecification]]></code>
-    </MixedArgumentTypeCoercion>
-    <MixedArrayAccess>
-      <code><![CDATA[$filter['name']]]></code>
-    </MixedArrayAccess>
     <MixedAssignment>
       <code><![CDATA[$key]]></code>
-      <code><![CDATA[$name]]></code>
-      <code><![CDATA[$options]]></code>
-      <code><![CDATA[$priority]]></code>
       <code><![CDATA[$value]]></code>
     </MixedAssignment>
-    <MixedMethodCall>
-      <code><![CDATA[new $class()]]></code>
-    </MixedMethodCall>
-    <PossiblyInvalidArgument>
-      <code><![CDATA[$value]]></code>
-      <code><![CDATA[$value]]></code>
-    </PossiblyInvalidArgument>
-    <UnusedPsalmSuppress>
-      <code><![CDATA[DeprecatedMethod]]></code>
-      <code><![CDATA[DocblockTypeContradiction]]></code>
-      <code><![CDATA[DocblockTypeContradiction]]></code>
-      <code><![CDATA[RedundantConditionGivenDocblockType]]></code>
-    </UnusedPsalmSuppress>
   </file>
   <file src="src/FileInput.php">
     <InvalidPropertyAssignmentValue>
@@ -194,14 +165,6 @@
       <code><![CDATA[(bool) $continueIfEmpty]]></code>
       <code><![CDATA[(string) $errorMessage]]></code>
     </RedundantCastGivenDocblockType>
-  </file>
-  <file src="src/InputFilter.php">
-    <MixedArgumentTypeCoercion>
-      <code><![CDATA[$input]]></code>
-    </MixedArgumentTypeCoercion>
-    <PossiblyInvalidArgument>
-      <code><![CDATA[$input]]></code>
-    </PossiblyInvalidArgument>
   </file>
   <file src="src/InputFilterAbstractServiceFactory.php">
     <MixedArgument>
@@ -293,17 +256,6 @@
       <code><![CDATA[testSetDataAndGetRawValueGetValue]]></code>
       <code><![CDATA[testSetTraversableDataAndGetRawValueGetValue]]></code>
     </InvalidArgument>
-    <LessSpecificReturnStatement>
-      <code><![CDATA[$dataSets]]></code>
-    </LessSpecificReturnStatement>
-    <MissingClosureParamType>
-      <code><![CDATA[$inputTypeData]]></code>
-      <code><![CDATA[$inputTypeData]]></code>
-    </MissingClosureParamType>
-    <MissingClosureReturnType>
-      <code><![CDATA[static fn($inputTypeData) => $inputTypeData[1]]]></code>
-      <code><![CDATA[static fn($inputTypeData) => $inputTypeData[2]]]></code>
-    </MissingClosureReturnType>
     <MixedArgument>
       <code><![CDATA[$input]]></code>
       <code><![CDATA[$set[5]]]></code>
@@ -314,10 +266,6 @@
       <code><![CDATA[$msg]]></code>
       <code><![CDATA[$msg]]></code>
     </MixedArgumentTypeCoercion>
-    <MixedArrayAccess>
-      <code><![CDATA[$inputTypeData[1]]]></code>
-      <code><![CDATA[$inputTypeData[2]]]></code>
-    </MixedArrayAccess>
     <MixedArrayAssignment>
       <code><![CDATA[$set[0][$name]]]></code>
       <code><![CDATA[$set[5][$name]]]></code>
@@ -331,8 +279,6 @@
       <code><![CDATA[$set[0][$name]]]></code>
       <code><![CDATA[$set[5][$name]]]></code>
       <code><![CDATA[$set[6][$name]]]></code>
-      <code><![CDATA[$tmpTemplate[2]]]></code>
-      <code><![CDATA[$tmpTemplate[3]]]></code>
     </MixedAssignment>
     <MixedReturnTypeCoercion>
       <code><![CDATA[$dataSets]]></code>
@@ -347,32 +293,55 @@
      *     7: string[]
      * }>]]></code>
     </MixedReturnTypeCoercion>
-    <MoreSpecificReturnType>
-      <code><![CDATA[array<string, array{
-     *     0: InputInterface,
-     *     1: null|string,
-     *     2: null|string,
-     *     3: InputInterface,
-     * }>]]></code>
-    </MoreSpecificReturnType>
     <PossiblyInvalidArgument>
-      <code><![CDATA[$input]]></code>
-      <code><![CDATA[$input]]></code>
-      <code><![CDATA[$input]]></code>
       <code><![CDATA[testSetDataAndGetRawValueGetValue]]></code>
       <code><![CDATA[testSetTraversableDataAndGetRawValueGetValue]]></code>
     </PossiblyInvalidArgument>
-    <PossiblyNullArgument>
-      <code><![CDATA[$expectedInputName]]></code>
-      <code><![CDATA[$expectedInputName]]></code>
-      <code><![CDATA[$expectedInputName]]></code>
-      <code><![CDATA[$expectedInputName]]></code>
-      <code><![CDATA[$expectedInputName]]></code>
-    </PossiblyNullArgument>
-    <PossiblyUndefinedMethod>
-      <code><![CDATA[getName]]></code>
-      <code><![CDATA[getName]]></code>
-    </PossiblyUndefinedMethod>
+  </file>
+  <file src="test/CollectionInputFilterTest.php">
+    <InvalidArgument>
+      <code><![CDATA[[
+                'element' => [
+                    'type'  => InputFilter::class,
+                    'type1' => [
+                        'type'         => CollectionInputFilter::class,
+                        'input_filter' => [
+                            'test_field' => [
+                                'type'         => CollectionInputFilter::class,
+                                'input_filter' => [
+                                    'test_field1' => [
+                                        'required'   => false,
+                                        'validators' => [
+                                            [
+                                                'name'    => NumberComparison::class,
+                                                'options' => [
+                                                    'min'     => 50,
+                                                    'max'     => 100,
+                                                    'message' => '%value% is incorrect',
+                                                ],
+                                            ],
+                                        ],
+                                    ],
+                                    'price'       => [
+                                        'required'   => false,
+                                        'validators' => [
+                                            [
+                                                'name'    => NumberComparison::class,
+                                                'options' => [
+                                                    'min'     => 50,
+                                                    'max'     => 100,
+                                                    'message' => '%value% is incorrect',
+                                                ],
+                                            ],
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ]]]></code>
+    </InvalidArgument>
   </file>
   <file src="test/FactoryTest.php">
     <DeprecatedConstant>
@@ -382,17 +351,103 @@
     <DeprecatedMethod>
       <code><![CDATA[getFilters]]></code>
       <code><![CDATA[getPluginManager]]></code>
-      <code><![CDATA[getPluginManager]]></code>
-      <code><![CDATA[setPluginManager]]></code>
     </DeprecatedMethod>
-    <PossiblyNullReference>
-      <code><![CDATA[getPluginManager]]></code>
-      <code><![CDATA[getPluginManager]]></code>
-    </PossiblyNullReference>
-    <PossiblyUndefinedMethod>
-      <code><![CDATA[breakOnFailure]]></code>
-      <code><![CDATA[breakOnFailure]]></code>
-    </PossiblyUndefinedMethod>
+    <InvalidArgument>
+      <code><![CDATA[[
+            'foo'  => [
+                'name'       => 'foo',
+                'required'   => false,
+                'validators' => [
+                    [
+                        'name' => Validator\NotEmpty::class,
+                    ],
+                    [
+                        'name'    => Validator\StringLength::class,
+                        'options' => [
+                            'min' => 3,
+                            'max' => 5,
+                        ],
+                    ],
+                ],
+            ],
+            'bar'  => [
+                'allow_empty' => true,
+                'filters'     => [
+                    [
+                        'name' => Filter\StringTrim::class,
+                    ],
+                    [
+                        'name'    => Filter\StringToLower::class,
+                        'options' => [
+                            'encoding' => 'ISO-8859-1',
+                        ],
+                    ],
+                ],
+            ],
+            'baz'  => [
+                'type' => InputFilter::class,
+                'foo'  => [
+                    'name'       => 'foo',
+                    'required'   => false,
+                    'validators' => [
+                        [
+                            'name' => Validator\NotEmpty::class,
+                        ],
+                        [
+                            'name'    => Validator\StringLength::class,
+                            'options' => [
+                                'min' => 3,
+                                'max' => 5,
+                            ],
+                        ],
+                    ],
+                ],
+                'bar'  => [
+                    'allow_empty' => true,
+                    'filters'     => [
+                        [
+                            'name' => Filter\StringTrim::class,
+                        ],
+                        [
+                            'name'    => Filter\StringToLower::class,
+                            'options' => [
+                                'encoding' => 'ISO-8859-1',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            'bat'  => [
+                'type' => CustomInput::class,
+                'name' => 'bat',
+            ],
+            'zomg' => [
+                'name'              => 'zomg',
+                'continue_if_empty' => true,
+            ],
+        ]]]></code>
+      <code><![CDATA[[
+            0 => [
+                'type' => InputFilter::class,
+                'name' => 'bar',
+                '0'    => [
+                    'name' => 'bat',
+                ],
+                '1'    => [
+                    'name' => 'baz',
+                ],
+            ],
+            1 => [
+                'type'         => CollectionInputFilter::class,
+                'name'         => 'foo',
+                'input_filter' => [
+                    '0' => [
+                        'name' => 'bat',
+                    ],
+                ],
+            ],
+        ]]]></code>
+    </InvalidArgument>
     <UndefinedInterfaceMethod>
       <code><![CDATA[continueIfEmpty]]></code>
     </UndefinedInterfaceMethod>
@@ -419,28 +474,6 @@
      *     2: class-string<InputInterface>
      * }>]]></code>
     </MoreSpecificReturnType>
-  </file>
-  <file src="test/InputFilterTest.php">
-    <ImplementedReturnTypeMismatch>
-      <code><![CDATA[array<string, array{
-     *     0: array|Traversable,
-     *     1: string,
-     *     2: Input
-     * }>]]></code>
-    </ImplementedReturnTypeMismatch>
-    <LessSpecificReturnStatement>
-      <code><![CDATA[$dataSets]]></code>
-    </LessSpecificReturnStatement>
-    <MoreSpecificReturnType>
-      <code><![CDATA[array<string, array{
-     *     0: array|Traversable,
-     *     1: string,
-     *     2: Input
-     * }>]]></code>
-    </MoreSpecificReturnType>
-    <NonInvariantDocblockPropertyType>
-      <code><![CDATA[$inputFilter]]></code>
-    </NonInvariantDocblockPropertyType>
   </file>
   <file src="test/TestAsset/ModuleEventInterface.php">
     <PossiblyUnusedMethod>

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -28,11 +28,6 @@
                 <directory name="test/StaticAnalysis" />
             </errorLevel>
         </UnusedClass>
-        <PossiblyUnusedParam>
-            <errorLevel type="suppress">
-                <directory name="test" />
-            </errorLevel>
-        </PossiblyUnusedParam>
         <MissingOverrideAttribute>
             <errorLevel type="suppress">
                 <directory name="src" />

--- a/src/BaseInputFilter.php
+++ b/src/BaseInputFilter.php
@@ -79,18 +79,13 @@ class BaseInputFilter implements
         return count($this->inputs);
     }
 
-    /**
-     * Add an input to the input filter
-     *
-     * @param InputInterface|InputFilterInterface $input
-     * @param null|string|int $name Name used to retrieve this input. Can be an integer for collections
-     * @return $this
-     * @psalm-suppress MoreSpecificImplementedParamType
-     * @throws Exception\InvalidArgumentException
-     */
-    public function add($input, $name = null)
+    /** @inheritDoc */
+    public function add($input, $name = null): static
     {
-        /** @psalm-suppress RedundantConditionGivenDocblockType */
+        if (is_array($input)) {
+            $input = $this->factory->create($input);
+        }
+
         if (! $input instanceof InputInterface && ! $input instanceof InputFilterInterface) {
             throw new Exception\InvalidArgumentException(sprintf(
                 '%s expects an instance of %s or %s as its first argument; received "%s"',

--- a/src/BaseInputFilter.php
+++ b/src/BaseInputFilter.php
@@ -23,6 +23,8 @@ use function is_int;
 use function sprintf;
 
 /**
+ * @psalm-import-type InputSpecification from InputFilterInterface
+ * @psalm-import-type InputFilterSpecification from InputFilterInterface
  * @template TFilteredValues
  * @implements InputFilterInterface<TFilteredValues>
  */
@@ -119,7 +121,7 @@ class BaseInputFilter implements
     /**
      * Replace a named input
      *
-     * @param  InputInterface|InputFilterInterface $input
+     * @param  InputInterface|InputFilterInterface|InputSpecification|InputFilterSpecification $input
      * @param  array-key                           $name Name of the input to replace
      * @throws Exception\InvalidArgumentException If input to replace not exists.
      * @return self
@@ -145,9 +147,8 @@ class BaseInputFilter implements
      *
      * @param  array-key $name
      * @throws Exception\InvalidArgumentException
-     * @return InputInterface|InputFilterInterface
      */
-    public function get($name)
+    public function get($name): InputInterface|InputFilterInterface
     {
         if (! array_key_exists($name, $this->inputs)) {
             throw new Exception\InvalidArgumentException(sprintf(

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -41,6 +41,7 @@ final class ConfigProvider
                 'InputFilterManager' => InputFilterPluginManager::class,
             ],
             'factories' => [
+                Factory::class                  => FactoryFactory::class,
                 InputFilterPluginManager::class => InputFilterPluginManagerFactory::class,
             ],
         ];

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -16,11 +16,8 @@ use Laminas\Validator\ValidatorPluginManager;
 use Psr\Container\ContainerInterface;
 use Traversable;
 
-use function array_intersect;
-use function array_keys;
 use function assert;
 use function class_exists;
-use function count;
 use function get_debug_type;
 use function in_array;
 use function is_a;
@@ -229,7 +226,19 @@ final class Factory
      */
     private function isInputSpecification(array $spec): bool
     {
+        /** @var mixed $type */
+        $type = $spec['type'] ?? null;
+
+        if (is_string($type) && is_a($type, InputInterface::class, true)) {
+            return true;
+        }
+
+        if (is_string($type) && is_a($type, InputFilterInterface::class, true)) {
+            return false;
+        }
+
         $keys = [
+            'type',
             'name',
             'required',
             'allow_empty',
@@ -241,14 +250,11 @@ final class Factory
             'validators',
         ];
 
-        if (count(array_intersect($keys, array_keys($spec))) > 0) {
-            return true;
+        foreach ($keys as $key) {
+            unset($spec[$key]);
         }
 
-        /** @var mixed $type */
-        $type = $spec['type'] ?? null;
-
-        return is_string($type) && is_a($type, InputInterface::class, true);
+        return $spec === [];
     }
 
     /** @param InputSpecification|InputFilterSpecification $spec */

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -7,6 +7,7 @@ namespace Laminas\InputFilter;
 use Laminas\Filter\FilterChain;
 use Laminas\Filter\FilterInterface;
 use Laminas\Filter\FilterPluginManager;
+use Laminas\InputFilter\Exception\RuntimeException;
 use Laminas\ServiceManager\ServiceManager;
 use Laminas\Stdlib\ArrayUtils;
 use Laminas\Validator\ValidatorChain;
@@ -15,14 +16,17 @@ use Laminas\Validator\ValidatorPluginManager;
 use Psr\Container\ContainerInterface;
 use Traversable;
 
+use function array_intersect;
+use function array_keys;
 use function assert;
 use function class_exists;
+use function count;
 use function get_debug_type;
+use function in_array;
 use function is_a;
 use function is_array;
 use function is_callable;
 use function is_int;
-use function is_object;
 use function is_string;
 use function sprintf;
 
@@ -35,9 +39,6 @@ use function sprintf;
  */
 final class Factory
 {
-    protected ?FilterChain $defaultFilterChain;
-    protected ?ValidatorChain $defaultValidatorChain;
-
     public static function new(ContainerInterface|null $container = null): self
     {
         $container = $container ?? new ServiceManager();
@@ -68,235 +69,198 @@ final class Factory
     public function __construct(
         private readonly FilterPluginManager $filterPluginManager,
         private readonly ValidatorPluginManager $validatorPluginManager,
-        private readonly InputFilterPluginManager $inputFilterPluginManager
+        private readonly InputFilterPluginManager $inputFilterPluginManager,
     ) {
-        $this->defaultFilterChain = new FilterChain();
-        $this->defaultFilterChain->setPluginManager($filterPluginManager);
-
-        $this->defaultValidatorChain = new ValidatorChain();
-        $this->defaultValidatorChain->setPluginManager($validatorPluginManager);
     }
 
     /**
-     * Set default filter chain to use
-     *
-     * @return $this
+     * @param class-string $class
+     * @psalm-assert-if-true class-string<Input>|class-string<ArrayInput>|class-string<FileInput> $class
      */
-    public function setDefaultFilterChain(FilterChain $filterChain)
+    private function canCreateInputType(string $class): bool
     {
-        $this->defaultFilterChain = $filterChain;
-        return $this;
+        return in_array(
+            $class,
+            [
+                Input::class,
+                ArrayInput::class,
+                FileInput::class,
+            ],
+            true,
+        );
     }
 
     /**
-     * Get default filter chain, if any
-     *
-     * @return null|FilterChain
+     * @todo           should return and check for interfaces when SMv4 is installed
+     * @psalm-suppress DeprecatedMethod removal will be done in Service Manager 4 upgrade
+     * @param InputSpecification $spec
+     * @return array{
+     *     filterChain: FilterChain,
+     *     validatorChain: ValidatorChain,
+     * }
      */
-    public function getDefaultFilterChain()
+    private function buildChainsFromSpecification(array $spec): array
     {
-        return $this->defaultFilterChain;
-    }
+        $filters = $spec['filters'] ?? [];
+        if ($filters instanceof FilterChain) {
+            $filterChain = $filters;
+            $filterChain->setPluginManager($this->filterPluginManager);
+        } else {
+            $filterChain = new FilterChain();
+            $filterChain->setPluginManager($this->filterPluginManager);
+            $this->populateFilters($filterChain, $filters);
+        }
 
-    /**
-     * Clear the default filter chain (i.e., don't inject one into new inputs)
-     *
-     * @return void
-     */
-    public function clearDefaultFilterChain()
-    {
-        $this->defaultFilterChain = null;
-    }
+        $validators = $spec['validators'] ?? [];
+        if ($validators instanceof ValidatorChain) {
+            $validatorChain = $validators;
+            $validatorChain->setPluginManager($this->validatorPluginManager);
+        } else {
+            $validatorChain = new ValidatorChain();
+            $validatorChain->setPluginManager($this->validatorPluginManager);
+            $this->populateValidators($validatorChain, $validators);
+        }
 
-    /**
-     * Set default validator chain to use
-     *
-     * @return $this
-     */
-    public function setDefaultValidatorChain(ValidatorChain $validatorChain)
-    {
-        $this->defaultValidatorChain = $validatorChain;
-        return $this;
-    }
-
-    /**
-     * Get default validator chain, if any
-     *
-     * @return null|ValidatorChain
-     */
-    public function getDefaultValidatorChain()
-    {
-        return $this->defaultValidatorChain;
-    }
-
-    /**
-     * Clear the default validator chain (i.e., don't inject one into new inputs)
-     *
-     * @return void
-     */
-    public function clearDefaultValidatorChain()
-    {
-        $this->defaultValidatorChain = null;
+        return [
+            'filterChain'    => $filterChain,
+            'validatorChain' => $validatorChain,
+        ];
     }
 
     /**
      * Factory for input objects
      *
-     * @param  InputSpecification|Traversable|InputProviderInterface $inputSpecification
+     * @param InputSpecification|InputProviderInterface $inputSpecification
      * @throws Exception\InvalidArgumentException
-     * @throws Exception\RuntimeException
-     * @return InputInterface|InputFilterInterface
+     * @throws RuntimeException
      */
-    public function createInput($inputSpecification)
+    public function createInput(array|InputProviderInterface $inputSpecification): InputInterface
     {
-        if ($inputSpecification instanceof InputProviderInterface) {
-            $inputSpecification = $inputSpecification->getInputSpecification();
-        }
+        $spec = $inputSpecification instanceof InputProviderInterface
+            ? $inputSpecification->getInputSpecification()
+            : $inputSpecification;
 
-        if ($inputSpecification instanceof Traversable) {
-            $inputSpecification = ArrayUtils::iteratorToArray($inputSpecification);
-        }
+        $class = $spec['type'] ?? Input::class;
 
-        /** @psalm-suppress DocblockTypeContradiction */
-        if (! is_array($inputSpecification)) {
-            throw new Exception\InvalidArgumentException(sprintf(
-                '%s expects an array or Traversable; received "%s"',
-                __METHOD__,
-                get_debug_type($inputSpecification),
-            ));
-        }
+        /** @var mixed|null $customInput */
+        $customInput = $this->inputFilterPluginManager->has($class)
+            ? $this->inputFilterPluginManager->get($class)
+            : null;
 
-        $class = Input::class;
-
-        if (isset($inputSpecification['type']) && is_string($inputSpecification['type'])) {
-            $class = $inputSpecification['type'];
-        }
-
-        $managerInstance = null;
-        if ($this->inputFilterPluginManager->has($class)) {
-            $managerInstance = $this->inputFilterPluginManager->get($class);
-        }
-
-        if (! $managerInstance && ! class_exists($class)) {
-            throw new Exception\RuntimeException(sprintf(
+        if ($customInput === null && ! class_exists($class)) {
+            throw new RuntimeException(sprintf(
                 'Input factory expects the "type" to be a valid class or a plugin name; received "%s"',
-                $class
+                $class,
             ));
         }
 
-        if (is_a($class, Input::class, true)) {
-            $filterChain = new FilterChain();
-            /** @psalm-suppress DeprecatedMethod removal will be done in Service Manager 4 upgrade */
-            $filterChain->setPluginManager($this->filterPluginManager);
+        if ($customInput === null && ! $this->canCreateInputType($class)) {
+            throw new RuntimeException(sprintf(
+                'Only internal input types "Input", "ArrayInput" and "FileInput" can be created by the factory. '
+                . 'You will need to create your own factory for custom inputs because we cannot know what your '
+                . 'constructor arguments might be. Received the type: "%s"',
+                $class,
+            ));
+        }
 
-            $validatorChain = new ValidatorChain();
-            $validatorChain->setPluginManager($this->validatorPluginManager);
+        if ($customInput === null) {
+            [
+                'filterChain'    => $filterChain,
+                'validatorChain' => $validatorChain,
+            ] = $this->buildChainsFromSpecification($spec);
 
             /** @psalm-suppress UnsafeInstantiation */
-            $input = $managerInstance ?: new $class($filterChain, $validatorChain);
+            $input = new $class($filterChain, $validatorChain);
         } else {
-            $input = $managerInstance ?: new $class();
-        }
-
-        if ($input instanceof InputFilterInterface) {
-            return $this->createInputFilter($inputSpecification);
+            /** @var mixed $input */
+            $input = $customInput;
         }
 
         if (! $input instanceof InputInterface) {
-            throw new Exception\RuntimeException(sprintf(
+            throw new RuntimeException(sprintf(
                 'Input factory expects the "type" to be a class implementing %s; received "%s"',
                 InputInterface::class,
-                $class
+                get_debug_type($input),
             ));
         }
 
-        $managerInstance
-            ? $this->injectFilterAndValidatorChainsWithPluginManagers($input)
-            : $this->injectDefaultFilterAndValidatorChains($input);
+        $this->applyInputOptions($input, $spec);
 
-        /**
-         * Even though the specification is typed, psalm cannot tell the individual item types inside the switch
-         *
-         * @psalm-suppress MixedArgument, DeprecatedMethod
-         */
-        foreach ($inputSpecification as $key => $value) {
-            switch ($key) {
-                case 'name':
-                    $input->setName($value);
-                    break;
-                case 'required':
-                    $input->setRequired($value);
-                    break;
-                case 'allow_empty':
-                    $input->setAllowEmpty($value);
-                    if (! isset($inputSpecification['required'])) {
-                        $input->setRequired(! $value);
-                    }
-                    break;
-                case 'continue_if_empty':
-                    if (! $input instanceof Input) {
-                        throw new Exception\RuntimeException(sprintf(
-                            '%s "continue_if_empty" can only set to inputs of type "%s"',
-                            __METHOD__,
-                            Input::class
-                        ));
-                    }
-                    $input->setContinueIfEmpty($inputSpecification['continue_if_empty']);
-                    break;
-                case 'error_message':
-                    $input->setErrorMessage($value);
-                    break;
-                case 'fallback_value':
-                    if (! $input instanceof Input) {
-                        throw new Exception\RuntimeException(sprintf(
-                            '%s "fallback_value" can only set to inputs of type "%s"',
-                            __METHOD__,
-                            Input::class
-                        ));
-                    }
-                    $input->setFallbackValue($value);
-                    break;
-                case 'break_on_failure':
-                    $input->setBreakOnFailure($value);
-                    break;
-                case 'filters':
-                    if ($value instanceof FilterChain) {
-                        $input->setFilterChain($value);
-                        break;
-                    }
-                    if (! is_array($value) && ! $value instanceof Traversable) {
-                        throw new Exception\RuntimeException(sprintf(
-                            '%s expects the value associated with "filters" to be an array/Traversable of filters'
-                            . ' or filter specifications, or a FilterChain; received "%s"',
-                            __METHOD__,
-                            get_debug_type($value)
-                        ));
-                    }
-                    $this->populateFilters($input->getFilterChain(), $value);
-                    break;
-                case 'validators':
-                    if ($value instanceof ValidatorChain) {
-                        $input->setValidatorChain($value);
-                        break;
-                    }
-                    if (! is_array($value) && ! $value instanceof Traversable) {
-                        throw new Exception\RuntimeException(sprintf(
-                            '%s expects the value associated with "validators" to be an array/Traversable of validators'
-                            . ' or validator specifications, or a ValidatorChain; received "%s"',
-                            __METHOD__,
-                            get_debug_type($value)
-                        ));
-                    }
+        return $input;
+    }
 
-                    $this->populateValidators($input->getValidatorChain(), $value);
-                    break;
-                default:
-                    // ignore unknown keys
-                    break;
+    /** @param InputSpecification $spec */
+    private function applyInputOptions(InputInterface $input, array $spec): void
+    {
+        if (isset($spec['name'])) {
+            $input->setName($spec['name']);
+        }
+
+        if (isset($spec['required'])) {
+            $input->setRequired($spec['required']);
+        }
+
+        if (isset($spec['allow_empty'])) {
+            $input->setAllowEmpty($spec['allow_empty']);
+            if (! isset($spec['required'])) {
+                $input->setRequired(! $spec['allow_empty']);
             }
         }
 
-        return $input;
+        if (isset($spec['continue_if_empty']) && $input instanceof Input) {
+            $input->setContinueIfEmpty($spec['continue_if_empty']);
+        }
+
+        if (isset($spec['error_message'])) {
+            $input->setErrorMessage($spec['error_message']);
+        }
+
+        if (isset($spec['fallback_value']) && $input instanceof Input) {
+            $input->setFallbackValue($spec['fallback_value']);
+        }
+
+        if (isset($spec['break_on_failure'])) {
+            $input->setBreakOnFailure($spec['break_on_failure']);
+        }
+    }
+
+    /**
+     * @psalm-assert-if-true InputSpecification $spec
+     */
+    private function isInputSpecification(array $spec): bool
+    {
+        $keys = [
+            'name',
+            'required',
+            'allow_empty',
+            'continue_if_empty',
+            'error_message',
+            'fallback_value',
+            'break_on_failure',
+            'filters',
+            'validators',
+        ];
+
+        if (count(array_intersect($keys, array_keys($spec))) > 0) {
+            return true;
+        }
+
+        /** @var mixed $type */
+        $type = $spec['type'] ?? null;
+
+        return is_string($type) && is_a($type, InputInterface::class, true);
+    }
+
+    /** @param InputSpecification|InputFilterSpecification $spec */
+    public function create(array $spec): InputInterface|InputFilterInterface
+    {
+        if ($this->isInputSpecification($spec)) {
+            return $this->createInput($spec);
+        }
+
+        /** @psalm-var InputFilterSpecification $spec */
+
+        return $this->createInputFilter($spec);
     }
 
     /**
@@ -305,7 +269,7 @@ final class Factory
      * phpcs:ignore Generic.Files.LineLength.TooLong, SlevomatCodingStandard.Commenting.DocCommentSpacing
      * @param InputFilterSpecification|CollectionSpecification|Traversable|InputFilterProviderInterface $inputFilterSpecification
      * @return InputFilterInterface
-     * @throws Exception\RuntimeException
+     * @throws RuntimeException
      * @throws Exception\InvalidArgumentException
      */
     public function createInputFilter($inputFilterSpecification)
@@ -384,55 +348,48 @@ final class Factory
                 unset($value['name']);
             }
 
-            $inputFilter->add($this->createInput($value), $key);
+            $inputFilter->add($this->create($value), $key);
         }
 
         return $inputFilter;
     }
 
     /**
-     * @param  iterable<array-key, FilterInterface|callable|FilterSpecification> $filters
-     * @throws Exception\RuntimeException
-     * @return void
+     * @param iterable<array-key, FilterInterface|(callable(mixed): mixed)|FilterSpecification> $filters
+     * @throws RuntimeException
+     * @todo Can be replaced with
+     *       `$this->filterPluginManager->build(FilterChain::class, $filters)`
+     *       once SMv4 is installed
      */
-    protected function populateFilters(FilterChain $chain, $filters)
+    private function populateFilters(FilterChain $chain, iterable $filters): void
     {
         foreach ($filters as $filter) {
-            /** @psalm-suppress RedundantConditionGivenDocblockType */
-            if (is_object($filter) || is_callable($filter)) {
+            if (is_callable($filter)) {
                 $chain->attach($filter);
                 continue;
             }
 
-            /** @psalm-suppress RedundantConditionGivenDocblockType, DocblockTypeContradiction */
-            if (is_array($filter)) {
-                if (! isset($filter['name'])) {
-                    throw new Exception\RuntimeException(
-                        'Invalid filter specification provided; does not include "name" key'
-                    );
-                }
-                $name     = $filter['name'];
-                $priority = $filter['priority'] ?? FilterChain::DEFAULT_PRIORITY;
-                $options  = [];
-                if (isset($filter['options'])) {
-                    $options = $filter['options'];
-                }
-                $chain->attachByName($name, $options, $priority);
-                continue;
+            if (! isset($filter['name'])) {
+                throw new RuntimeException(
+                    'Invalid filter specification provided; does not include "name" key',
+                );
             }
+            $name     = $filter['name'];
+            $priority = $filter['priority'] ?? FilterChain::DEFAULT_PRIORITY;
+            $options  = $filter['options'] ?? [];
 
-            throw new Exception\RuntimeException(
-                'Invalid filter specification provided; was neither a filter instance nor an array specification'
-            );
+            $chain->attachByName($name, $options, $priority);
         }
     }
 
     /**
-     * @param  iterable<array-key, ValidatorInterface|ValidatorSpecification> $validators
-     * @throws Exception\RuntimeException
-     * @return void
+     * @param iterable<array-key, ValidatorInterface|ValidatorSpecification> $validators
+     * @throws RuntimeException
+     * @todo Can be replaced with
+     *        `$this->validatorPluginManager->build(ValidatorChain::class, $validators)`
+     *        once SMv4 is installed
      */
-    protected function populateValidators(ValidatorChain $chain, $validators)
+    private function populateValidators(ValidatorChain $chain, iterable $validators): void
     {
         foreach ($validators as $validator) {
             if ($validator instanceof ValidatorInterface) {
@@ -440,75 +397,18 @@ final class Factory
                 continue;
             }
 
-            /** @psalm-suppress RedundantConditionGivenDocblockType */
-            if (is_array($validator)) {
-                if (! isset($validator['name'])) {
-                    throw new Exception\RuntimeException(
-                        'Invalid validator specification provided; does not include "name" key'
-                    );
-                }
-                $name    = $validator['name'];
-                $options = [];
-                if (isset($validator['options'])) {
-                    $options = $validator['options'];
-                }
-                $breakChainOnFailure = false;
-                if (isset($validator['break_chain_on_failure'])) {
-                    $breakChainOnFailure = $validator['break_chain_on_failure'];
-                }
-                $priority = $validator['priority'] ?? ValidatorChain::DEFAULT_PRIORITY;
-                $chain->attachByName($name, $options, $breakChainOnFailure, $priority);
-                continue;
+            if (! isset($validator['name'])) {
+                throw new RuntimeException(
+                    'Invalid validator specification provided; does not include "name" key',
+                );
             }
 
-            throw new Exception\RuntimeException(
-                'Invalid validator specification provided; was neither a validator instance nor an array specification'
+            $chain->attachByName(
+                $validator['name'],
+                $validator['options'] ?? [],
+                $validator['break_chain_on_failure'] ?? false,
+                $validator['priority'] ?? ValidatorChain::DEFAULT_PRIORITY,
             );
-        }
-    }
-
-    /**
-     * Inject the default filter and validator chains into the input, if present.
-     *
-     * This ensures custom plugins are made available to the input instance.
-     *
-     * @return void
-     */
-    protected function injectDefaultFilterAndValidatorChains(InputInterface $input)
-    {
-        if ($this->defaultFilterChain) {
-            $input->setFilterChain(clone $this->defaultFilterChain);
-        }
-
-        if ($this->defaultValidatorChain) {
-            $input->setValidatorChain(clone $this->defaultValidatorChain);
-        }
-    }
-
-    /**
-     * Inject filter and validator chains with the plugin managers from
-     * the default chains, if present.
-     *
-     * This ensures custom plugins are made available to the input instance.
-     *
-     * @return void
-     */
-    protected function injectFilterAndValidatorChainsWithPluginManagers(InputInterface $input)
-    {
-        if ($this->defaultFilterChain) {
-            $filterChain = $input->getFilterChain();
-            /** @psalm-suppress RedundantConditionGivenDocblockType, DocblockTypeContradiction, DeprecatedMethod */
-            $filterChain instanceof FilterChain
-                ? $filterChain->setPluginManager($this->defaultFilterChain->getPluginManager())
-                : $input->setFilterChain(clone $this->defaultFilterChain);
-        }
-
-        if ($this->defaultValidatorChain) {
-            $validatorChain = $input->getValidatorChain();
-            /** @psalm-suppress RedundantConditionGivenDocblockType, DocblockTypeContradiction */
-            $validatorChain instanceof ValidatorChain
-                ? $validatorChain->setPluginManager($this->defaultValidatorChain->getPluginManager())
-                : $input->setValidatorChain(clone $this->defaultValidatorChain);
         }
     }
 

--- a/src/Input.php
+++ b/src/Input.php
@@ -106,6 +106,7 @@ class Input implements
         return $this;
     }
 
+    /** @inheritDoc */
     public function setName($name)
     {
         $this->name = (string) $name;

--- a/src/Input.php
+++ b/src/Input.php
@@ -106,13 +106,8 @@ class Input implements
         return $this;
     }
 
-    /**
-     * @param  string $name
-     * @return $this
-     */
     public function setName($name)
     {
-        /** @psalm-suppress RedundantCastGivenDocblockType */
         $this->name = (string) $name;
         return $this;
     }

--- a/src/InputFilter.php
+++ b/src/InputFilter.php
@@ -4,38 +4,10 @@ declare(strict_types=1);
 
 namespace Laminas\InputFilter;
 
-use Traversable;
-
-use function is_array;
-
 /**
- * @psalm-import-type InputSpecification from InputFilterInterface
  * @template TFilteredValues
  * @extends BaseInputFilter<TFilteredValues>
  */
 class InputFilter extends BaseInputFilter
 {
-    /**
-     * Add an input to the input filter
-     *
-     * @param  InputSpecification|Traversable|InputInterface|InputFilterInterface $input
-     * @param  array-key|null $name
-     * @return $this
-     */
-    public function add($input, $name = null)
-    {
-        if (
-            is_array($input)
-            || ($input instanceof Traversable && ! $input instanceof InputFilterInterface)
-        ) {
-            $factory = $this->factory;
-            $input   = $factory->createInput($input);
-        }
-
-        // At this point $input is potentially invalid. parent::add() will throw an exception in this case.
-
-        parent::add($input, $name);
-
-        return $this;
-    }
 }

--- a/src/InputFilterInterface.php
+++ b/src/InputFilterInterface.php
@@ -35,7 +35,6 @@ use Traversable;
  *     break_on_failure?: bool,
  *     filters?: FilterChain|iterable<array-key, FilterSpecification|callable|FilterInterface>,
  *     validators?: ValidatorChain|iterable<array-key, ValidatorSpecification|ValidatorInterface>,
- *     ...
  * }
  * @psalm-type InputFilterSpecification = array{
  *     type?: class-string<InputFilterInterface>|string,

--- a/src/InputFilterInterface.php
+++ b/src/InputFilterInterface.php
@@ -9,7 +9,6 @@ use Laminas\Filter\FilterChain; // phpcs:ignore
 use Laminas\Filter\FilterInterface; // phpcs:ignore
 use Laminas\Validator\ValidatorChain; // phpcs:ignore
 use Laminas\Validator\ValidatorInterface; // phpcs:ignore
-use Traversable;
 
 /**
  * @template TFilteredValues

--- a/src/InputFilterInterface.php
+++ b/src/InputFilterInterface.php
@@ -65,10 +65,9 @@ interface InputFilterInterface extends Countable
     /**
      * Retrieve a named input
      *
-     * @param  array-key $name
-     * @return InputInterface|InputFilterInterface
+     * @param array-key $name
      */
-    public function get($name);
+    public function get($name): InputInterface|InputFilterInterface;
 
     /**
      * Test if an input or input filter by the given name is attached

--- a/src/InputFilterInterface.php
+++ b/src/InputFilterInterface.php
@@ -33,11 +33,11 @@ use Traversable;
  *     error_message?: string|null,
  *     fallback_value?: mixed|null,
  *     break_on_failure?: bool,
- *     filters?: FilterChain|iterable<array-key, FilterSpecification|callable|FilterInterface>,
+ *     filters?: FilterChain|iterable<array-key, FilterSpecification|(callable(mixed):mixed)|FilterInterface>,
  *     validators?: ValidatorChain|iterable<array-key, ValidatorSpecification|ValidatorInterface>,
  * }
  * @psalm-type InputFilterSpecification = array{
- *     type?: class-string<InputFilterInterface>|string,
+ *     type: class-string<InputFilterInterface>|string,
  * }&array<array-key, InputSpecification|InputFilterInterface|InputInterface>
  * @psalm-type CollectionSpecification = array{
  *     type?: class-string<InputFilterInterface>|string,
@@ -54,14 +54,14 @@ interface InputFilterInterface extends Countable
     /**
      * Add an input to the input filter
      *
-     * @param  InputInterface|InputFilterInterface|InputSpecification|Traversable $input
+     * @param  InputInterface|InputFilterInterface|InputSpecification|InputFilterSpecification $input
      *     Implementations MUST handle at least one of the specified types, and
      *     raise an exception for any they cannot process.
      * @param  null|array-key $name Name used to retrieve this input
-     * @return InputFilterInterface
      * @throws Exception\InvalidArgumentException If unable to handle the input type.
+     * @return $this
      */
-    public function add($input, $name = null);
+    public function add($input, $name = null): static;
 
     /**
      * Retrieve a named input

--- a/src/InputInterface.php
+++ b/src/InputInterface.php
@@ -33,7 +33,7 @@ interface InputInterface
     public function setFilterChain(FilterChain $filterChain);
 
     /**
-     * @param string $name
+     * @param array-key $name
      * @return $this
      */
     public function setName($name);

--- a/test/BaseInputFilterTest.php
+++ b/test/BaseInputFilterTest.php
@@ -1,4 +1,7 @@
-<?php // phpcs:disable WebimpressCodingStandard.NamingConventions.ValidVariableName.NotCamelCaps
+<?php // phpcs:disable WebimpressCodingStandard.NamingConventions.ValidVariableName
+
+
+declare(strict_types=1);
 
 namespace LaminasTest\InputFilter;
 
@@ -30,18 +33,22 @@ use function array_walk;
 use function assert;
 use function count;
 use function in_array;
-use function is_callable;
+use function is_array;
 use function json_encode;
 use function sprintf;
+use function uniqid;
 
 use const JSON_THROW_ON_ERROR;
 
+/**
+ * @psalm-import-type InputSpecification from InputFilterInterface
+ * @psalm-import-type InputFilterSpecification from InputFilterInterface
+ */
 #[CoversClass(BaseInputFilter::class)]
-class BaseInputFilterTest extends TestCase
+final class BaseInputFilterTest extends TestCase
 {
     protected Factory $factory;
-    /** @var BaseInputFilter $inputFilter */
-    protected $inputFilter;
+    protected BaseInputFilter $inputFilter;
 
     protected function setUp(): void
     {
@@ -223,53 +230,105 @@ class BaseInputFilterTest extends TestCase
         $inputFilter->getUnknown();
     }
 
+    public function testAddHasFluentInterface(): void
+    {
+        $input = self::createInput('anything');
+        self::assertSame(
+            $this->inputFilter,
+            $this->inputFilter->add($input),
+        );
+    }
+
+    public function testRemoveHasFluentInterface(): void
+    {
+        $input = self::createInput('anything');
+        $this->inputFilter->add($input);
+
+        self::assertSame(
+            $this->inputFilter,
+            $this->inputFilter->remove('anything'),
+        );
+    }
+
+    /**
+     * @return array<string, array{
+     *     0: InputInterface|InputFilterInterface,
+     *     1: non-empty-string,
+     * }>
+     */
+    public static function addItemsDataProvider(): array
+    {
+        $input       = self::createInputInterfaceMock('anything', null);
+        $inputFilter = self::createInputFilterInterfaceMock();
+
+        return [
+            'Input with non-empty name'       => [
+                $input,
+                'example',
+            ],
+            'InputFilter with non-empty name' => [
+                $inputFilter,
+                'example',
+            ],
+        ];
+    }
+
     /**
      * Verify the state of the input filter is the desired after change it using the method `add()`
      */
-    #[DataProvider('addMethodArgumentsProvider')]
+    #[DataProvider('addItemsDataProvider')]
     public function testAddHasGet(
-        InputInterface|InputFilterInterface|iterable $input,
-        ?string $name,
-        ?string $expectedInputName,
-        object $expectedInput
+        InputInterface|InputFilterInterface $input,
+        string $name,
     ): void {
-        $inputFilter = $this->inputFilter;
         self::assertFalse(
-            $inputFilter->has($expectedInputName),
-            "InputFilter shouldn't have an input with the name $expectedInputName yet"
+            $this->inputFilter->has($name),
+            "InputFilter shouldn't have an input with the name $name yet"
         );
-        $currentNumberOfFilters = count($inputFilter);
 
-        $return = $inputFilter->add($input, $name);
-        self::assertSame($inputFilter, $return, "add() must return it self");
+        $initialCount = count($this->inputFilter);
 
-        // **Check input collection state**
-        self::assertTrue($inputFilter->has($expectedInputName), "There is no input with name $expectedInputName");
-        self::assertCount($currentNumberOfFilters + 1, $inputFilter, 'Number of filters must be increased by 1');
+        $this->inputFilter->add($input, $name);
 
-        $returnInput = $inputFilter->get($expectedInputName);
-        self::assertEquals($expectedInput, $returnInput, 'get() does not match the expected input');
+        self::assertTrue(
+            $this->inputFilter->has($name),
+            "There is no input with name $name",
+        );
+
+        self::assertCount(
+            $initialCount + 1,
+            $this->inputFilter,
+            'Number of inputs should have increased by 1',
+        );
+
+        self::assertSame(
+            $input,
+            $this->inputFilter->get($name),
+            'get() does not match the expected input',
+        );
     }
 
     /**
      * Verify the state of the input filter is the desired after change it using the method `add()` and `remove()`
      */
-    #[DataProvider('addMethodArgumentsProvider')]
+    #[DataProvider('addItemsDataProvider')]
     public function testAddRemove(
-        InputInterface|InputFilterInterface|iterable $input,
-        ?string $name,
-        ?string $expectedInputName
+        InputInterface|InputFilterInterface $input,
+        string $name,
     ): void {
-        $inputFilter = $this->inputFilter;
+        $this->inputFilter->add($input, $name);
+        $this->inputFilter->remove($name);
 
-        $inputFilter->add($input, $name);
-        $currentNumberOfFilters = count($inputFilter);
+        self::assertFalse(
+            $this->inputFilter->has($name),
+            "There is no input with name $name",
+        );
 
-        $return = $inputFilter->remove($expectedInputName);
-        self::assertSame($inputFilter, $return, 'remove() must return it self');
-
-        self::assertFalse($inputFilter->has($expectedInputName), "There is no input with name $expectedInputName");
-        self::assertCount($currentNumberOfFilters - 1, $inputFilter, 'Number of filters must be decreased by 1');
+        self::assertCount(
+            0,
+            $this->inputFilter,
+            'There should be zero inputs',
+        );
     }
 
     public function testAddingInputWithNameDoesNotInjectNameInInput(): void
@@ -284,25 +343,91 @@ class BaseInputFilterTest extends TestCase
         self::assertEquals('foo', $foo->getName(), 'Input name should not change');
     }
 
+    /**
+     * @psalm-return array<string, array{
+     *     0: InputInterface|InputFilterInterface|InputSpecification|InputFilterSpecification,
+     *     1: class-string,
+     * }>
+     */
+    public static function inputProvider(): array
+    {
+        $input       = self::createInputInterfaceMock('fooInput', null);
+        $inputFilter = self::createInputFilterInterfaceMock();
+
+        return [
+            'InputInterface'       => [
+                $input,
+                $input::class,
+            ],
+            'InputFilterInterface' => [
+                $inputFilter,
+                $inputFilter::class,
+            ],
+            'Input Spec'           => [
+                [
+                    'name' => uniqid(),
+                ],
+                Input::class,
+            ],
+            'InputFilter Spec'     => [
+                [
+                    'type' => InputFilter::class,
+                    'foo'  => [
+                        'name' => 'foo',
+                    ],
+                    'bar'  => [
+                        'name' => 'bar',
+                    ],
+                ],
+                InputFilter::class,
+            ],
+        ];
+    }
+
+    /**
+     * @param InputInterface|InputFilterInterface|InputSpecification|InputFilterSpecification $input
+     * @param class-string $expectedType
+     */
     #[DataProvider('inputProvider')]
     public function testReplace(
-        InputInterface|InputFilterInterface|iterable $input,
-        ?string $inputName,
-        object $expectedInput
+        InputInterface|InputFilterInterface|array $input,
+        string $expectedType,
     ): void {
-        $inputFilter    = $this->inputFilter;
         $nameToReplace  = 'replace_me';
         $inputToReplace = $this->createInput($nameToReplace);
 
-        $inputFilter->add($inputToReplace);
-        $currentNumberOfFilters = count($inputFilter);
+        $this->inputFilter->add($inputToReplace);
+        $currentNumberOfFilters = count($this->inputFilter);
 
-        $return = $inputFilter->replace($input, $nameToReplace);
-        self::assertSame($inputFilter, $return, 'replace() must return it self');
-        self::assertCount($currentNumberOfFilters, $inputFilter, "Number of filters shouldn't change");
+        self::assertSame(
+            $this->inputFilter,
+            $this->inputFilter->replace($input, $nameToReplace),
+            'replace() must return it self',
+        );
 
-        $returnInput = $inputFilter->get($nameToReplace);
-        self::assertEquals($expectedInput, $returnInput, 'get() does not match the expected input');
+        self::assertCount($currentNumberOfFilters, $this->inputFilter, "Number of filters shouldn't change");
+
+        $object = $this->inputFilter->get($nameToReplace);
+
+        self::assertInstanceOf(
+            $expectedType,
+            $object,
+            sprintf(
+                'Expected "%s" but the instance was "%s"',
+                $expectedType,
+                $object::class,
+            ),
+        );
+
+        if (is_array($input)) {
+            return;
+        }
+
+        self::assertSame(
+            $input,
+            $object,
+            'get() does not match the expected input',
+        );
     }
 
     /**
@@ -591,6 +716,8 @@ class BaseInputFilterTest extends TestCase
         $filters = $filter->getInputs();
 
         self::assertCount(2, $filters);
+        self::assertInstanceOf(Input::class, $filters['foo']);
+        self::assertInstanceOf(Input::class, $filters['bar']);
         self::assertEquals('foo', $filters['foo']->getName());
         self::assertEquals('bar', $filters['bar']->getName());
     }
@@ -739,49 +866,6 @@ class BaseInputFilterTest extends TestCase
         self::assertSame($unfilteredArray, $baseInputFilter->getUnfilteredData());
         self::assertSame($filteredArray, $baseInputFilter->getValues());
         self::assertSame($filteredArray, $baseInputFilter->getRawValues());
-    }
-
-    /**
-     * @psalm-return array<string, array{
-     *     0: InputInterface,
-     *     1: null|string,
-     *     2: null|string,
-     *     3: InputInterface,
-     * }>
-     */
-    public static function addMethodArgumentsProvider(): array
-    {
-        $inputTypes = static::inputProvider();
-
-        $inputName = static fn($inputTypeData) => $inputTypeData[1];
-
-        $sameInput = static fn($inputTypeData) => $inputTypeData[2];
-
-        // phpcs:disable WebimpressCodingStandard.WhiteSpace.CommaSpacing.SpaceBeforeComma
-        $dataTemplates = [
-            // Description => [[$input argument], $name argument, $expectedName, $expectedInput]
-            'null'        => [$inputTypes, null         , $inputName   , $sameInput],
-            'custom_name' => [$inputTypes, 'custom_name', 'custom_name', $sameInput],
-        ];
-        // phpcs:enable WebimpressCodingStandard.WhiteSpace.CommaSpacing.SpaceBeforeComma
-
-        // Expand data template matrix for each possible input type.
-        // Description => [$input argument, $name argument, $expectedName, $expectedInput]
-        $dataSets = [];
-        foreach ($dataTemplates as $dataTemplateDescription => $dataTemplate) {
-            foreach ($dataTemplate[0] as $inputTypeDescription => $inputTypeData) {
-                $tmpTemplate    = $dataTemplate;
-                $tmpTemplate[0] = $inputTypeData[0]; // expand input
-                if (is_callable($dataTemplate[2])) {
-                    $tmpTemplate[2] = $dataTemplate[2]($inputTypeData);
-                }
-                $tmpTemplate[3] = $dataTemplate[3]($inputTypeData);
-
-                $dataSets[$inputTypeDescription . ' / ' . $dataTemplateDescription] = $tmpTemplate;
-            }
-        }
-
-        return $dataSets;
     }
 
     /**
@@ -939,32 +1023,11 @@ class BaseInputFilterTest extends TestCase
     }
 
     /**
-     * @psalm-return array<string, array{
-     *     0: InputInterface|InputFilterInterface,
-     *     1: null|string,
-     *     2: InputInterface|InputFilterInterface,
-     * }>
-     */
-    public static function inputProvider(): array
-    {
-        $input       = self::createInputInterfaceMock('fooInput', null);
-        $inputFilter = self::createInputFilterInterfaceMock();
-
-        // phpcs:disable WebimpressCodingStandard.WhiteSpace.CommaSpacing.SpaceBeforeComma
-        return [
-            // Description         => [input,     expected name, $expectedReturnInput]
-            'InputInterface'       => [$input,       'fooInput',       $input],
-            'InputFilterInterface' => [$inputFilter,       null, $inputFilter],
-        ];
-        // phpcs:enable WebimpressCodingStandard.WhiteSpace.CommaSpacing.SpaceBeforeComma
-    }
-
-    /**
      * @param array<string, mixed> $getRawValues
      * @param array<string, mixed> $getValues
      * @param array<array-key, array<string, string>> $getMessages
      */
-    private static function createInputFilterInterfaceMock(
+    public static function createInputFilterInterfaceMock(
         bool|null $isValid = null,
         array $getRawValues = [],
         array $getValues = [],
@@ -980,7 +1043,7 @@ class BaseInputFilterTest extends TestCase
     }
 
     /** @param array<string, string> $getMessages */
-    private static function createInputInterfaceMock(
+    public static function createInputInterfaceMock(
         string $name,
         bool|null $isRequired,
         bool|null $isValid = null,

--- a/test/CollectionInputFilterTest.php
+++ b/test/CollectionInputFilterTest.php
@@ -341,7 +341,7 @@ final class CollectionInputFilterTest extends TestCase
 
         $baseInputFilter = new BaseInputFilter($factory);
 
-        $inputFilterSpecificationAsArray = [];
+        $inputFilterSpecificationAsArray = ['type' => InputFilter::class];
         $inputSpecificationAsTraversable = new ArrayIterator($inputFilterSpecificationAsArray);
 
         return [

--- a/test/ConfigProviderTest.php
+++ b/test/ConfigProviderTest.php
@@ -6,28 +6,10 @@ namespace LaminasTest\InputFilter;
 
 use Laminas\InputFilter\ConfigProvider;
 use Laminas\InputFilter\InputFilterAbstractServiceFactory;
-use Laminas\InputFilter\InputFilterPluginManager;
-use Laminas\InputFilter\InputFilterPluginManagerFactory;
 use PHPUnit\Framework\TestCase;
 
 final class ConfigProviderTest extends TestCase
 {
-    public function testProvidesExpectedConfiguration(): void
-    {
-        $provider = new ConfigProvider();
-
-        $expected = [
-            'aliases'   => [
-                'InputFilterManager' => InputFilterPluginManager::class,
-            ],
-            'factories' => [
-                InputFilterPluginManager::class => InputFilterPluginManagerFactory::class,
-            ],
-        ];
-
-        self::assertEquals($expected, $provider->getDependencyConfig());
-    }
-
     public function testProvidesExpectedInputFilterConfiguration(): void
     {
         $provider = new ConfigProvider();
@@ -49,6 +31,6 @@ final class ConfigProviderTest extends TestCase
             'dependencies'  => $provider->getDependencyConfig(),
             'input_filters' => $provider->getInputFilterConfig(),
         ];
-        self::assertEquals($expected, $provider());
+        self::assertEquals($expected, $provider->__invoke());
     }
 }

--- a/test/FactoryTest.php
+++ b/test/FactoryTest.php
@@ -23,12 +23,10 @@ use Laminas\Validator\NotEmpty;
 use Laminas\Validator\ValidatorPluginManager;
 use LaminasTest\InputFilter\TestAsset\CustomInput;
 use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
-
-use function sprintf;
+use TypeError;
 
 #[CoversClass(Factory::class)]
 final class FactoryTest extends TestCase
@@ -37,8 +35,7 @@ final class FactoryTest extends TestCase
     {
         $factory = $this->createDefaultFactory();
 
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('expects an array or Traversable; received "string"');
+        $this->expectException(TypeError::class);
         /** @psalm-suppress InvalidArgument */
         $factory->createInput('invalid_value');
     }
@@ -84,7 +81,7 @@ final class FactoryTest extends TestCase
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage(
             'Input factory expects the "type" to be a class implementing Laminas\InputFilter\InputInterface; '
-            . 'received "fooPlugin"'
+            . 'received "string"'
         );
         $factory->createInput([
             'type' => $type,
@@ -98,8 +95,8 @@ final class FactoryTest extends TestCase
 
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage(
-            'Input factory expects the "type" to be a class implementing Laminas\InputFilter\InputInterface; '
-            . 'received "stdClass"'
+            'You will need to create your own factory for custom inputs '
+            . 'because we cannot know what your constructor arguments might be'
         );
         $factory->createInput([
             'type' => $type,
@@ -110,11 +107,7 @@ final class FactoryTest extends TestCase
     {
         $factory = $this->createDefaultFactory();
 
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage(
-            'expects the value associated with "filters" to be an array/Traversable'
-            . ' of filters or filter specifications, or a FilterChain; received "string"'
-        );
+        $this->expectException(TypeError::class);
         /** @psalm-suppress InvalidArgument */
         $factory->createInput([
             'filters' => 'invalid_value',
@@ -143,7 +136,7 @@ final class FactoryTest extends TestCase
 
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage(
-            'Invalid filter specification provided; was neither a filter instance nor an array specification'
+            'Invalid filter specification provided;'
         );
         $factory->createInput([
             'filters' => [
@@ -156,11 +149,7 @@ final class FactoryTest extends TestCase
     {
         $factory = $this->createDefaultFactory();
 
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage(
-            'expects the value associated with "validators" to be an array/Traversable of validators or validator '
-            . 'specifications, or a ValidatorChain; received "string"'
-        );
+        $this->expectException(TypeError::class);
         /** @psalm-suppress InvalidArgument */
         $factory->createInput([
             'validators' => 'invalid_value',
@@ -183,48 +172,13 @@ final class FactoryTest extends TestCase
         ]);
     }
 
-    /** @psalm-return array<string, array{0: 'continue_if_empty'|'fallback_value'}> */
-    public static function inputTypeSpecificationProvider(): array
-    {
-        return [
-            // Description => [$specificationKey]
-            'continue_if_empty' => ['continue_if_empty'],
-            'fallback_value'    => ['fallback_value'],
-        ];
-    }
-
-    /**
-     * @psalm-param 'continue_if_empty'|'fallback_value' $specificationKey
-     */
-    #[DataProvider('inputTypeSpecificationProvider')]
-    public function testCreateInputWithSpecificInputTypeSettingsThrowException(string $specificationKey): void
-    {
-        $type = 'pluginInputInterface';
-
-        $pluginManager = $this->createInputFilterPluginManagerMockForPlugin(
-            $type,
-            $this->createMock(InputInterface::class)
-        );
-
-        $factory = $this->createDefaultFactory($pluginManager);
-
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage(
-            sprintf('"%s" can only set to inputs of type "Laminas\InputFilter\Input"', $specificationKey)
-        );
-        $factory->createInput([
-            'type'            => $type,
-            $specificationKey => true,
-        ]);
-    }
-
     public function testCreateInputWithValidatorsAsAnCollectionOfInvalidTypesThrowException(): void
     {
         $factory = $this->createDefaultFactory();
 
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage(
-            'Invalid validator specification provided; was neither a validator instance nor an array specification'
+            'Invalid validator specification provided;'
         );
         /** @psalm-suppress InvalidArgument */
         $factory->createInput([
@@ -244,88 +198,51 @@ final class FactoryTest extends TestCase
         $factory->createInputFilter('invalid_value');
     }
 
-    public function testFactoryComposesFilterChainByDefault(): void
+    public function testFactoryCreatesFilterChainWithComposedPluginManagerWhenCreatingNewInputObjects(): void
     {
-        $factory = $this->createDefaultFactory();
-        self::assertInstanceOf(Filter\FilterChain::class, $factory->getDefaultFilterChain());
-    }
+        $container = TestHelper::getContainer();
+        $factory   = $container->get(Factory::class);
+        $plugins   = $container->get(FilterPluginManager::class);
 
-    public function testFactoryComposesValidatorChainByDefault(): void
-    {
-        $factory = $this->createDefaultFactory();
-        self::assertInstanceOf(Validator\ValidatorChain::class, $factory->getDefaultValidatorChain());
-    }
-
-    public function testFactoryAllowsInjectingFilterChain(): void
-    {
-        $factory     = $this->createDefaultFactory();
-        $filterChain = new Filter\FilterChain();
-        $factory->setDefaultFilterChain($filterChain);
-        self::assertSame($filterChain, $factory->getDefaultFilterChain());
-    }
-
-    public function testFactoryAllowsInjectingValidatorChain(): void
-    {
-        $factory        = $this->createDefaultFactory();
-        $validatorChain = new Validator\ValidatorChain();
-        $factory->setDefaultValidatorChain($validatorChain);
-        self::assertSame($validatorChain, $factory->getDefaultValidatorChain());
-    }
-
-    public function testFactoryUsesComposedFilterChainWhenCreatingNewInputObjects(): void
-    {
-        $smMock = $this->createMock(ContainerInterface::class);
-
-        $factory       = $this->createDefaultFactory();
-        $filterChain   = new Filter\FilterChain();
-        $pluginManager = new Filter\FilterPluginManager($smMock);
-        $filterChain->setPluginManager($pluginManager);
-        $factory->setDefaultFilterChain($filterChain);
         $input = $factory->createInput([
             'name' => 'foo',
         ]);
-        self::assertInstanceOf(InputInterface::class, $input);
+
         $inputFilterChain = $input->getFilterChain();
-        self::assertNotSame($filterChain, $inputFilterChain);
-        self::assertSame($pluginManager, TestHelper::getFilterPluginManagerFromFilterChain($inputFilterChain));
+        self::assertSame(
+            $plugins,
+            TestHelper::getFilterPluginManagerFromFilterChain($inputFilterChain),
+        );
     }
 
-    public function testFactoryUsesComposedValidatorChainWhenCreatingNewInputObjects(): void
+    public function testFactoryCreatesValidatorChainWithComposedPluginManagerWhenCreatingNewInputObjects(): void
     {
-        $smMock           = $this->createMock(ContainerInterface::class);
-        $factory          = $this->createDefaultFactory();
-        $validatorChain   = new Validator\ValidatorChain();
-        $validatorPlugins = new Validator\ValidatorPluginManager($smMock);
-        $validatorChain->setPluginManager($validatorPlugins);
-        $factory->setDefaultValidatorChain($validatorChain);
-        $input = $factory->createInput([
+        $factory = $this->createDefaultFactory();
+        $plugins = $factory->getValidatorPluginManager();
+        $input   = $factory->createInput([
             'name' => 'foo',
         ]);
-        self::assertInstanceOf(InputInterface::class, $input);
+
         $inputValidatorChain = $input->getValidatorChain();
-        self::assertNotSame($validatorChain, $inputValidatorChain);
-        self::assertSame($validatorPlugins, $inputValidatorChain->getPluginManager());
+        self::assertSame(
+            $plugins,
+            $inputValidatorChain->getPluginManager(),
+        );
     }
 
     public function testFactoryInjectsComposedFilterAndValidatorChainsIntoInputObjectsWhenCreatingNewInputFilterObjects(): void // phpcs:ignore
     {
-        $smMock           = $this->createMock(ContainerInterface::class);
-        $factory          = $this->createDefaultFactory();
-        $filterPlugins    = new Filter\FilterPluginManager($smMock);
-        $validatorPlugins = new Validator\ValidatorPluginManager($smMock);
-        $filterChain      = new Filter\FilterChain();
-        /** @psalm-suppress DeprecatedMethod removal will be done in Service Manager 4 upgrade */
-        $filterChain->setPluginManager($filterPlugins);
-        $validatorChain = new Validator\ValidatorChain();
-        $validatorChain->setPluginManager($validatorPlugins);
-        $factory->setDefaultFilterChain($filterChain);
-        $factory->setDefaultValidatorChain($validatorChain);
+        $container        = TestHelper::getContainer();
+        $factory          = $container->get(Factory::class);
+        $filterPlugins    = $container->get(FilterPluginManager::class);
+        $validatorPlugins = $container->get(ValidatorPluginManager::class);
 
-        $inputFilter = $factory->createInputFilter([
+        $inputFilter = $factory->create([
             'foo' => [
                 'name' => 'foo',
             ],
         ]);
+
         self::assertInstanceOf(InputFilterInterface::class, $inputFilter);
         self::assertCount(1, $inputFilter);
         $input = $inputFilter->get('foo');
@@ -827,24 +744,6 @@ final class FactoryTest extends TestCase
         self::assertEquals('Custom error message', $input->getErrorMessage());
     }
 
-    public function testSetInputFilterManagerWithServiceManager(): void
-    {
-        $serviceManager         = new ServiceManager();
-        $inputFilterManager     = new InputFilterPluginManager($serviceManager);
-        $validatorPluginManager = new Validator\ValidatorPluginManager($serviceManager);
-        $filterPluginManager    = new Filter\FilterPluginManager($serviceManager);
-        $serviceManager->setService(Validator\ValidatorPluginManager::class, $validatorPluginManager);
-        $serviceManager->setService(Filter\FilterPluginManager::class, $filterPluginManager);
-        $factory = new Factory(
-            $filterPluginManager,
-            $validatorPluginManager,
-            $inputFilterManager
-        );
-
-        self::assertSame($validatorPluginManager, $factory->getDefaultValidatorChain()->getPluginManager());
-        self::assertSame($filterPluginManager, $factory->getDefaultFilterChain()->getPluginManager());
-    }
-
     public function testSetsBreakChainOnFailure(): void
     {
         $factory = $this->createDefaultFactory();
@@ -1035,59 +934,45 @@ final class FactoryTest extends TestCase
         self::assertTrue($collectionInputFilter->has('bat'));
     }
 
-    public function testClearDefaultFilterChain(): void
-    {
-        $factory = $this->createDefaultFactory();
-        $factory->clearDefaultFilterChain();
-        self::assertNull($factory->getDefaultFilterChain());
-    }
-
-    public function testClearDefaultValidatorChain(): void
-    {
-        $factory = $this->createDefaultFactory();
-        $factory->clearDefaultValidatorChain();
-        self::assertNull($factory->getDefaultValidatorChain());
-    }
-
     public function testWhenCreateInputPullsInputFromThePluginManagerItMustNotOverwriteFilterAndValidatorChains(): void
     {
-        $serviceManager      = new ServiceManager();
-        $filterPluginManager = new FilterPluginManager($serviceManager);
+        $container                = TestHelper::getContainer();
+        $filterPluginManager      = $container->get(FilterPluginManager::class);
+        $validatorPlugins         = $container->get(ValidatorPluginManager::class);
+        $inputFilterPluginManager = $container->get(InputFilterPluginManager::class);
+        $factory                  = $container->get(Factory::class);
 
         $filterChain = new Filter\FilterChain();
         /** @psalm-suppress DeprecatedMethod removal will be done in Service Manager 4 upgrade */
         $filterChain->setPluginManager($filterPluginManager);
 
         $validatorChain = new Validator\ValidatorChain();
+        $validatorChain->setPluginManager($validatorPlugins);
 
         $input = new Input($filterChain, $validatorChain);
-        $input->setFilterChain($filterChain);
-        $input->setValidatorChain($validatorChain);
 
-        $inputFilterPluginManager = new InputFilterPluginManager($serviceManager);
         $inputFilterPluginManager->setService('Some\Test\Input', $input);
-
-        $factory = new Factory(
-            new FilterPluginManager($serviceManager),
-            new ValidatorPluginManager($serviceManager),
-            $inputFilterPluginManager
-        );
-
-        $defaultFilterChain = new Filter\FilterChain();
-        /** @psalm-suppress DeprecatedMethod removal will be done in Service Manager 4 upgrade */
-        $defaultFilterChain->setPluginManager($filterPluginManager);
-        $defaultValidatorChain = new Validator\ValidatorChain();
-        $factory->setDefaultFilterChain($defaultFilterChain);
-        $factory->setDefaultValidatorChain($defaultValidatorChain);
 
         $spec         = ['type' => 'Some\Test\Input'];
         $createdInput = $factory->createInput($spec);
 
-        self::assertSame($input, $createdInput);
-        self::assertSame($filterChain, $input->getFilterChain());
-        self::assertSame($validatorChain, $input->getValidatorChain());
-        self::assertNotSame($defaultFilterChain, $input->getFilterChain());
-        self::assertNotSame($defaultValidatorChain, $input->getValidatorChain());
+        self::assertSame(
+            $input,
+            $createdInput,
+            'The input fixture should be available in the input filter plugin manager',
+        );
+
+        self::assertSame(
+            $filterChain,
+            $input->getFilterChain(),
+            'The filter chain of the input should not have been changed',
+        );
+
+        self::assertSame(
+            $validatorChain,
+            $input->getValidatorChain(),
+            'The validator chain of the input should not have been changed',
+        );
     }
 
     public function testFactoryCanCreateCollectionInputFilterWithRequiredMessage(): void
@@ -1127,12 +1012,9 @@ final class FactoryTest extends TestCase
         return $factory;
     }
 
-    /**
-     * @param mixed $pluginValue
-     */
-    protected function createInputFilterPluginManagerMockForPlugin(
+    private function createInputFilterPluginManagerMockForPlugin(
         string $pluginName,
-        $pluginValue
+        mixed $pluginValue,
     ): InputFilterPluginManager {
         $pluginManager = $this->createMock(InputFilterPluginManager::class);
         $pluginManager->expects(self::atLeastOnce())

--- a/test/InputFilterPluginManagerTest.php
+++ b/test/InputFilterPluginManagerTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace LaminasTest\InputFilter;
 
-use Laminas\Filter\FilterChain;
 use Laminas\Filter\FilterPluginManager;
 use Laminas\InputFilter\CollectionInputFilter;
 use Laminas\InputFilter\Exception\RuntimeException;
@@ -16,7 +15,6 @@ use Laminas\InputFilter\InputInterface;
 use Laminas\ServiceManager\AbstractPluginManager;
 use Laminas\ServiceManager\Exception\InvalidServiceException;
 use Laminas\ServiceManager\ServiceManager;
-use Laminas\Validator\ValidatorChain;
 use Laminas\Validator\ValidatorPluginManager;
 use LaminasTest\InputFilter\FileInput\TestAsset\InitializableInputFilterInterface;
 use LaminasTest\InputFilter\TestAsset\InputFilterInterfaceStub;

--- a/test/InputFilterPluginManagerTest.php
+++ b/test/InputFilterPluginManagerTest.php
@@ -101,43 +101,6 @@ final class InputFilterPluginManagerTest extends TestCase
         self::assertInstanceOf($expectedInstance, $service, 'get() return type not match');
     }
 
-    public function testInputFilterInvokableClassSMDependenciesArePopulatedWithServiceLocator(): void
-    {
-        $serviceManager = new ServiceManager();
-
-        $filterManager    = new FilterPluginManager($serviceManager);
-        $validatorManager = new ValidatorPluginManager($serviceManager);
-        $serviceManager->setService(FilterPluginManager::class, $filterManager);
-        $serviceManager->setService(ValidatorPluginManager::class, $validatorManager);
-
-        $manager = new InputFilterPluginManager($serviceManager);
-        $factory = new Factory($filterManager, $validatorManager, $manager);
-
-        $serviceManager->setService(Factory::class, $factory);
-
-        /** @var InputFilter $service */
-        $service = $manager->get('inputfilter');
-
-        /** @var Factory $factory */
-        $factory = (new ReflectionObject($service))->getProperty('factory')->getValue($service);
-
-        $defaultFilterChain = $factory->getDefaultFilterChain();
-        self::assertInstanceOf(FilterChain::class, $defaultFilterChain);
-        self::assertSame(
-            $filterManager,
-            TestHelper::getFilterPluginManagerFromFilterChain($defaultFilterChain),
-            'Factory::getDefaultFilterChain() is not populated with the expected plugin manager'
-        );
-
-        $defaultValidatorChain = $factory->getDefaultValidatorChain();
-        self::assertInstanceOf(ValidatorChain::class, $defaultValidatorChain);
-        self::assertSame(
-            $validatorManager,
-            $defaultValidatorChain->getPluginManager(),
-            'Factory::getDefaultValidatorChain() is not populated with the expected plugin manager'
-        );
-    }
-
     /**
      * @psalm-return array<string, array{
      *     0: string,

--- a/test/InputFilterTest.php
+++ b/test/InputFilterTest.php
@@ -4,57 +4,25 @@ declare(strict_types=1);
 
 namespace LaminasTest\InputFilter;
 
-use ArrayIterator;
+use Laminas\InputFilter\Factory;
 use Laminas\InputFilter\Input;
 use Laminas\InputFilter\InputFilter;
+use Laminas\InputFilter\InputFilterInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
-use Traversable;
+use PHPUnit\Framework\TestCase;
 
-use function array_merge;
-
+/**
+ * @psalm-import-type InputSpecification from InputFilterInterface
+ * @psalm-import-type InputFilterSpecification from InputFilterInterface
+ */
 #[CoversClass(InputFilter::class)]
-final class InputFilterTest extends BaseInputFilterTest
+final class InputFilterTest extends TestCase
 {
-    /** @var InputFilter $inputFilter */
-    protected $inputFilter;
+    private Factory $factory;
 
     protected function setUp(): void
     {
         $this->factory = TestHelper::createInputFilterFactory();
-
-        $this->inputFilter = new InputFilter($this->factory);
-    }
-
-    /**
-     * @psalm-return array<string, array{
-     *     0: array|Traversable,
-     *     1: string,
-     *     2: Input
-     * }>
-     */
-    public static function inputProvider(): array
-    {
-        $dataSets = parent::inputProvider();
-
-        $inputSpecificationAsArray       = [
-            'name' => 'inputFoo',
-        ];
-        $inputSpecificationAsTraversable = new ArrayIterator($inputSpecificationAsArray);
-
-        $inputSpecificationResult = TestHelper::createInputFilterFactory()->createInput([
-            'name' => 'inputFoo',
-        ]);
-
-        // phpcs:disable
-        $inputFilterDataSets = [
-            // Description => [input, expected name, $expectedReturnInput]
-            'array' =>       [$inputSpecificationAsArray      , 'inputFoo', $inputSpecificationResult],
-            'Traversable' => [$inputSpecificationAsTraversable, 'inputFoo', $inputSpecificationResult],
-        ];
-        // phpcs:enable
-        $dataSets = array_merge($dataSets, $inputFilterDataSets);
-
-        return $dataSets;
     }
 
     /**

--- a/test/StaticAnalysis/AddingInputsWithArraySpecs.php
+++ b/test/StaticAnalysis/AddingInputsWithArraySpecs.php
@@ -30,13 +30,4 @@ final class AddingInputsWithArraySpecs extends InputFilter
             ],
         ]);
     }
-
-    public function addsAnInputWithNonStandardKeys(): void
-    {
-        $this->add([
-            'name'       => 'input1',
-            'required'   => true,
-            'custom-key' => 'something',
-        ]);
-    }
 }

--- a/test/TestHelper.php
+++ b/test/TestHelper.php
@@ -6,6 +6,7 @@ namespace LaminasTest\InputFilter;
 
 use Laminas\Filter\FilterChain;
 use Laminas\Filter\FilterPluginManager;
+use Laminas\InputFilter\ConfigProvider;
 use Laminas\InputFilter\Factory;
 use Laminas\InputFilter\InputFilterPluginManager;
 use Laminas\ServiceManager\ServiceManager;
@@ -13,35 +14,70 @@ use Laminas\Validator\ValidatorChain;
 use Laminas\Validator\ValidatorInterface;
 use Laminas\Validator\ValidatorPluginManager;
 use LaminasTest\InputFilter\TestAsset\ValidatorStub;
-use Psr\Container\ContainerInterface;
 use ReflectionProperty;
 
+use function array_replace_recursive;
+
+/** @psalm-import-type ServiceManagerConfiguration from ServiceManager */
 final class TestHelper
 {
-    public static function createInputFilterFactory(): Factory
+    public static function getContainer(array $config = []): ServiceManager
     {
-        $serviceManager = new ServiceManager();
-
-        $factory = new Factory(
-            self::createFilterPluginManager($serviceManager),
-            self::createValidatorPluginManager($serviceManager),
-            new InputFilterPluginManager($serviceManager)
+        $config = array_replace_recursive(
+            (new \Laminas\Filter\ConfigProvider())->__invoke(),
+            (new \Laminas\Validator\ConfigProvider())->__invoke(),
+            (new ConfigProvider())->__invoke(),
+            $config,
         );
 
-        $serviceManager->setService(Factory::class, $factory);
+        /** @psalm-var ServiceManagerConfiguration $deps */
+        $deps                       = $config['dependencies'] ?? [];
+        $deps['services']         ??= [];
+        $deps['services']['config'] = $config;
+
+        /** @psalm-var ServiceManagerConfiguration $deps */
+
+        return new ServiceManager($deps);
+    }
+
+    public static function createInputFilterFactory(ServiceManager|null $container = null): Factory
+    {
+        $container ??= self::getContainer();
+
+        if ($container->has(Factory::class)) {
+            return $container->get(Factory::class);
+        }
+
+        $factory = new Factory(
+            self::createFilterPluginManager($container),
+            self::createValidatorPluginManager($container),
+            new InputFilterPluginManager($container),
+        );
+
+        $container->setService(Factory::class, $factory);
 
         return $factory;
     }
 
-    public static function createFilterPluginManager(ContainerInterface|null $container = null): FilterPluginManager
+    public static function createFilterPluginManager(ServiceManager|null $container = null): FilterPluginManager
     {
-        return new FilterPluginManager($container ?? new ServiceManager());
+        $container ??= self::getContainer();
+        if ($container->has(FilterPluginManager::class)) {
+            return $container->get(FilterPluginManager::class);
+        }
+
+        return new FilterPluginManager($container);
     }
 
     public static function createValidatorPluginManager(
-        ContainerInterface|null $container = null
+        ServiceManager|null $container = null,
     ): ValidatorPluginManager {
-        return new ValidatorPluginManager($container ?? new ServiceManager());
+        $container ??= self::getContainer();
+        if ($container->has(ValidatorPluginManager::class)) {
+            return $container->get(ValidatorPluginManager::class);
+        }
+
+        return new ValidatorPluginManager($container);
     }
 
     public static function getFilterPluginManagerFromFilterChain(FilterChain $filterChain): mixed
@@ -54,7 +90,7 @@ final class TestHelper
         ?bool $isValid,
         mixed $value = 'not-set',
         ?array $context = null,
-        array $messages = []
+        array $messages = [],
     ): ValidatorInterface {
         return new ValidatorStub($isValid, $value, $context, $messages);
     }


### PR DESCRIPTION
- Factory now refuses to `new` custom `Input` types. We don't know what an extending class constructor looks like because they are not subject to LSP rules.
- `createInput` can no longer return an `InputFilter` - this brings significant improvements to type inference for users. A `create` method is used to conditionally return an `Input|InputFilter`
- "Default" filter chains, and "Default" validator chains are gone, along with the setters and getters.

Also, pretty big changes to the `InputFilter` Tests… Some of the data providers were hellish to read and follow and uneccessarily complicated.

The plan here is that after the upgrade, we should be closer to green CI - and hopefully failing tests in #149 will be fixed, or more easily fixable 🤞