### PR TITLE
Add a guard against invalid input names in input filter

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -37,9 +37,6 @@
     <MixedPropertyTypeCoercion>
       <code><![CDATA[$inputs]]></code>
     </MixedPropertyTypeCoercion>
-    <PossiblyNullArrayOffset>
-      <code><![CDATA[$this->inputs]]></code>
-    </PossiblyNullArrayOffset>
     <TooManyArguments>
       <code><![CDATA[isValid]]></code>
       <code><![CDATA[isValid]]></code>
@@ -371,17 +368,6 @@
       <code><![CDATA[testSetDataAndGetRawValueGetValue]]></code>
       <code><![CDATA[testSetTraversableDataAndGetRawValueGetValue]]></code>
     </InvalidArgument>
-    <LessSpecificReturnStatement>
-      <code><![CDATA[$dataSets]]></code>
-    </LessSpecificReturnStatement>
-    <MissingClosureParamType>
-      <code><![CDATA[$inputTypeData]]></code>
-      <code><![CDATA[$inputTypeData]]></code>
-    </MissingClosureParamType>
-    <MissingClosureReturnType>
-      <code><![CDATA[static fn($inputTypeData) => $inputTypeData[1]]]></code>
-      <code><![CDATA[static fn($inputTypeData) => $inputTypeData[2]]]></code>
-    </MissingClosureReturnType>
     <MixedArgument>
       <code><![CDATA[$input]]></code>
       <code><![CDATA[$set[5]]]></code>
@@ -392,10 +378,6 @@
       <code><![CDATA[$msg]]></code>
       <code><![CDATA[$msg]]></code>
     </MixedArgumentTypeCoercion>
-    <MixedArrayAccess>
-      <code><![CDATA[$inputTypeData[1]]]></code>
-      <code><![CDATA[$inputTypeData[2]]]></code>
-    </MixedArrayAccess>
     <MixedArrayAssignment>
       <code><![CDATA[$set[0][$name]]]></code>
       <code><![CDATA[$set[5][$name]]]></code>
@@ -409,9 +391,11 @@
       <code><![CDATA[$set[0][$name]]]></code>
       <code><![CDATA[$set[5][$name]]]></code>
       <code><![CDATA[$set[6][$name]]]></code>
-      <code><![CDATA[$tmpTemplate[2]]]></code>
-      <code><![CDATA[$tmpTemplate[3]]]></code>
     </MixedAssignment>
+    <MixedReturnStatement>
+      <code><![CDATA[$inputTypeData[1]]]></code>
+      <code><![CDATA[$inputTypeData[2]]]></code>
+    </MixedReturnStatement>
     <MixedReturnTypeCoercion>
       <code><![CDATA[$dataSets]]></code>
       <code><![CDATA[array<string, array{
@@ -425,14 +409,6 @@
      *     7: string[]
      * }>]]></code>
     </MixedReturnTypeCoercion>
-    <MoreSpecificReturnType>
-      <code><![CDATA[array<string, array{
-     *     0: InputInterface,
-     *     1: null|string,
-     *     2: null|string,
-     *     3: InputInterface,
-     * }>]]></code>
-    </MoreSpecificReturnType>
     <PossiblyInvalidArgument>
       <code><![CDATA[$input]]></code>
       <code><![CDATA[$input]]></code>
@@ -440,13 +416,6 @@
       <code><![CDATA[testSetDataAndGetRawValueGetValue]]></code>
       <code><![CDATA[testSetTraversableDataAndGetRawValueGetValue]]></code>
     </PossiblyInvalidArgument>
-    <PossiblyNullArgument>
-      <code><![CDATA[$expectedInputName]]></code>
-      <code><![CDATA[$expectedInputName]]></code>
-      <code><![CDATA[$expectedInputName]]></code>
-      <code><![CDATA[$expectedInputName]]></code>
-      <code><![CDATA[$expectedInputName]]></code>
-    </PossiblyNullArgument>
     <PossiblyUndefinedMethod>
       <code><![CDATA[getName]]></code>
       <code><![CDATA[getName]]></code>
@@ -540,13 +509,6 @@
     </MoreSpecificReturnType>
   </file>
   <file src="test/InputFilterTest.php">
-    <ImplementedReturnTypeMismatch>
-      <code><![CDATA[array<string, array{
-     *     0: array|Traversable,
-     *     1: string,
-     *     2: Input
-     * }>]]></code>
-    </ImplementedReturnTypeMismatch>
     <LessSpecificReturnStatement>
       <code><![CDATA[$dataSets]]></code>
     </LessSpecificReturnStatement>
