### PR TITLE
Require `psr/http-message` as a direct dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,19 +36,16 @@
         "laminas/laminas-servicemanager": "^4.0",
         "laminas/laminas-stdlib": "^3.19",
         "laminas/laminas-validator": "^3.11.0",
-        "psr/container": "^1.1 || ^2.0"
+        "psr/container": "^1.1 || ^2.0",
+        "psr/http-message": "^2.0"
     },
     "require-dev": {
         "ext-json": "*",
         "laminas/laminas-coding-standard": "^3.1.0",
         "phpunit/phpunit": "^11.5.44",
         "psalm/plugin-phpunit": "^0.19.5",
-        "psr/http-message": "^2.0",
         "vimeo/psalm": "^6.13.1",
         "webmozart/assert": "^1.12.1"
-    },
-    "suggest": {
-        "psr/http-message-implementation": "PSR-7 is required if you wish to validate PSR-7 UploadedFileInterface payloads"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6a78a77453101402cf8f765c22392f02",
+    "content-hash": "64a06d157bb07660f9764a3a14e04c25",
     "packages": [
         {
             "name": "brick/varexporter",
@@ -5545,16 +5545,16 @@
         },
         {
             "name": "theseer/tokenizer",
-            "version": "1.3.0",
+            "version": "1.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/theseer/tokenizer.git",
-                "reference": "d74205c497bfbca49f34d4bc4c19c17e22db4ebb"
+                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/d74205c497bfbca49f34d4bc4c19c17e22db4ebb",
-                "reference": "d74205c497bfbca49f34d4bc4c19c17e22db4ebb",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/b7489ce515e168639d17feec34b8847c326b0b3c",
+                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c",
                 "shasum": ""
             },
             "require": {
@@ -5583,7 +5583,7 @@
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
             "support": {
                 "issues": "https://github.com/theseer/tokenizer/issues",
-                "source": "https://github.com/theseer/tokenizer/tree/1.3.0"
+                "source": "https://github.com/theseer/tokenizer/tree/1.3.1"
             },
             "funding": [
                 {
@@ -5591,7 +5591,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-11-13T13:44:09+00:00"
+            "time": "2025-11-17T20:03:58+00:00"
         },
         {
             "name": "vimeo/psalm",

--- a/tools/crc/config.json
+++ b/tools/crc/config.json
@@ -1,5 +1,2 @@
 {
-    "symbol-whitelist" : [
-        "Psr\\Http\\Message\\UploadedFileInterface"
-    ]
 }


### PR DESCRIPTION
We use these symbols in `/src` so they should be listed as a hard dependency