@@ -560,6 +522,9 @@
     <NonInvariantDocblockPropertyType>
       <code><![CDATA[$inputFilter]]></code>
     </NonInvariantDocblockPropertyType>
+    <OverriddenPropertyAccess>
+      <code><![CDATA[$inputFilter]]></code>
+    </OverriddenPropertyAccess>
     <PossiblyInvalidArgument>
       <code><![CDATA[$factory]]></code>
     </PossiblyInvalidArgument>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -522,9 +522,6 @@
     <NonInvariantDocblockPropertyType>
       <code><![CDATA[$inputFilter]]></code>
     </NonInvariantDocblockPropertyType>
-    <OverriddenPropertyAccess>
-      <code><![CDATA[$inputFilter]]></code>
-    </OverriddenPropertyAccess>
     <PossiblyInvalidArgument>
       <code><![CDATA[$factory]]></code>
     </PossiblyInvalidArgument>

--- a/src/BaseInputFilter.php
+++ b/src/BaseInputFilter.php
@@ -20,6 +20,7 @@ use function func_get_args;
 use function get_debug_type;
 use function is_array;
 use function is_int;
+use function is_string;
 use function sprintf;
 
 /**
@@ -98,6 +99,29 @@ class BaseInputFilter implements
 
         if ($input instanceof InputInterface && ($name === null || $name === '' || is_int($name))) {
             $name = $input->getName();
+
+            /** @psalm-suppress DocblockTypeContradiction Input conflicts with InputInterface docblock and allows null. */
+            if ($name === null || $name === '') {
+                throw new Exception\InvalidArgumentException(sprintf(
+                    '%s: input instance must have a valid name or input name must be provided as a parameter',
+                    __METHOD__,
+                ));
+            }
+        }
+
+        if (! is_string($name) && ! is_int($name)) {
+            throw new Exception\InvalidArgumentException(sprintf(
+                '%s: input name expected to be string or int, %s given',
+                __METHOD__,
+                get_debug_type($name)
+            ));
+        }
+
+        if ($name === '') {
+            throw new Exception\InvalidArgumentException(sprintf(
+                '%s: input name can not be an empty string',
+                __METHOD__,
+            ));
         }
 
         if (
@@ -126,6 +150,15 @@ class BaseInputFilter implements
      */
     public function replace($input, $name)
     {
+        /** @psalm-suppress DocblockTypeContradiction  */
+        if (! is_string($name) && ! is_int($name)) {
+            throw new Exception\InvalidArgumentException(sprintf(
+                '%s: input name expected to be string or int, %s given',
+                __METHOD__,
+                get_debug_type($name),
+            ));
+        }
+
         if (! array_key_exists($name, $this->inputs)) {
             throw new Exception\InvalidArgumentException(sprintf(
                 '%s: no input found matching "%s"',
@@ -149,6 +182,15 @@ class BaseInputFilter implements
      */
     public function get($name)
     {
+        /** @psalm-suppress DocblockTypeContradiction  */
+        if (! is_string($name) && ! is_int($name)) {
+            throw new Exception\InvalidArgumentException(sprintf(
+                '%s: input name expected to be string or int, %s given',
+                __METHOD__,
+                get_debug_type($name),
+            ));
+        }
+
         if (! array_key_exists($name, $this->inputs)) {
             throw new Exception\InvalidArgumentException(sprintf(
                 '%s: no input found matching "%s"',
@@ -167,6 +209,14 @@ class BaseInputFilter implements
      */
     public function has($name)
     {
+        /** @psalm-suppress DocblockTypeContradiction  */
+        if (! is_string($name) && ! is_int($name)) {
+            throw new Exception\InvalidArgumentException(sprintf(
+                '%s: input name expected to be string or int, %s given',
+                __METHOD__,
+                get_debug_type($name),
+            ));
+        }
         return array_key_exists($name, $this->inputs);
     }
 
@@ -178,6 +228,14 @@ class BaseInputFilter implements
      */
     public function remove($name)
     {
+        /** @psalm-suppress DocblockTypeContradiction  */
+        if (! is_string($name) && ! is_int($name)) {
+            throw new Exception\InvalidArgumentException(sprintf(
+                '%s: input name expected to be string or int, %s given',
+                __METHOD__,
+                get_debug_type($name),
+            ));
+        }
         unset($this->inputs[$name]);
         return $this;
     }

--- a/test/BaseInputFilterTest.php
+++ b/test/BaseInputFilterTest.php
@@ -218,7 +218,7 @@ class BaseInputFilterTest extends TestCase
     public function testAddHasGet(
         InputInterface|InputFilterInterface|iterable $input,
         ?string $name,
-        ?string $expectedInputName,
+        string $expectedInputName,
         object $expectedInput
     ): void {
         $inputFilter = $this->inputFilter;
@@ -246,7 +246,7 @@ class BaseInputFilterTest extends TestCase
     public function testAddRemove(
         InputInterface|InputFilterInterface|iterable $input,
         ?string $name,
-        ?string $expectedInputName
+        string $expectedInputName
     ): void {
         $inputFilter = $this->inputFilter;
 
@@ -723,19 +723,19 @@ class BaseInputFilterTest extends TestCase
 
     /**
      * @psalm-return array<string, array{
-     *     0: InputInterface,
+     *     0: InputInterface|InputFilterInterface|iterable,
      *     1: null|string,
-     *     2: null|string,
-     *     3: InputInterface,
+     *     2: string,
+     *     3: InputInterface|InputFilterInterface,
      * }>
      */
     public static function addMethodArgumentsProvider(): array
     {
         $inputTypes = static::inputProvider();
 
-        $inputName = static fn($inputTypeData) => $inputTypeData[1];
+        $inputName = static fn(array $inputTypeData): string => $inputTypeData[1];
 
-        $sameInput = static fn($inputTypeData) => $inputTypeData[2];
+        $sameInput = static fn(array $inputTypeData): InputInterface|InputFilterInterface => $inputTypeData[2];
 
         // phpcs:disable WebimpressCodingStandard.WhiteSpace.CommaSpacing.SpaceBeforeComma
         $dataTemplates = [
@@ -750,10 +750,17 @@ class BaseInputFilterTest extends TestCase
         $dataSets = [];
         foreach ($dataTemplates as $dataTemplateDescription => $dataTemplate) {
             foreach ($dataTemplate[0] as $inputTypeDescription => $inputTypeData) {
+                if ($dataTemplate[1] === null && $inputTypeData[1] === null) {
+                    /**
+                     * Input name must be provided explicitly or implicitly.
+                     * InputFilterInterface does not have an instance name so it can't be set implicitly.
+                     */
+                    continue;
+                }
                 $tmpTemplate    = $dataTemplate;
                 $tmpTemplate[0] = $inputTypeData[0]; // expand input
-                if (is_callable($dataTemplate[2])) {
-                    $tmpTemplate[2] = $dataTemplate[2]($inputTypeData);
+                if (is_callable($tmpTemplate[2])) {
+                    $tmpTemplate[2] = $tmpTemplate[2]($inputTypeData);
                 }
                 $tmpTemplate[3] = $dataTemplate[3]($inputTypeData);
 
@@ -920,7 +927,7 @@ class BaseInputFilterTest extends TestCase
 
     /**
      * @psalm-return array<string, array{
-     *     0: InputInterface|InputFilterInterface,
+     *     0: InputInterface|InputFilterInterface|iterable,
      *     1: null|string,
      *     2: InputInterface|InputFilterInterface,
      * }>

--- a/test/InputFilterTest.php
+++ b/test/InputFilterTest.php
@@ -108,17 +108,4 @@ final class InputFilterTest extends BaseInputFilterTest
         $filter1->setData(['nested' => null]);
         self::assertEquals($expect, $filter1->getValues());
     }
-
-    public function testInputsWithoutANameYieldMergedInputsWithAnEmptyName(): void
-    {
-        $a = new Input();
-        $b = new Input();
-
-        $filter = new InputFilter();
-        $filter->add($a);
-        $filter->add($b);
-
-        self::assertCount(1, $filter->getInputs());
-        self::assertSame($a, $filter->get(''));
-    }
 }


### PR DESCRIPTION
Input filter does not properly handle invalid input filter names. Problematic behavior is exhibited when input name is null or empty string and input instance has null or empty string for the name.

```php
$input1 = new Input();
$input2 = new Input();
// ... some code
$inputFilter->add($input2); // set as ''
$inputFilter->add($input2); // merged into '' - input 1
$inputFilter->has(null); // true
$inputFilter->get(null); // same as get('') and returns input 1
```

Both inputs have null as an input name that effectively is treated as `''`. 
Quite unexpected `$input` instance was modified with values from `$anotherInput`. Yikes.

https://github.com/laminas/laminas-inputfilter/blob/63e2e94cb8e71a923bcc0b7e72c6fbe5aa3718bd/src/BaseInputFilter.php#L103-L112

Ironically, tests are setup with invalid dataset in data provider and it came to light only thanks to PHP 8.5 deprecation. See #155 

Let's practice Source Driven Test Development :+1:. Tests are unreadable so I start with introduction of the guards in the source to make tests fail.