### PR TITLE
Add native property, parameter and return types

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -7,6 +7,9 @@
       <code><![CDATA[$this->value]]></code>
       <code><![CDATA[$this->value]]></code>
     </DeprecatedProperty>
+    <MixedArgumentTypeCoercion>
+      <code><![CDATA[$context]]></code>
+    </MixedArgumentTypeCoercion>
     <MixedAssignment>
       <code><![CDATA[$value]]></code>
     </MixedAssignment>
@@ -14,68 +17,34 @@
   <file src="src/BaseInputFilter.php">
     <InvalidReturnStatement>
       <code><![CDATA[$values]]></code>
+      <code><![CDATA[array_map(
+            static fn (InputInterface|InputFilterInterface $input): array => $input->getMessages(),
+            $this->getInvalidInput(),
+        )]]></code>
     </InvalidReturnStatement>
     <InvalidReturnType>
       <code><![CDATA[TFilteredValues]]></code>
+      <code><![CDATA[array]]></code>
     </InvalidReturnType>
     <MixedArgumentTypeCoercion>
-      <code><![CDATA[$inputs]]></code>
+      <code><![CDATA[$value]]></code>
+      <code><![CDATA[$value]]></code>
     </MixedArgumentTypeCoercion>
     <MixedAssignment>
-      <code><![CDATA[$inputContext]]></code>
-      <code><![CDATA[$unknownInputs[$key]]]></code>
       <code><![CDATA[$value]]></code>
     </MixedAssignment>
-    <MixedPropertyTypeCoercion>
-      <code><![CDATA[$inputs]]></code>
-    </MixedPropertyTypeCoercion>
     <PossiblyUnusedMethod>
       <code><![CDATA[count]]></code>
     </PossiblyUnusedMethod>
-    <TooManyArguments>
-      <code><![CDATA[isValid]]></code>
-      <code><![CDATA[isValid]]></code>
-    </TooManyArguments>
   </file>
   <file src="src/CollectionInputFilter.php">
-    <ImplementedParamTypeMismatch>
-      <code><![CDATA[$name]]></code>
-      <code><![CDATA[$name]]></code>
-    </ImplementedParamTypeMismatch>
     <InvalidPropertyAssignmentValue>
-      <code><![CDATA[$name]]></code>
       <code><![CDATA[$this->collectionMessages]]></code>
       <code><![CDATA[$this->collectionMessages]]></code>
-      <code><![CDATA[$this->invalidInputs]]></code>
-      <code><![CDATA[$this->validInputs]]></code>
     </InvalidPropertyAssignmentValue>
-    <InvalidReturnStatement>
-      <code><![CDATA[$this->collectionValues]]></code>
-    </InvalidReturnStatement>
-    <InvalidReturnType>
-      <code><![CDATA[TFilteredValues]]></code>
-    </InvalidReturnType>
-    <MixedArgument>
-      <code><![CDATA[$data]]></code>
-    </MixedArgument>
-    <MixedAssignment>
-      <code><![CDATA[$data]]></code>
-    </MixedAssignment>
-    <MixedPropertyTypeCoercion>
-      <code><![CDATA[$this->collectionValues]]></code>
-    </MixedPropertyTypeCoercion>
-    <PossiblyUnusedReturnValue>
-      <code><![CDATA[array[]]]></code>
-      <code><![CDATA[array[]]]></code>
-    </PossiblyUnusedReturnValue>
-    <UnusedPsalmSuppress>
-      <code><![CDATA[DocblockTypeContradiction]]></code>
-      <code><![CDATA[DocblockTypeContradiction]]></code>
-      <code><![CDATA[DocblockTypeContradiction]]></code>
-      <code><![CDATA[RedundantConditionGivenDocblockType]]></code>
-      <code><![CDATA[RedundantConditionGivenDocblockType]]></code>
-      <code><![CDATA[RedundantConditionGivenDocblockType]]></code>
-    </UnusedPsalmSuppress>
+    <PropertyTypeCoercion>
+      <code><![CDATA[$name]]></code>
+    </PropertyTypeCoercion>
   </file>
   <file src="src/EmptyContextInterface.php">
     <PossiblyUnusedReturnValue>
@@ -100,6 +69,10 @@
     </MoreSpecificImplementedParamType>
   </file>
   <file src="src/FileInput/HttpServerFileInputHandler.php">
+    <MixedArgumentTypeCoercion>
+      <code><![CDATA[$context]]></code>
+      <code><![CDATA[$context]]></code>
+    </MixedArgumentTypeCoercion>
     <MixedAssignment>
       <code><![CDATA[$fileData]]></code>
       <code><![CDATA[$value]]></code>
@@ -109,6 +82,10 @@
     <MixedArgument>
       <code><![CDATA[$rawValue[0]]]></code>
     </MixedArgument>
+    <MixedArgumentTypeCoercion>
+      <code><![CDATA[$context]]></code>
+      <code><![CDATA[$context]]></code>
+    </MixedArgumentTypeCoercion>
     <MixedAssignment>
       <code><![CDATA[$fileData]]></code>
       <code><![CDATA[$newValue[]]]></code>
@@ -119,9 +96,20 @@
     </MoreSpecificImplementedParamType>
   </file>
   <file src="src/Input.php">
-    <MixedAssignment>
-      <code><![CDATA[$value]]></code>
-    </MixedAssignment>
+    <InvalidReturnStatement>
+      <code><![CDATA[(array) $this->errorMessage]]></code>
+    </InvalidReturnStatement>
+    <InvalidReturnType>
+      <code><![CDATA[array]]></code>
+    </InvalidReturnType>
+    <LessSpecificReturnStatement>
+      <code><![CDATA[$this]]></code>
+      <code><![CDATA[$this]]></code>
+      <code><![CDATA[$this]]></code>
+    </LessSpecificReturnStatement>
+    <MixedArgumentTypeCoercion>
+      <code><![CDATA[$context]]></code>
+    </MixedArgumentTypeCoercion>
   </file>
   <file src="src/InputFilterAbstractServiceFactory.php">
     <MixedArgument>
@@ -169,7 +157,6 @@
   </file>
   <file src="test/BaseInputFilterTest.php">
     <InvalidArgument>
-      <code><![CDATA[['nested' => ['nested-input1', 'nested-input2']]]]></code>
       <code><![CDATA[testSetDataAndGetRawValueGetValue]]></code>
       <code><![CDATA[testSetTraversableDataAndGetRawValueGetValue]]></code>
     </InvalidArgument>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -46,11 +46,6 @@
       <code><![CDATA[$name]]></code>
     </PropertyTypeCoercion>
   </file>
-  <file src="src/EmptyContextInterface.php">
-    <PossiblyUnusedReturnValue>
-      <code><![CDATA[static]]></code>
-    </PossiblyUnusedReturnValue>
-  </file>
   <file src="src/Factory.php">
     <MixedArgument>
       <code><![CDATA[$inputFilterSpecification['count']]]></code>
@@ -124,11 +119,6 @@
       <code><![CDATA[$config]]></code>
     </MixedAssignment>
   </file>
-  <file src="src/InputFilterInterface.php">
-    <PossiblyUnusedReturnValue>
-      <code><![CDATA[static]]></code>
-    </PossiblyUnusedReturnValue>
-  </file>
   <file src="src/InputFilterPluginManager.php">
     <MethodSignatureMismatch>
       <code><![CDATA[InputFilterPluginManager]]></code>
@@ -140,13 +130,6 @@
   </file>
   <file src="src/InputInterface.php">
     <PossiblyUnusedReturnValue>
-      <code><![CDATA[static]]></code>
-      <code><![CDATA[static]]></code>
-      <code><![CDATA[static]]></code>
-      <code><![CDATA[static]]></code>
-      <code><![CDATA[static]]></code>
-      <code><![CDATA[static]]></code>
-      <code><![CDATA[static]]></code>
       <code><![CDATA[static]]></code>
     </PossiblyUnusedReturnValue>
   </file>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -33,9 +33,6 @@
     <MixedAssignment>
       <code><![CDATA[$value]]></code>
     </MixedAssignment>
-    <PossiblyUnusedMethod>
-      <code><![CDATA[count]]></code>
-    </PossiblyUnusedMethod>
   </file>
   <file src="src/CollectionInputFilter.php">
     <InvalidPropertyAssignmentValue>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -7,17 +7,9 @@
       <code><![CDATA[$this->value]]></code>
       <code><![CDATA[$this->value]]></code>
     </DeprecatedProperty>
-    <InvalidPropertyAssignmentValue>
-      <code><![CDATA[$this->prepareNotArrayFailureMessage()]]></code>
-      <code><![CDATA[$this->prepareRequiredValidationFailureMessage()]]></code>
-      <code><![CDATA[$this->prepareRequiredValidationFailureMessage()]]></code>
-    </InvalidPropertyAssignmentValue>
     <MixedAssignment>
       <code><![CDATA[$value]]></code>
     </MixedAssignment>
-    <RedundantConditionGivenDocblockType>
-      <code><![CDATA[! $required]]></code>
-    </RedundantConditionGivenDocblockType>
   </file>
   <file src="src/BaseInputFilter.php">
     <InvalidReturnStatement>
@@ -37,6 +29,9 @@
     <MixedPropertyTypeCoercion>
       <code><![CDATA[$inputs]]></code>
     </MixedPropertyTypeCoercion>
+    <PossiblyUnusedMethod>
+      <code><![CDATA[count]]></code>
+    </PossiblyUnusedMethod>
     <TooManyArguments>
       <code><![CDATA[isValid]]></code>
       <code><![CDATA[isValid]]></code>
@@ -84,7 +79,7 @@
   </file>
   <file src="src/EmptyContextInterface.php">
     <PossiblyUnusedReturnValue>
-      <code><![CDATA[self]]></code>
+      <code><![CDATA[static]]></code>
     </PossiblyUnusedReturnValue>
   </file>
   <file src="src/Factory.php">
@@ -96,9 +91,6 @@
     </MixedArgument>
   </file>
   <file src="src/FileInput.php">
-    <InvalidPropertyAssignmentValue>
-      <code><![CDATA[$this->prepareRequiredValidationFailureMessage()]]></code>
-    </InvalidPropertyAssignmentValue>
     <MixedAssignment>
       <code><![CDATA[$rawValue]]></code>
     </MixedAssignment>
@@ -110,7 +102,6 @@
   <file src="src/FileInput/HttpServerFileInputHandler.php">
     <MixedAssignment>
       <code><![CDATA[$fileData]]></code>
-      <code><![CDATA[$newValue[]]]></code>
       <code><![CDATA[$value]]></code>
     </MixedAssignment>
   </file>
@@ -128,24 +119,18 @@
     </MoreSpecificImplementedParamType>
   </file>
   <file src="src/Input.php">
-    <DocblockTypeContradiction>
-      <code><![CDATA[is_array($this->errorMessage)]]></code>
-    </DocblockTypeContradiction>
     <ImplementedReturnTypeMismatch>
       <code><![CDATA[null|string]]></code>
     </ImplementedReturnTypeMismatch>
-    <InvalidPropertyAssignmentValue>
-      <code><![CDATA[$this->prepareRequiredValidationFailureMessage()]]></code>
-    </InvalidPropertyAssignmentValue>
+    <InvalidReturnStatement>
+      <code><![CDATA[$this->errorMessage]]></code>
+    </InvalidReturnStatement>
+    <InvalidReturnType>
+      <code><![CDATA[string|null]]></code>
+    </InvalidReturnType>
     <MixedAssignment>
       <code><![CDATA[$value]]></code>
     </MixedAssignment>
-    <RedundantCastGivenDocblockType>
-      <code><![CDATA[(bool) $allowEmpty]]></code>
-      <code><![CDATA[(bool) $breakOnFailure]]></code>
-      <code><![CDATA[(bool) $continueIfEmpty]]></code>
-      <code><![CDATA[(string) $errorMessage]]></code>
-    </RedundantCastGivenDocblockType>
   </file>
   <file src="src/InputFilterAbstractServiceFactory.php">
     <MixedArgument>
@@ -177,13 +162,13 @@
   <file src="src/InputInterface.php">
     <PossiblyUnusedReturnValue>
       <code><![CDATA[$this]]></code>
-      <code><![CDATA[$this]]></code>
-      <code><![CDATA[$this]]></code>
-      <code><![CDATA[$this]]></code>
-      <code><![CDATA[$this]]></code>
-      <code><![CDATA[$this]]></code>
-      <code><![CDATA[$this]]></code>
-      <code><![CDATA[$this]]></code>
+      <code><![CDATA[static]]></code>
+      <code><![CDATA[static]]></code>
+      <code><![CDATA[static]]></code>
+      <code><![CDATA[static]]></code>
+      <code><![CDATA[static]]></code>
+      <code><![CDATA[static]]></code>
+      <code><![CDATA[static]]></code>
     </PossiblyUnusedReturnValue>
   </file>
   <file src="src/OptionalInputFilter.php">

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -119,15 +119,6 @@
     </MoreSpecificImplementedParamType>
   </file>
   <file src="src/Input.php">
-    <ImplementedReturnTypeMismatch>
-      <code><![CDATA[null|string]]></code>
-    </ImplementedReturnTypeMismatch>
-    <InvalidReturnStatement>
-      <code><![CDATA[$this->errorMessage]]></code>
-    </InvalidReturnStatement>
-    <InvalidReturnType>
-      <code><![CDATA[string|null]]></code>
-    </InvalidReturnType>
     <MixedAssignment>
       <code><![CDATA[$value]]></code>
     </MixedAssignment>
@@ -161,7 +152,7 @@
   </file>
   <file src="src/InputInterface.php">
     <PossiblyUnusedReturnValue>
-      <code><![CDATA[$this]]></code>
+      <code><![CDATA[static]]></code>
       <code><![CDATA[static]]></code>
       <code><![CDATA[static]]></code>
       <code><![CDATA[static]]></code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -41,9 +41,6 @@
       <code><![CDATA[isValid]]></code>
       <code><![CDATA[isValid]]></code>
     </TooManyArguments>
-    <UnusedPsalmSuppress>
-      <code><![CDATA[RedundantConditionGivenDocblockType]]></code>
-    </UnusedPsalmSuppress>
   </file>
   <file src="src/CollectionInputFilter.php">
     <ImplementedParamTypeMismatch>
@@ -165,7 +162,7 @@
   </file>
   <file src="src/InputFilterInterface.php">
     <PossiblyUnusedReturnValue>
-      <code><![CDATA[InputFilterInterface]]></code>
+      <code><![CDATA[static]]></code>
     </PossiblyUnusedReturnValue>
   </file>
   <file src="src/InputFilterPluginManager.php">

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -216,29 +216,6 @@
     </PossiblyInvalidArgument>
   </file>
   <file src="test/FactoryTest.php">
-    <InvalidArgument>
-      <code><![CDATA[[
-            0 => [
-                'type' => InputFilter::class,
-                'name' => 'bar',
-                '0'    => [
-                    'name' => 'bat',
-                ],
-                '1'    => [
-                    'name' => 'baz',
-                ],
-            ],
-            1 => [
-                'type'         => CollectionInputFilter::class,
-                'name'         => 'foo',
-                'input_filter' => [
-                    '0' => [
-                        'name' => 'bat',
-                    ],
-                ],
-            ],
-        ]]]></code>
-    </InvalidArgument>
     <UndefinedInterfaceMethod>
       <code><![CDATA[continueIfEmpty]]></code>
     </UndefinedInterfaceMethod>

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -9,6 +9,7 @@
     findUnusedCode="true"
     findUnusedBaselineEntry="true"
     findUnusedPsalmSuppress="true"
+    ensureOverrideAttribute="false"
 >
     <projectFiles>
         <directory name="src"/>
@@ -34,13 +35,6 @@
                 <directory name="test/StaticAnalysis" />
             </errorLevel>
         </PossiblyUnusedMethod>
-
-        <MissingOverrideAttribute>
-            <errorLevel type="suppress">
-                <directory name="src" />
-                <directory name="test" />
-            </errorLevel>
-        </MissingOverrideAttribute>
     </issueHandlers>
 
     <stubs>

--- a/src/ArrayInput.php
+++ b/src/ArrayInput.php
@@ -25,7 +25,7 @@ class ArrayInput extends Input
      *
      * @inheritDoc
      */
-    public function resetValue()
+    public function resetValue(): static
     {
         $this->value    = [];
         $this->hasValue = false;

--- a/src/ArrayInput.php
+++ b/src/ArrayInput.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Laminas\InputFilter;
 
 use Laminas\Validator\IsArray;
+use Laminas\Validator\ValidatorChain;
 
 use function array_map;
 use function assert;
@@ -13,12 +14,8 @@ use function is_array;
 /** @final */
 class ArrayInput extends Input
 {
-    /**
-     * @deprecated since 2.30.1 The default value should be null as in parent `Input`
-     *
-     * @var mixed
-     */
-    protected $value = [];
+    /** @deprecated since 2.30.1 The default value should be null as in parent `Input` */
+    protected mixed $value = [];
 
     /**
      * @deprecated since 2.30.1 Once the default value is null, this method is no longer required
@@ -32,8 +29,7 @@ class ArrayInput extends Input
         return $this;
     }
 
-    /** @inheritDoc */
-    public function getValue()
+    public function getValue(): mixed
     {
         if (! is_array($this->value)) {
             return $this->value;
@@ -50,27 +46,23 @@ class ArrayInput extends Input
     /** @inheritDoc */
     public function isValid(?array $context = null): bool
     {
-        $hasValue    = $this->hasValue();
-        $required    = $this->isRequired();
-        $hasFallback = $this->hasFallback();
-
-        if (! $hasValue && $hasFallback) {
+        if (! $this->hasValue && $this->hasFallback) {
             $this->setValue($this->getFallbackValue());
             return true;
         }
 
-        if (! $hasValue && $required) {
+        if (! $this->hasValue && $this->required) {
             if ($this->errorMessage === null) {
                 $this->errorMessage = $this->prepareRequiredValidationFailureMessage();
             }
             return false;
         }
 
-        if (! $hasValue && ! $required) {
+        if (! $this->hasValue) {
             return true;
         }
 
-        if (! $this->continueIfEmpty() && ! $this->allowEmpty()) {
+        if (! $this->continueIfEmpty && ! $this->allowEmpty) {
             $this->injectNotEmptyValidator();
         }
 
@@ -85,7 +77,7 @@ class ArrayInput extends Input
         $validator = $this->getValidatorChain();
         $result    = true;
 
-        if ($required && empty($values)) {
+        if ($this->required && empty($values)) {
             if ($this->errorMessage === null) {
                 $this->errorMessage = $this->prepareRequiredValidationFailureMessage();
             }
@@ -104,7 +96,7 @@ class ArrayInput extends Input
             }
             $result = $validator->isValid($value, $context);
             if (! $result) {
-                if ($hasFallback) {
+                if ($this->hasFallback) {
                     $this->setValue($this->getFallbackValue());
                     return true;
                 }
@@ -118,7 +110,12 @@ class ArrayInput extends Input
     /** @return array<string, string> */
     private function prepareNotArrayFailureMessage(): array
     {
-        $chain   = $this->getValidatorChain();
+        $chain = $this->getValidatorChain();
+        /**
+         * @todo We cannot call half these methods on ValidatorChainInterface, so we must devise a better way
+         *       of configuring the 'Not Array' error messages, and, allowing users to translate these error messages.
+         */
+        assert($chain instanceof ValidatorChain);
         $isArray = $chain->plugin(IsArray::class);
 
         foreach ($chain->getValidators() as $validator) {

--- a/src/ArrayInput.php
+++ b/src/ArrayInput.php
@@ -44,7 +44,7 @@ class ArrayInput extends Input
     }
 
     /** @inheritDoc */
-    public function isValid(?array $context = null): bool
+    public function isValid(array|null $context = null): bool
     {
         if (! $this->hasValue && $this->hasFallback) {
             $this->setValue($this->getFallbackValue());

--- a/src/BaseInputFilter.php
+++ b/src/BaseInputFilter.php
@@ -375,7 +375,7 @@ class BaseInputFilter implements
      *
      * @return array<array-key, InputInterface|InputFilterInterface>
      */
-    public function getInvalidInput()
+    public function getInvalidInput(): array
     {
         return is_array($this->invalidInputs) ? $this->invalidInputs : [];
     }
@@ -388,7 +388,7 @@ class BaseInputFilter implements
      *
      * @return array<array-key, InputInterface|InputFilterInterface>
      */
-    public function getValidInput()
+    public function getValidInput(): array
     {
         return is_array($this->validInputs) ? $this->validInputs : [];
     }
@@ -424,7 +424,7 @@ class BaseInputFilter implements
      *
      * @return TFilteredValues
      */
-    public function getValues()
+    public function getValues(): array
     {
         $inputs = $this->validationGroup ?? array_keys($this->inputs);
         $values = [];
@@ -470,7 +470,7 @@ class BaseInputFilter implements
      *
      * @return array<array-key, mixed>
      */
-    public function getRawValues()
+    public function getRawValues(): array
     {
         $values = [];
         foreach ($this->inputs as $name => $input) {
@@ -493,7 +493,7 @@ class BaseInputFilter implements
      *
      * @return array<array-key, array<array-key, string|array>>
      */
-    public function getMessages()
+    public function getMessages(): array
     {
         $messages = [];
         foreach ($this->getInvalidInput() as $name => $input) {
@@ -575,9 +575,8 @@ class BaseInputFilter implements
      * Is the data set has unknown input ?
      *
      * @throws Exception\RuntimeException
-     * @return bool
      */
-    public function hasUnknown()
+    public function hasUnknown(): bool
     {
         return $this->getUnknown() ? true : false;
     }

--- a/src/BaseInputFilter.php
+++ b/src/BaseInputFilter.php
@@ -148,9 +148,8 @@ class BaseInputFilter implements
      * @param  InputInterface|InputFilterInterface|InputSpecification|InputFilterSpecification $input
      * @param  array-key                           $name Name of the input to replace
      * @throws Exception\InvalidArgumentException If input to replace not exists.
-     * @return self
      */
-    public function replace($input, $name)
+    public function replace($input, $name): static
     {
         /** @psalm-suppress DocblockTypeContradiction  */
         if (! is_string($name) && ! is_int($name)) {
@@ -224,10 +223,9 @@ class BaseInputFilter implements
     /**
      * Remove a named input
      *
-     * @param  array-key $name
-     * @return InputFilterInterface
+     * @param array-key $name
      */
-    public function remove($name)
+    public function remove($name): static
     {
         /** @psalm-suppress DocblockTypeContradiction  */
         if (! is_string($name) && ! is_int($name)) {
@@ -246,9 +244,8 @@ class BaseInputFilter implements
      *
      * @param  iterable|null $data null is cast to an empty array.
      * @throws Exception\InvalidArgumentException
-     * @return InputFilterInterface
      */
-    public function setData($data)
+    public function setData($data): static
     {
         // A null value indicates an empty set
         if (null === $data) {
@@ -259,7 +256,7 @@ class BaseInputFilter implements
             $data = ArrayUtils::iteratorToArray($data);
         }
 
-        /** @psalm-suppress RedundantConditionGivenDocblockType, DocblockTypeContradiction */
+        /** @psalm-suppress DocblockTypeContradiction */
         if (! is_array($data)) {
             throw new Exception\InvalidArgumentException(sprintf(
                 '%s expects an array or Traversable argument; received %s',
@@ -369,9 +366,8 @@ class BaseInputFilter implements
      *
      * @param  array-key|array<array-key, array-key> $name
      * @throws Exception\InvalidArgumentException
-     * @return InputFilterInterface
      */
-    public function setValidationGroup($name)
+    public function setValidationGroup($name): static
     {
         if ($name === self::VALIDATE_ALL) {
             $this->validationGroup = null;
@@ -675,7 +671,7 @@ class BaseInputFilter implements
      *
      * @return $this
      */
-    public function merge(BaseInputFilter $inputFilter)
+    public function merge(BaseInputFilter $inputFilter): static
     {
         foreach ($inputFilter->getInputs() as $name => $input) {
             $this->add($input, $name);
@@ -696,7 +692,7 @@ class BaseInputFilter implements
      * @param array<array-key, mixed> $data
      * @return $this
      */
-    public function setUnfilteredData($data)
+    public function setUnfilteredData($data): static
     {
         $this->unfilteredData = $data;
         return $this;

--- a/src/BaseInputFilter.php
+++ b/src/BaseInputFilter.php
@@ -585,9 +585,9 @@ class BaseInputFilter implements
      * Return the unknown input
      *
      * @throws Exception\RuntimeException
-     * @return array
+     * @return array<array-key, mixed>
      */
-    public function getUnknown()
+    public function getUnknown(): array
     {
         if (null === $this->data) {
             throw new Exception\RuntimeException(sprintf(
@@ -616,7 +616,7 @@ class BaseInputFilter implements
      *
      * @return array<array-key, InputInterface|InputFilterInterface>
      */
-    public function getInputs()
+    public function getInputs(): array
     {
         return $this->inputs;
     }

--- a/src/BaseInputFilter.php
+++ b/src/BaseInputFilter.php
@@ -101,8 +101,6 @@ class BaseInputFilter implements
 
         if ($input instanceof InputInterface && ($name === null || $name === '' || is_int($name))) {
             $name = $input->getName();
-
-            /** @psalm-suppress DocblockTypeContradiction Input conflicts with InputInterface docblock and allows null. */
             if ($name === null || $name === '') {
                 throw new Exception\InvalidArgumentException(sprintf(
                     '%s: input instance must have a valid name or input name must be provided as a parameter',

--- a/src/BaseInputFilter.php
+++ b/src/BaseInputFilter.php
@@ -4,15 +4,15 @@ declare(strict_types=1);
 
 namespace Laminas\InputFilter;
 
+use Laminas\InputFilter\Exception\InputNotFoundException;
+use Laminas\InputFilter\Exception\InvalidArgumentException;
 use Laminas\Stdlib\ArrayUtils;
 use Laminas\Stdlib\InitializableInterface;
-use ReturnTypeWillChange;
 use Traversable;
 
-use function array_diff;
-use function array_intersect;
 use function array_key_exists;
 use function array_keys;
+use function array_map;
 use function array_merge;
 use function assert;
 use function count;
@@ -20,6 +20,7 @@ use function func_get_args;
 use function get_debug_type;
 use function is_array;
 use function is_int;
+use function is_iterable;
 use function is_string;
 use function sprintf;
 
@@ -42,30 +43,28 @@ class BaseInputFilter implements
     }
 
     /** @var array<array-key, mixed>|null */
-    protected $data;
+    protected array|null $data = null;
 
     /** @var array<array-key, mixed> */
-    protected $unfilteredData = [];
+    protected array $unfilteredData = [];
 
     /** @var array<array-key, InputInterface|InputFilterInterface> */
-    protected $inputs = [];
+    protected array $inputs = [];
 
     /** @var array<array-key, InputInterface|InputFilterInterface>|null */
-    protected $invalidInputs;
-
-    /** @var null|array<array-key, string> Input names */
-    protected $validationGroup;
+    protected array|null $invalidInputs = null;
 
     /** @var array<array-key, InputInterface|InputFilterInterface>|null */
-    protected $validInputs;
+    protected array|null $validInputs = null;
+
+    /** @var null|list<array-key> Input names */
+    protected array|null $validationGroup = null;
 
     /**
      * This function is automatically called when creating element with factory. It
      * allows to perform various operations (add elements...)
-     *
-     * @return void
      */
-    public function init()
+    public function init(): void
     {
     }
 
@@ -73,54 +72,29 @@ class BaseInputFilter implements
      * Countable: number of inputs in this input filter
      *
      * Only details the number of direct children.
-     *
-     * @return int
      */
-    #[ReturnTypeWillChange]
-    public function count()
+    public function count(): int
     {
         return count($this->inputs);
     }
 
     /** @inheritDoc */
-    public function add($input, $name = null): static
-    {
+    public function add(
+        InputInterface|InputFilterInterface|array $input,
+        string|int|null $name = null,
+    ): static {
         if (is_array($input)) {
             $input = $this->factory->create($input);
         }
 
-        if (! $input instanceof InputInterface && ! $input instanceof InputFilterInterface) {
-            throw new Exception\InvalidArgumentException(sprintf(
-                '%s expects an instance of %s or %s as its first argument; received "%s"',
-                __METHOD__,
-                InputInterface::class,
-                InputFilterInterface::class,
-                get_debug_type($input),
-            ));
-        }
-
         if ($input instanceof InputInterface && ($name === null || $name === '' || is_int($name))) {
             $name = $input->getName();
-            if ($name === null || $name === '') {
-                throw new Exception\InvalidArgumentException(sprintf(
-                    '%s: input instance must have a valid name or input name must be provided as a parameter',
-                    __METHOD__,
-                ));
-            }
         }
 
-        if (! is_string($name) && ! is_int($name)) {
-            throw new Exception\InvalidArgumentException(sprintf(
-                '%s: input name expected to be string or int, %s given',
-                __METHOD__,
-                get_debug_type($name)
-            ));
-        }
-
-        if ($name === '') {
-            throw new Exception\InvalidArgumentException(sprintf(
-                '%s: input name can not be an empty string',
-                __METHOD__,
+        if (! $this->isKey($name)) {
+            throw new InvalidArgumentException(sprintf(
+                'Input or InputFilter name must be a non-empty string or an int, %s given',
+                get_debug_type($name),
             ));
         }
 
@@ -137,6 +111,7 @@ class BaseInputFilter implements
         }
 
         $this->inputs[$name] = $input;
+
         return $this;
     }
 
@@ -145,25 +120,14 @@ class BaseInputFilter implements
      *
      * @param  InputInterface|InputFilterInterface|InputSpecification|InputFilterSpecification $input
      * @param  array-key                           $name Name of the input to replace
-     * @throws Exception\InvalidArgumentException If input to replace not exists.
+     * @throws InputNotFoundException If input to replace not exists.
      */
-    public function replace($input, $name): static
-    {
-        /** @psalm-suppress DocblockTypeContradiction  */
-        if (! is_string($name) && ! is_int($name)) {
-            throw new Exception\InvalidArgumentException(sprintf(
-                '%s: input name expected to be string or int, %s given',
-                __METHOD__,
-                get_debug_type($name),
-            ));
-        }
-
+    public function replace(
+        InputInterface|InputFilterInterface|array $input,
+        int|string $name,
+    ): static {
         if (! array_key_exists($name, $this->inputs)) {
-            throw new Exception\InvalidArgumentException(sprintf(
-                '%s: no input found matching "%s"',
-                __METHOD__,
-                $name
-            ));
+            throw InputNotFoundException::forKey($name);
         }
 
         $this->remove($name);
@@ -175,17 +139,14 @@ class BaseInputFilter implements
     /**
      * Retrieve a named input
      *
-     * @throws Exception\InvalidArgumentException
+     * @throws InputNotFoundException
      */
     public function get(int|string $name): InputInterface|InputFilterInterface
     {
         if (! array_key_exists($name, $this->inputs)) {
-            throw new Exception\InvalidArgumentException(sprintf(
-                '%s: no input found matching "%s"',
-                __METHOD__,
-                $name
-            ));
+            throw InputNotFoundException::forKey($name);
         }
+
         return $this->inputs[$name];
     }
 
@@ -200,13 +161,8 @@ class BaseInputFilter implements
         return $this;
     }
 
-    /**
-     * Set data to use when validating and filtering
-     *
-     * @param  iterable|null $data null is cast to an empty array.
-     * @throws Exception\InvalidArgumentException
-     */
-    public function setData($data): static
+    /** @inheritDoc */
+    public function setData(iterable|null $data): static
     {
         // A null value indicates an empty set
         if (null === $data) {
@@ -217,15 +173,6 @@ class BaseInputFilter implements
             $data = ArrayUtils::iteratorToArray($data);
         }
 
-        /** @psalm-suppress DocblockTypeContradiction */
-        if (! is_array($data)) {
-            throw new Exception\InvalidArgumentException(sprintf(
-                '%s expects an array or Traversable argument; received %s',
-                __METHOD__,
-                get_debug_type($data),
-            ));
-        }
-
         $this->setUnfilteredData($data);
 
         $this->data = $data;
@@ -234,18 +181,13 @@ class BaseInputFilter implements
         return $this;
     }
 
-    /**
-     * Is the data set valid?
-     *
-     * @param  mixed|null $context
-     * @throws Exception\RuntimeException
-     */
-    public function isValid($context = null): bool
+    /** @inheritDoc */
+    public function isValid(array|null $context = null): bool
     {
         if (null === $this->data) {
             throw new Exception\RuntimeException(sprintf(
                 '%s: no data present to validate!',
-                __METHOD__
+                __METHOD__,
             ));
         }
 
@@ -256,12 +198,11 @@ class BaseInputFilter implements
     /**
      * Validate a set of inputs against the current data
      *
-     * @param  array<array-key, array-key> $inputs Array of input names.
+     * @param  list<array-key> $inputs A list of input names to validate
      * @param  array<array-key, mixed> $data
-     * @param  mixed|null $context
-     * @return bool
+     * @param  array<array-key, mixed>|null $context
      */
-    protected function validateInputs(array $inputs, array $data = [], $context = null)
+    protected function validateInputs(array $inputs, array $data, array|null $context = null): bool
     {
         $inputContext = $context ?? array_merge($this->getRawValues(), $data);
 
@@ -283,10 +224,7 @@ class BaseInputFilter implements
                 continue;
             }
 
-            // If input is not InputInterface then silently continue (BC safe)
-            if (! $input instanceof InputInterface) {
-                continue;
-            }
+            assert($input instanceof InputInterface);
 
             // If input is optional (not required), and value is not set, then ignore.
             if (
@@ -314,20 +252,10 @@ class BaseInputFilter implements
     }
 
     /**
-     * Provide a list of one or more elements indicating the complete set to validate
-     *
-     * When provided, calls to {@link isValid()} will only validate the provided set.
-     *
-     * If the initial value is {@link VALIDATE_ALL}, the current validation group, if
-     * any, should be cleared.
-     *
-     * Implementations should allow passing a single array value, or multiple arguments,
-     * each specifying a single input.
-     *
-     * @param  array-key|array<array-key, array-key> $name
-     * @throws Exception\InvalidArgumentException
+     * @inheritDoc
+     * @throws InvalidArgumentException
      */
-    public function setValidationGroup($name): static
+    public function setValidationGroup(int|string|array $name): static
     {
         if ($name === self::VALIDATE_ALL) {
             $this->validationGroup = null;
@@ -339,27 +267,41 @@ class BaseInputFilter implements
             return $this;
         }
 
-        if (is_array($name)) {
-            $inputs = [];
-            foreach ($name as $key => $value) {
-                if (! $this->has($key)) {
-                    $inputs[] = $value;
-                    continue;
-                }
+        $inputs = [];
 
-                $inputs[] = $key;
+        if (! is_array($name)) {
+            $name = func_get_args();
+        }
 
-                $input = $this->inputs[$key];
+        /** @psalm-var mixed $value */
+        foreach ($name as $key => $value) {
+            if ($this->isKey($value) && $this->has($value)) {
+                $inputs[] = $value;
+                continue;
+            }
+
+            if (is_array($value) && $this->has($key)) {
+                $input = $this->get($key);
                 if ($input instanceof InputFilterInterface) {
                     // Recursively populate validation groups for sub input filters
                     $input->setValidationGroup($value);
                 }
+
+                $inputs[] = $key;
+                continue;
             }
-        } else {
-            $inputs = func_get_args();
+
+            if ($this->has($key)) {
+                $inputs[] = $key;
+                continue;
+            }
+
+            $missing = is_string($value) ? $value : $key;
+
+            throw InputNotFoundException::forKey($missing);
         }
 
-        if (! empty($inputs)) {
+        if ($inputs !== []) {
             $this->validateValidationGroup($inputs);
             $this->validationGroup = $inputs;
         }
@@ -396,15 +338,15 @@ class BaseInputFilter implements
     /**
      * Retrieve a value from a named input
      *
-     * @throws Exception\InvalidArgumentException
+     * @throws InvalidArgumentException
      */
     public function getValue(int|string $name): mixed
     {
         if (! array_key_exists($name, $this->inputs)) {
-            throw new Exception\InvalidArgumentException(sprintf(
+            throw new InvalidArgumentException(sprintf(
                 '%s expects a valid input name; "%s" was not found in the filter',
                 __METHOD__,
-                $name
+                $name,
             ));
         }
         $input = $this->inputs[$name];
@@ -441,35 +383,16 @@ class BaseInputFilter implements
         return $values;
     }
 
-    /**
-     * Retrieve a raw (unfiltered) value from a named input
-     *
-     * @throws Exception\InvalidArgumentException
-     */
     public function getRawValue(int|string $name): mixed
     {
-        if (! array_key_exists($name, $this->inputs)) {
-            throw new Exception\InvalidArgumentException(sprintf(
-                '%s expects a valid input name; "%s" was not found in the filter',
-                __METHOD__,
-                $name
-            ));
-        }
-        $input = $this->inputs[$name];
-        if ($input instanceof InputFilterInterface) {
-            return $input->getRawValues();
-        }
-        return $input->getRawValue();
+        $input = $this->get($name);
+
+        return $input instanceof InputFilterInterface
+            ? $input->getRawValues()
+            : $input->getRawValue();
     }
 
-    /**
-     * Return a list of unfiltered values
-     *
-     * List should be an associative array of named input/value pairs,
-     * with the values unfiltered.
-     *
-     * @return array<array-key, mixed>
-     */
+    /** @inheritDoc */
     public function getRawValues(): array
     {
         $values = [];
@@ -485,49 +408,35 @@ class BaseInputFilter implements
         return $values;
     }
 
-    /**
-     * Return a list of validation failure messages
-     *
-     * Should return an associative array of named input/message list pairs.
-     * Pairs should only be returned for inputs that failed validation.
-     *
-     * @return array<array-key, array<array-key, string|array>>
-     */
+    /** @inheritDoc */
     public function getMessages(): array
     {
-        $messages = [];
-        foreach ($this->getInvalidInput() as $name => $input) {
-            $messages[$name] = $input->getMessages();
-        }
-
-        return $messages;
+        return array_map(
+            static fn (InputInterface|InputFilterInterface $input): array => $input->getMessages(),
+            $this->getInvalidInput(),
+        );
     }
 
     /**
      * Ensure all names of a validation group exist as input in the filter
      *
-     * @param  array<array-key, array-key> $inputs Input names
-     * @return void
-     * @throws Exception\InvalidArgumentException
+     * @param array<array-key, mixed> $inputs Input names
+     * @throws InputNotFoundException
+     * @psalm-assert list<array-key> $inputs
      */
-    protected function validateValidationGroup(array $inputs)
+    protected function validateValidationGroup(array $inputs): void
     {
         foreach ($inputs as $name) {
-            if (! array_key_exists($name, $this->inputs)) {
-                throw new Exception\InvalidArgumentException(sprintf(
-                    'setValidationGroup() expects a list of valid input names; "%s" was not found',
-                    (string) $name
-                ));
+            if (! $this->isKey($name) || ! array_key_exists($name, $this->inputs)) {
+                throw InputNotFoundException::forKey((string) $name);
             }
         }
     }
 
     /**
      * Populate the values of all attached inputs
-     *
-     * @return void
      */
-    protected function populate()
+    protected function populate(): void
     {
         assert($this->data !== null);
         foreach (array_keys($this->inputs) as $name) {
@@ -554,12 +463,12 @@ class BaseInputFilter implements
                 continue;
             }
 
-            /** @psalm-suppress MixedAssignment */
+            /** @psalm-var mixed $value */
             $value = $this->data[$name];
 
             if ($input instanceof InputFilterInterface) {
                 // Fixes #159
-                if (! is_array($value) && ! $value instanceof Traversable) {
+                if (! is_iterable($value)) {
                     $value = [];
                 }
 
@@ -572,43 +481,38 @@ class BaseInputFilter implements
     }
 
     /**
-     * Is the data set has unknown input ?
-     *
+     * @inheritDoc
      * @throws Exception\RuntimeException
      */
     public function hasUnknown(): bool
     {
-        return $this->getUnknown() ? true : false;
+        return (bool) $this->getUnknown();
     }
 
     /**
-     * Return the unknown input
-     *
+     * @inheritDoc
      * @throws Exception\RuntimeException
-     * @return array<array-key, mixed>
      */
     public function getUnknown(): array
     {
         if (null === $this->data) {
             throw new Exception\RuntimeException(sprintf(
                 '%s: no data present!',
-                __METHOD__
+                __METHOD__,
             ));
         }
 
-        $data   = array_keys($this->data);
-        $inputs = array_keys($this->inputs);
-        $diff   = array_diff($data, $inputs);
-
-        $unknownInputs = [];
-        $intersect     = array_intersect($diff, $data);
-        if (! empty($intersect)) {
-            foreach ($intersect as $key) {
-                $unknownInputs[$key] = $this->data[$key];
+        $unknown = [];
+        /** @psalm-suppress MixedAssignment */
+        foreach ($this->data as $key => $value) {
+            if ($this->has($key)) {
+                continue;
             }
+
+            $unknown[$key] = $value;
         }
 
-        return $unknownInputs;
+        return $unknown;
     }
 
     /**
@@ -623,8 +527,6 @@ class BaseInputFilter implements
 
     /**
      * Merges the inputs from an InputFilter into the current one
-     *
-     * @return $this
      */
     public function merge(BaseInputFilter $inputFilter): static
     {
@@ -635,21 +537,22 @@ class BaseInputFilter implements
         return $this;
     }
 
-    /**
-     * @return array<array-key, mixed>
-     */
-    public function getUnfilteredData()
+    /** @inheritDoc */
+    public function getUnfilteredData(): array
     {
         return $this->unfilteredData;
     }
 
-    /**
-     * @param array<array-key, mixed> $data
-     * @return $this
-     */
-    public function setUnfilteredData($data): static
+    /** @inheritDoc */
+    public function setUnfilteredData(array $data): static
     {
         $this->unfilteredData = $data;
         return $this;
+    }
+
+    /** @psalm-assert-if-true int|non-empty-string $value */
+    protected function isKey(mixed $value): bool
+    {
+        return is_int($value) || (is_string($value) && $value !== '');
     }
 }

--- a/src/BaseInputFilter.php
+++ b/src/BaseInputFilter.php
@@ -175,20 +175,10 @@ class BaseInputFilter implements
     /**
      * Retrieve a named input
      *
-     * @param  array-key $name
      * @throws Exception\InvalidArgumentException
      */
-    public function get($name): InputInterface|InputFilterInterface
+    public function get(int|string $name): InputInterface|InputFilterInterface
     {
-        /** @psalm-suppress DocblockTypeContradiction  */
-        if (! is_string($name) && ! is_int($name)) {
-            throw new Exception\InvalidArgumentException(sprintf(
-                '%s: input name expected to be string or int, %s given',
-                __METHOD__,
-                get_debug_type($name),
-            ));
-        }
-
         if (! array_key_exists($name, $this->inputs)) {
             throw new Exception\InvalidArgumentException(sprintf(
                 '%s: no input found matching "%s"',
@@ -199,40 +189,13 @@ class BaseInputFilter implements
         return $this->inputs[$name];
     }
 
-    /**
-     * Test if an input or input filter by the given name is attached
-     *
-     * @param  array-key $name
-     * @return bool
-     */
-    public function has($name)
+    public function has(int|string $name): bool
     {
-        /** @psalm-suppress DocblockTypeContradiction  */
-        if (! is_string($name) && ! is_int($name)) {
-            throw new Exception\InvalidArgumentException(sprintf(
-                '%s: input name expected to be string or int, %s given',
-                __METHOD__,
-                get_debug_type($name),
-            ));
-        }
         return array_key_exists($name, $this->inputs);
     }
 
-    /**
-     * Remove a named input
-     *
-     * @param array-key $name
-     */
-    public function remove($name): static
+    public function remove(int|string $name): static
     {
-        /** @psalm-suppress DocblockTypeContradiction  */
-        if (! is_string($name) && ! is_int($name)) {
-            throw new Exception\InvalidArgumentException(sprintf(
-                '%s: input name expected to be string or int, %s given',
-                __METHOD__,
-                get_debug_type($name),
-            ));
-        }
         unset($this->inputs[$name]);
         return $this;
     }
@@ -276,9 +239,8 @@ class BaseInputFilter implements
      *
      * @param  mixed|null $context
      * @throws Exception\RuntimeException
-     * @return bool
      */
-    public function isValid($context = null)
+    public function isValid($context = null): bool
     {
         if (null === $this->data) {
             throw new Exception\RuntimeException(sprintf(
@@ -434,11 +396,9 @@ class BaseInputFilter implements
     /**
      * Retrieve a value from a named input
      *
-     * @param  array-key $name
      * @throws Exception\InvalidArgumentException
-     * @return mixed
      */
-    public function getValue($name)
+    public function getValue(int|string $name): mixed
     {
         if (! array_key_exists($name, $this->inputs)) {
             throw new Exception\InvalidArgumentException(sprintf(
@@ -484,11 +444,9 @@ class BaseInputFilter implements
     /**
      * Retrieve a raw (unfiltered) value from a named input
      *
-     * @param  array-key $name
      * @throws Exception\InvalidArgumentException
-     * @return mixed
      */
-    public function getRawValue($name)
+    public function getRawValue(int|string $name): mixed
     {
         if (! array_key_exists($name, $this->inputs)) {
             throw new Exception\InvalidArgumentException(sprintf(

--- a/src/CollectionInputFilter.php
+++ b/src/CollectionInputFilter.php
@@ -176,7 +176,7 @@ class CollectionInputFilter extends InputFilter
     /**
      * @inheritDoc
      */
-    public function isValid($context = null)
+    public function isValid($context = null): bool
     {
         $this->collectionMessages = [];
         $inputFilter              = $this->getInputFilter();

--- a/src/CollectionInputFilter.php
+++ b/src/CollectionInputFilter.php
@@ -5,60 +5,69 @@ declare(strict_types=1);
 namespace Laminas\InputFilter;
 
 use Laminas\Validator\NotEmpty;
-use Traversable;
 
+use function assert;
 use function count;
 use function get_debug_type;
 use function is_array;
 use function is_iterable;
+use function iterator_to_array;
+use function max;
 use function sprintf;
 
 /**
  * @psalm-import-type InputFilterSpecification from InputFilterInterface
  * @template TFilteredValues
- * @extends InputFilter<TFilteredValues>
+ * @extends InputFilter<array<array-key, TFilteredValues>>
  */
 class CollectionInputFilter extends InputFilter
 {
-    /** @var bool */
-    protected $isRequired = false;
-
-    /** @var null|int */
-    protected $count;
-
+    protected bool $isRequired = false;
+    protected int|null $count  = null;
+    /** @var array<array-key, TFilteredValues> */
+    protected array $collectionValues = [];
     /** @var array<array-key, array> */
-    protected $collectionValues = [];
-
-    /** @var array<array-key, array> */
-    protected $collectionRawValues = [];
-
+    protected array $collectionRawValues = [];
     /** @var array<array-key, array<string, array<array-key, string>>> */
-    protected $collectionMessages = [];
+    protected array $collectionMessages = [];
+    /** @var InputFilterInterface<TFilteredValues>|null */
+    protected InputFilterInterface|null $inputFilter = null;
+    private string|null $emptyErrorMessage           = null;
 
-    /** @var BaseInputFilter|null */
-    protected $inputFilter;
-    private ?string $emptyErrorMessage = null;
+    /**
+     * Data in a collection is guaranteed to be an array of arrays
+     *
+     * @psalm-suppress NonInvariantDocblockPropertyType
+     * @var array<array-key, array<array-key, mixed>>|null
+     */
+    protected array|null $data = null;
+
+    /**
+     * In Collections, the type is not compatible with the parent class
+     *
+     * @psalm-suppress NonInvariantDocblockPropertyType
+     * @var array<array-key, array<array-key, InputInterface|InputFilterInterface>>|null
+     */
+    protected array|null $invalidInputs = null;
+
+    /**
+     * In Collections, the type is not compatible with the parent class
+     *
+     * @psalm-suppress NonInvariantDocblockPropertyType
+     * @var array<array-key, array<array-key, InputInterface|InputFilterInterface>>|null
+     */
+    protected array|null $validInputs = null;
 
     /**
      * Set the input filter to use when looping the data
      *
-     * @param BaseInputFilter|InputFilterSpecification|Traversable $inputFilter
-     * @throws Exception\RuntimeException
+     * @param InputFilterInterface<TFilteredValues>|InputFilterSpecification|iterable $inputFilter
      */
-    public function setInputFilter($inputFilter): static
+    public function setInputFilter(InputFilterInterface|iterable $inputFilter): static
     {
         if (is_iterable($inputFilter)) {
+            /** @psalm-var InputFilterInterface<TFilteredValues> $inputFilter */
             $inputFilter = $this->factory->createInputFilter($inputFilter);
-        }
-
-        /** @psalm-suppress RedundantConditionGivenDocblockType, DocblockTypeContradiction */
-        if (! $inputFilter instanceof BaseInputFilter) {
-            throw new Exception\RuntimeException(sprintf(
-                '%s expects an instance of %s; received "%s"',
-                __METHOD__,
-                BaseInputFilter::class,
-                get_debug_type($inputFilter)
-            ));
         }
 
         $this->inputFilter = $inputFilter;
@@ -69,9 +78,9 @@ class CollectionInputFilter extends InputFilter
     /**
      * Get the input filter used when looping the data
      *
-     * @return BaseInputFilter
+     * @return InputFilterInterface<TFilteredValues>
      */
-    public function getInputFilter()
+    public function getInputFilter(): InputFilterInterface
     {
         if (null === $this->inputFilter) {
             $this->inputFilter = new InputFilter($this->factory);
@@ -105,10 +114,8 @@ class CollectionInputFilter extends InputFilter
 
     /**
      * Get if collection can be empty
-     *
-     * @return bool
      */
-    public function getIsRequired()
+    public function getIsRequired(): bool
     {
         return $this->isRequired;
     }
@@ -118,17 +125,15 @@ class CollectionInputFilter extends InputFilter
      */
     public function setCount(int $count): static
     {
-        $this->count = $count > 0 ? $count : 0;
+        $this->count = max($count, 0);
 
         return $this;
     }
 
     /**
      * Get the count of data to validate, use the count of data by default
-     *
-     * @return int
      */
-    public function getCount()
+    public function getCount(): int
     {
         if (null === $this->count) {
             return $this->data !== null ? count($this->data) : 0;
@@ -137,27 +142,15 @@ class CollectionInputFilter extends InputFilter
         return $this->count;
     }
 
-    /**
-     * @param iterable|null $data
-     * @return $this
-     */
-    public function setData($data): static
+    /** @inheritDoc */
+    public function setData(iterable|null $data): static
     {
-        /** @psalm-suppress DocblockTypeContradiction, RedundantConditionGivenDocblockType */
-        if (! is_array($data) && ! $data instanceof Traversable) {
-            throw new Exception\InvalidArgumentException(sprintf(
-                '%s expects an array or Traversable collection; invalid collection of type %s provided',
-                __METHOD__,
-                get_debug_type($data)
-            ));
-        }
-
+        $data = iterator_to_array($data ?? []);
         $this->setUnfilteredData($data);
 
-        /** @psalm-suppress MixedAssignment */
+        /** @psalm-var mixed $item */
         foreach ($data as $item) {
-            /** @psalm-suppress RedundantConditionGivenDocblockType, DocblockTypeContradiction */
-            if (is_iterable($item)) {
+            if (is_array($item)) {
                 continue;
             }
 
@@ -165,18 +158,21 @@ class CollectionInputFilter extends InputFilter
                 '%s expects each item in a collection to be an array or Traversable; '
                 . 'invalid item in collection of type %s detected',
                 __METHOD__,
-                get_debug_type($item)
+                get_debug_type($item),
             ));
         }
 
+        /**
+         * Psalm cannot infer this from the previous scope
+         *
+         * @psalm-var array<array-key, array> $data
+         */
         $this->data = $data;
         return $this;
     }
 
-    /**
-     * @inheritDoc
-     */
-    public function isValid($context = null): bool
+    /** @inheritDoc */
+    public function isValid(array|null $context = null): bool
     {
         $this->collectionMessages = [];
         $inputFilter              = $this->getInputFilter();
@@ -199,14 +195,22 @@ class CollectionInputFilter extends InputFilter
             return $valid;
         }
 
-        /** @psalm-suppress MixedAssignment */
         foreach ($this->data as $key => $data) {
-            /** @psalm-suppress MixedArgument */
+            assert($this->isKey($key));
+
             $inputFilter->setData($data);
 
-            if (null !== $this->validationGroup) {
+            if ($this->validationGroup !== null && isset($this->validationGroup[$key])) {
                 $inputFilter->setValidationGroup($this->validationGroup[$key]);
             }
+
+            /**
+             * @todo The current implementation will validate all sets using the same validation group if only
+             *       the first item uses a validation group.
+             *       For example, setValidationGroup([0 => 'fieldName']) will mean that only `fieldName` is validated
+             *       for all items in the set.
+             *       The group should be set to VALIDATE_ALL on each iteration, and modified on a per-key basis.
+             */
 
             if ($inputFilter->isValid($context)) {
                 $this->validInputs[$key] = $inputFilter->getValidInput();
@@ -223,11 +227,8 @@ class CollectionInputFilter extends InputFilter
         return $valid;
     }
 
-    /**
-     * @param string|array<array-key, list<string>> $name
-     * @return $this
-     */
-    public function setValidationGroup($name): static
+    /** @inheritDoc */
+    public function setValidationGroup(int|string|array $name): static
     {
         if ($name === self::VALIDATE_ALL) {
             $name = null;
@@ -237,10 +238,7 @@ class CollectionInputFilter extends InputFilter
         return $this;
     }
 
-    /**
-     * @return array<array-key, array>
-     * @psalm-return TFilteredValues
-     */
+    /** @return array<array-key, TFilteredValues> */
     public function getValues(): array
     {
         return $this->collectionValues;
@@ -256,22 +254,18 @@ class CollectionInputFilter extends InputFilter
 
     /**
      * Clear collectionValues
-     *
-     * @return array[]
      */
-    public function clearValues()
+    public function clearValues(): void
     {
-        return $this->collectionValues = [];
+        $this->collectionValues = [];
     }
 
     /**
      * Clear collectionRawValues
-     *
-     * @return array[]
      */
-    public function clearRawValues()
+    public function clearRawValues(): void
     {
-        return $this->collectionRawValues = [];
+        $this->collectionRawValues = [];
     }
 
     /**
@@ -282,25 +276,27 @@ class CollectionInputFilter extends InputFilter
         return $this->collectionMessages;
     }
 
-    /**
-     * {@inheritdoc}
-     */
+    /** @inheritDoc */
     public function getUnknown(): array
     {
         if ($this->data === null) {
             throw new Exception\RuntimeException(sprintf(
                 '%s: no data present!',
-                __METHOD__
+                __METHOD__,
             ));
         }
 
         $inputFilter = $this->getInputFilter();
+        if (! $inputFilter instanceof UnknownInputsCapableInterface) {
+            return [];
+        }
 
         $unknownInputs = [];
         foreach ($this->data as $key => $data) {
             $inputFilter->setData($data);
+            $unknown = $inputFilter->getUnknown();
 
-            if ($unknown = $inputFilter->getUnknown()) {
+            if (count($unknown) > 0) {
                 $unknownInputs[$key] = $unknown;
             }
         }

--- a/src/CollectionInputFilter.php
+++ b/src/CollectionInputFilter.php
@@ -285,7 +285,7 @@ class CollectionInputFilter extends InputFilter
     /**
      * {@inheritdoc}
      */
-    public function getUnknown()
+    public function getUnknown(): array
     {
         if ($this->data === null) {
             throw new Exception\RuntimeException(sprintf(

--- a/src/CollectionInputFilter.php
+++ b/src/CollectionInputFilter.php
@@ -44,9 +44,8 @@ class CollectionInputFilter extends InputFilter
      *
      * @param BaseInputFilter|InputFilterSpecification|Traversable $inputFilter
      * @throws Exception\RuntimeException
-     * @return CollectionInputFilter
      */
-    public function setInputFilter($inputFilter)
+    public function setInputFilter($inputFilter): static
     {
         if (is_iterable($inputFilter)) {
             $inputFilter = $this->factory->createInputFilter($inputFilter);
@@ -116,11 +115,8 @@ class CollectionInputFilter extends InputFilter
 
     /**
      * Set the count of data to validate
-     *
-     * @param int $count
-     * @return CollectionInputFilter
      */
-    public function setCount($count)
+    public function setCount(int $count): static
     {
         $this->count = $count > 0 ? $count : 0;
 
@@ -145,7 +141,7 @@ class CollectionInputFilter extends InputFilter
      * @param iterable|null $data
      * @return $this
      */
-    public function setData($data)
+    public function setData($data): static
     {
         /** @psalm-suppress DocblockTypeContradiction, RedundantConditionGivenDocblockType */
         if (! is_array($data) && ! $data instanceof Traversable) {
@@ -231,7 +227,7 @@ class CollectionInputFilter extends InputFilter
      * @param string|array<array-key, list<string>> $name
      * @return $this
      */
-    public function setValidationGroup($name)
+    public function setValidationGroup($name): static
     {
         if ($name === self::VALIDATE_ALL) {
             $name = null;

--- a/src/CollectionInputFilter.php
+++ b/src/CollectionInputFilter.php
@@ -241,7 +241,7 @@ class CollectionInputFilter extends InputFilter
      * @return array<array-key, array>
      * @psalm-return TFilteredValues
      */
-    public function getValues()
+    public function getValues(): array
     {
         return $this->collectionValues;
     }
@@ -249,7 +249,7 @@ class CollectionInputFilter extends InputFilter
     /**
      * @return array<array-key, array>
      */
-    public function getRawValues()
+    public function getRawValues(): array
     {
         return $this->collectionRawValues;
     }
@@ -277,7 +277,7 @@ class CollectionInputFilter extends InputFilter
     /**
      * @return array<array-key, array<string, array<array-key, string>>>
      */
-    public function getMessages()
+    public function getMessages(): array
     {
         return $this->collectionMessages;
     }

--- a/src/EmptyContextInterface.php
+++ b/src/EmptyContextInterface.php
@@ -6,14 +6,7 @@ namespace Laminas\InputFilter;
 
 interface EmptyContextInterface
 {
-    /**
-     * @param bool $continueIfEmpty
-     * @return self
-     */
-    public function setContinueIfEmpty($continueIfEmpty);
+    public function setContinueIfEmpty(bool $continueIfEmpty): static;
 
-    /**
-     * @return bool
-     */
-    public function continueIfEmpty();
+    public function continueIfEmpty(): bool;
 }

--- a/src/Exception/InputNotFoundException.php
+++ b/src/Exception/InputNotFoundException.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\InputFilter\Exception;
+
+use InvalidArgumentException;
+
+use function sprintf;
+
+final class InputNotFoundException extends InvalidArgumentException implements ExceptionInterface
+{
+    public static function forKey(string|int $key): self
+    {
+        return new self(sprintf(
+            'The input or input filter named "%s" cannot be found',
+            $key,
+        ));
+    }
+}

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -274,13 +274,13 @@ final readonly class Factory
      * Factory for input filters
      *
      * phpcs:ignore Generic.Files.LineLength.TooLong, SlevomatCodingStandard.Commenting.DocCommentSpacing
-     * @param InputFilterSpecification|CollectionSpecification|Traversable|InputFilterProviderInterface $inputFilterSpecification
-     * @return InputFilterInterface
+     * @param InputFilterSpecification|CollectionSpecification|InputFilterProviderInterface|iterable $inputFilterSpecification
      * @throws RuntimeException
      * @throws InvalidArgumentException
      */
-    public function createInputFilter($inputFilterSpecification)
-    {
+    public function createInputFilter(
+        iterable|InputFilterProviderInterface $inputFilterSpecification,
+    ): InputFilterInterface {
         if ($inputFilterSpecification instanceof InputFilterProviderInterface) {
             $inputFilterSpecification = $inputFilterSpecification->getInputFilterSpecification();
         }

--- a/src/FileInput.php
+++ b/src/FileInput.php
@@ -37,7 +37,7 @@ final class FileInput extends Input
      * @inheritDoc
      * @param array|UploadedFileInterface $value
      */
-    public function setValue($value)
+    public function setValue($value): static
     {
         $this->handler = $this->createHandler($value);
         parent::setValue($value);
@@ -45,7 +45,7 @@ final class FileInput extends Input
     }
 
     /** @return $this */
-    public function resetValue()
+    public function resetValue(): static
     {
         $this->handler = null;
         return parent::resetValue();
@@ -55,7 +55,7 @@ final class FileInput extends Input
      * @param  bool $value Enable/Disable automatically prepending an Upload validator
      * @return $this
      */
-    public function setAutoPrependUploadValidator($value)
+    public function setAutoPrependUploadValidator($value): self
     {
         $this->autoPrependUploadValidator = $value;
         return $this;
@@ -144,7 +144,7 @@ final class FileInput extends Input
     /**
      * @return $this
      */
-    public function merge(InputInterface $input)
+    public function merge(InputInterface $input): static
     {
         parent::merge($input);
         if ($input instanceof FileInput) {
@@ -156,10 +156,8 @@ final class FileInput extends Input
     /**
      * No-op, NotEmpty validator does not apply for FileInputs.
      * See also: BaseInputFilter::isValid()
-     *
-     * @return void
      */
-    protected function injectNotEmptyValidator()
+    protected function injectNotEmptyValidator(): void
     {
         $this->notEmptyValidator = true;
     }

--- a/src/FileInput.php
+++ b/src/FileInput.php
@@ -98,7 +98,7 @@ final class FileInput extends Input
     }
 
     /** @inheritDoc */
-    public function isValid(?array $context = null): bool
+    public function isValid(array|null $context = null): bool
     {
         $rawValue        = $this->getRawValue();
         $hasValue        = $this->hasValue();

--- a/src/FileInput.php
+++ b/src/FileInput.php
@@ -55,7 +55,7 @@ final class FileInput extends Input
      * @param  bool $value Enable/Disable automatically prepending an Upload validator
      * @return $this
      */
-    public function setAutoPrependUploadValidator($value): self
+    public function setAutoPrependUploadValidator(bool $value): self
     {
         $this->autoPrependUploadValidator = $value;
         return $this;

--- a/src/FileInput.php
+++ b/src/FileInput.php
@@ -7,6 +7,7 @@ namespace Laminas\InputFilter;
 use Laminas\InputFilter\FileInput\FileInputHandlerInterface;
 use Laminas\Validator\File\UploadFile as UploadValidator;
 use Laminas\Validator\ValidatorChain;
+use Laminas\Validator\ValidatorChainInterface;
 use Psr\Http\Message\UploadedFileInterface;
 
 use function assert;
@@ -37,14 +38,13 @@ final class FileInput extends Input
      * @inheritDoc
      * @param array|UploadedFileInterface $value
      */
-    public function setValue($value): static
+    public function setValue(mixed $value): static
     {
         $this->handler = $this->createHandler($value);
         parent::setValue($value);
         return $this;
     }
 
-    /** @return $this */
     public function resetValue(): static
     {
         $this->handler = null;
@@ -61,18 +61,12 @@ final class FileInput extends Input
         return $this;
     }
 
-    /**
-     * @return bool
-     */
-    public function getAutoPrependUploadValidator()
+    public function getAutoPrependUploadValidator(): bool
     {
         return $this->autoPrependUploadValidator;
     }
 
-    /**
-     * @return mixed
-     */
-    public function getValue()
+    public function getValue(): mixed
     {
         if ($this->handler === null) {
             return $this->value;
@@ -141,9 +135,6 @@ final class FileInput extends Input
         return $this->isValid;
     }
 
-    /**
-     * @return $this
-     */
     public function merge(InputInterface $input): static
     {
         parent::merge($input);
@@ -183,8 +174,10 @@ final class FileInput extends Input
         return new FileInput\HttpServerFileInputHandler();
     }
 
-    private function injectUploadValidator(ValidatorChain $chain): ValidatorChain
+    private function injectUploadValidator(ValidatorChainInterface $chain): ValidatorChain
     {
+        assert($chain instanceof ValidatorChain);
+
         if (! $this->autoPrependUploadValidator) {
             return $chain;
         }

--- a/src/FileInput/FileInputHandlerInterface.php
+++ b/src/FileInput/FileInputHandlerInterface.php
@@ -24,6 +24,6 @@ interface FileInputHandlerInterface
 
     public function filterValue(mixed $value, bool $isValid, FilterChainInterface $filterChain): mixed;
 
-    /** @param array<string, mixed> $context Extra "context" to provide the validator */
+    /** @param array<array-key, mixed> $context Extra "context" to provide the validator */
     public function isValid(mixed $rawValue, ValidatorChainInterface $validatorChain, ?array $context = null): bool;
 }

--- a/src/FileInput/FileInputHandlerInterface.php
+++ b/src/FileInput/FileInputHandlerInterface.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Laminas\InputFilter\FileInput;
 
-use Laminas\Filter\FilterChain;
-use Laminas\Validator\ValidatorChain;
+use Laminas\Filter\FilterChainInterface;
+use Laminas\Validator\ValidatorChainInterface;
 
 /**
  * FileInputInterface defines expected methods for validating and filtering uploaded files.
@@ -22,8 +22,8 @@ interface FileInputHandlerInterface
     /** Checks if the raw input value is an empty file input eg: no file was uploaded */
     public static function isEmptyFile(mixed $rawValue): bool;
 
-    public function filterValue(mixed $value, bool $isValid, FilterChain $filterChain): mixed;
+    public function filterValue(mixed $value, bool $isValid, FilterChainInterface $filterChain): mixed;
 
     /** @param array<string, mixed> $context Extra "context" to provide the validator */
-    public function isValid(mixed $rawValue, ValidatorChain $validatorChain, ?array $context = null): bool;
+    public function isValid(mixed $rawValue, ValidatorChainInterface $validatorChain, ?array $context = null): bool;
 }

--- a/src/FileInput/HttpServerFileInputHandler.php
+++ b/src/FileInput/HttpServerFileInputHandler.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Laminas\InputFilter\FileInput;
 
-use Laminas\Filter\FilterChain;
-use Laminas\Validator\ValidatorChain;
+use Laminas\Filter\FilterChainInterface;
+use Laminas\Validator\ValidatorChainInterface;
 
 use function count;
 use function is_array;
@@ -49,7 +49,7 @@ final class HttpServerFileInputHandler implements FileInputHandlerInterface
         return false;
     }
 
-    public function filterValue(mixed $value, bool $isValid, FilterChain $filterChain): mixed
+    public function filterValue(mixed $value, bool $isValid, FilterChainInterface $filterChain): mixed
     {
         if (! $isValid || ! is_array($value)) {
             return $value;
@@ -76,7 +76,7 @@ final class HttpServerFileInputHandler implements FileInputHandlerInterface
     /**
      * @param array<string, mixed>|null $context Extra "context" to provide the validator
      */
-    public function isValid(mixed $rawValue, ValidatorChain $validatorChain, ?array $context = null): bool
+    public function isValid(mixed $rawValue, ValidatorChainInterface $validatorChain, ?array $context = null): bool
     {
         if (! is_array($rawValue)) {
             // This can happen in an AJAX POST, where the input comes across as a string

--- a/src/FileInput/HttpServerFileInputHandler.php
+++ b/src/FileInput/HttpServerFileInputHandler.php
@@ -73,9 +73,7 @@ final class HttpServerFileInputHandler implements FileInputHandlerInterface
         return $newValue;
     }
 
-    /**
-     * @param array<string, mixed>|null $context Extra "context" to provide the validator
-     */
+    /** @inheritDoc */
     public function isValid(mixed $rawValue, ValidatorChainInterface $validatorChain, ?array $context = null): bool
     {
         if (! is_array($rawValue)) {

--- a/src/FileInput/PsrFileInputHandler.php
+++ b/src/FileInput/PsrFileInputHandler.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Laminas\InputFilter\FileInput;
 
-use Laminas\Filter\FilterChain;
-use Laminas\Validator\ValidatorChain;
+use Laminas\Filter\FilterChainInterface;
+use Laminas\Validator\ValidatorChainInterface;
 use Psr\Http\Message\UploadedFileInterface;
 
 use function is_array;
@@ -45,7 +45,7 @@ final class PsrFileInputHandler implements FileInputHandlerInterface
         return $rawValue->getError() === UPLOAD_ERR_NO_FILE;
     }
 
-    public function filterValue(mixed $value, bool $isValid, FilterChain $filterChain): mixed
+    public function filterValue(mixed $value, bool $isValid, FilterChainInterface $filterChain): mixed
     {
         // Run filters ~after~ validation, so that is_uploaded_file()
         // validation is not affected by filters.
@@ -69,7 +69,7 @@ final class PsrFileInputHandler implements FileInputHandlerInterface
     /**
      * @param array<string, mixed>|null $context Extra "context" to provide the validator
      */
-    public function isValid(mixed $rawValue, ValidatorChain $validatorChain, ?array $context = null): bool
+    public function isValid(mixed $rawValue, ValidatorChainInterface $validatorChain, ?array $context = null): bool
     {
         if (is_array($rawValue)) {
             // Multi file input (multiple attribute set)

--- a/src/FileInput/PsrFileInputHandler.php
+++ b/src/FileInput/PsrFileInputHandler.php
@@ -26,6 +26,8 @@ use const UPLOAD_ERR_NO_FILE;
  * 3. Instead of adding a NotEmpty validator, it will (by default) automatically add
  *    a Laminas\Validator\File\Upload validator.
  *
+ * @internal
+ *
  * @psalm-internal Laminas\InputFilter
  * @psalm-internal LaminasTest\InputFilter
  */
@@ -66,9 +68,7 @@ final class PsrFileInputHandler implements FileInputHandlerInterface
         return $filterChain->filter($value);
     }
 
-    /**
-     * @param array<string, mixed>|null $context Extra "context" to provide the validator
-     */
+    /** @inheritDoc */
     public function isValid(mixed $rawValue, ValidatorChainInterface $validatorChain, ?array $context = null): bool
     {
         if (is_array($rawValue)) {

--- a/src/Input.php
+++ b/src/Input.php
@@ -6,6 +6,7 @@ namespace Laminas\InputFilter;
 
 use Laminas\Filter\FilterChain;
 use Laminas\Filter\FilterChainInterface;
+use Laminas\InputFilter\Exception\InvalidArgumentException;
 use Laminas\ServiceManager\AbstractPluginManager;
 use Laminas\Validator\NotEmpty;
 use Laminas\Validator\ValidatorChain;
@@ -20,12 +21,13 @@ class Input implements
     InputInterface,
     EmptyContextInterface
 {
+    protected string|int|null $name = null;
     protected bool $allowEmpty      = false;
     protected bool $continueIfEmpty = false;
     protected bool $breakOnFailure  = false;
     /**
      * @todo ArrayInput needs refactoring so that this type cannot be an array
-     * @var string|array<array-key, string>|null
+     * @var string|array<string, string>|null
      */
     protected string|array|null $errorMessage = null;
     protected bool $notEmptyValidator         = false;
@@ -41,8 +43,11 @@ class Input implements
     public function __construct(
         protected FilterChainInterface $filterChain,
         protected ValidatorChainInterface $validatorChain,
-        protected string|int|null $name = null
+        string|int|null $name = null
     ) {
+        if ($name !== null) {
+            $this->setName($name);
+        }
     }
 
     public function setAllowEmpty(bool $allowEmpty): static
@@ -77,18 +82,17 @@ class Input implements
 
     public function setName(string|int $name): static
     {
+        if ($name === '') {
+            throw new InvalidArgumentException('Input names cannot be an empty string');
+        }
+
         $this->name = $name;
         return $this;
     }
 
-    /**
-     * @param  bool $required
-     * @return $this
-     */
-    public function setRequired($required): static
+    public function setRequired(bool $required): static
     {
-        /** @psalm-suppress RedundantCastGivenDocblockType */
-        $this->required = (bool) $required;
+        $this->required = $required;
         return $this;
     }
 
@@ -266,41 +270,38 @@ class Input implements
         return $this;
     }
 
-    /** @param  array<string, mixed>|null $context Extra "context" to provide the validator */
-    public function isValid(?array $context = null): bool
+    /** @inheritDoc */
+    public function isValid(array|null $context = null): bool
     {
         if (is_array($this->errorMessage)) {
             $this->errorMessage = null;
         }
 
-        $value           = $this->getValue();
-        $hasValue        = $this->hasValue();
-        $empty           = $value === null || $value === '' || $value === [];
-        $required        = $this->isRequired();
-        $allowEmpty      = $this->allowEmpty();
-        $continueIfEmpty = $this->continueIfEmpty();
+        /** @psalm-var mixed $value */
+        $value = $this->getValue();
+        $empty = $value === null || $value === '' || $value === [];
 
-        if (! $hasValue && $this->hasFallback()) {
+        if (! $this->hasValue && $this->hasFallback()) {
             $this->setValue($this->getFallbackValue());
             return true;
         }
 
-        if (! $hasValue && ! $required) {
+        if (! $this->hasValue && ! $this->required) {
             return true;
         }
 
-        if (! $hasValue) { // required, but no value
+        if (! $this->hasValue) { // required, but no value
             if ($this->errorMessage === null) {
                 $this->errorMessage = $this->prepareRequiredValidationFailureMessage();
             }
             return false;
         }
 
-        if ($empty && ! $required && ! $continueIfEmpty) {
+        if ($empty && ! $this->required && ! $this->continueIfEmpty) {
             return true;
         }
 
-        if ($empty && $allowEmpty && ! $continueIfEmpty) {
+        if ($empty && $this->allowEmpty && ! $this->continueIfEmpty) {
             return true;
         }
 
@@ -308,7 +309,7 @@ class Input implements
         // If we do not allow empty and the "continue if empty" flag are
         // BOTH false, we inject the "not empty" validator into the chain,
         // which adds that logic into the validation routine.
-        if (! $allowEmpty && ! $continueIfEmpty) {
+        if (! $this->allowEmpty && ! $this->continueIfEmpty) {
             $this->injectNotEmptyValidator();
         }
 
@@ -322,10 +323,8 @@ class Input implements
         return $result;
     }
 
-    /**
-     * @return array<array-key, string>
-     */
-    public function getMessages()
+    /** @inheritDoc */
+    public function getMessages(): array
     {
         if (null !== $this->errorMessage) {
             return (array) $this->errorMessage;

--- a/src/Input.php
+++ b/src/Input.php
@@ -14,6 +14,7 @@ use Laminas\Validator\ValidatorChainInterface;
 use function assert;
 use function class_exists;
 use function is_array;
+use function reset;
 
 class Input implements
     InputInterface,
@@ -22,7 +23,10 @@ class Input implements
     protected bool $allowEmpty      = false;
     protected bool $continueIfEmpty = false;
     protected bool $breakOnFailure  = false;
-    /** @var string|array<array-key, string>|null */
+    /**
+     * @todo ArrayInput needs refactoring so that this type cannot be an array
+     * @var string|array<array-key, string>|null
+     */
     protected string|array|null $errorMessage = null;
     protected bool $notEmptyValidator         = false;
     protected bool $required                  = true;
@@ -37,7 +41,7 @@ class Input implements
     public function __construct(
         protected FilterChainInterface $filterChain,
         protected ValidatorChainInterface $validatorChain,
-        protected ?string $name = null
+        protected string|int|null $name = null
     ) {
     }
 
@@ -71,10 +75,9 @@ class Input implements
         return $this;
     }
 
-    /** @inheritDoc */
-    public function setName($name): static
+    public function setName(string|int $name): static
     {
-        $this->name = (string) $name;
+        $this->name = $name;
         return $this;
     }
 
@@ -153,11 +156,15 @@ class Input implements
     }
 
     /**
-     * @return string|null
+     * @todo Once ArrayInput is refactored, remove the array checks here
      */
-    public function getErrorMessage()
+    public function getErrorMessage(): string|null
     {
-        return $this->errorMessage;
+        $errorMessage = is_array($this->errorMessage)
+            ? reset($this->errorMessage)
+            : $this->errorMessage;
+
+        return $errorMessage === false ? null : $errorMessage;
     }
 
     public function getFilterChain(): FilterChainInterface
@@ -165,10 +172,7 @@ class Input implements
         return $this->filterChain;
     }
 
-    /**
-     * @return null|string
-     */
-    public function getName()
+    public function getName(): int|string|null
     {
         return $this->name;
     }
@@ -235,7 +239,10 @@ class Input implements
             $this->setContinueIfEmpty($input->continueIfEmpty());
         }
         $this->setErrorMessage($input->getErrorMessage());
-        $this->setName($input->getName());
+        $name = $input->getName();
+        if ($name !== null) {
+            $this->setName($name);
+        }
         $this->setRequired($input->isRequired());
         $this->setAllowEmpty($input->allowEmpty());
         if (! $input instanceof Input || $input->hasValue()) {

--- a/src/Input.php
+++ b/src/Input.php
@@ -379,7 +379,7 @@ class Input implements
      *
      * @return array<string, string>
      */
-    protected function prepareRequiredValidationFailureMessage()
+    protected function prepareRequiredValidationFailureMessage(): array
     {
         $chain = $this->getValidatorChain();
         /**

--- a/src/Input.php
+++ b/src/Input.php
@@ -5,10 +5,13 @@ declare(strict_types=1);
 namespace Laminas\InputFilter;
 
 use Laminas\Filter\FilterChain;
+use Laminas\Filter\FilterChainInterface;
 use Laminas\ServiceManager\AbstractPluginManager;
 use Laminas\Validator\NotEmpty;
 use Laminas\Validator\ValidatorChain;
+use Laminas\Validator\ValidatorChainInterface;
 
+use function assert;
 use function class_exists;
 use function is_array;
 
@@ -16,91 +19,53 @@ class Input implements
     InputInterface,
     EmptyContextInterface
 {
-    /** @var bool */
-    protected $allowEmpty = false;
-
-    /** @var bool */
-    protected $continueIfEmpty = false;
-
-    /** @var bool */
-    protected $breakOnFailure = false;
-
-    /** @var string|null */
-    protected $errorMessage;
-
-    /** @var bool */
-    protected $notEmptyValidator = false;
-
-    /** @var bool */
-    protected $required = true;
-
-    /** @var mixed */
-    protected $value;
-
+    protected bool $allowEmpty      = false;
+    protected bool $continueIfEmpty = false;
+    protected bool $breakOnFailure  = false;
+    /** @var string|array<array-key, string>|null */
+    protected string|array|null $errorMessage = null;
+    protected bool $notEmptyValidator         = false;
+    protected bool $required                  = true;
+    protected mixed $value                    = null; // phpcs:ignore
     /**
-     * Flag for distinguish when $value contains the value previously set or the default one.
-     *
-     * @var bool
+     * Flag to distinguish when $value contains the value previously set or the default one.
      */
-    protected $hasValue = false;
-
-    /** @var mixed|null */
-    protected $fallbackValue;
-
-    /** @var bool */
-    protected $hasFallback = false;
+    protected bool $hasValue = false;
+    protected mixed $fallbackValue;
+    protected bool $hasFallback = false;
 
     public function __construct(
-        protected FilterChain $filterChain,
-        protected ValidatorChain $validatorChain,
+        protected FilterChainInterface $filterChain,
+        protected ValidatorChainInterface $validatorChain,
         protected ?string $name = null
     ) {
     }
 
-    /**
-     * @param  bool $allowEmpty
-     * @return $this
-     */
-    public function setAllowEmpty($allowEmpty): static
+    public function setAllowEmpty(bool $allowEmpty): static
     {
-        $this->allowEmpty = (bool) $allowEmpty;
+        $this->allowEmpty = $allowEmpty;
         return $this;
     }
 
-    /**
-     * @param  bool $breakOnFailure
-     * @return $this
-     */
-    public function setBreakOnFailure($breakOnFailure): static
+    public function setBreakOnFailure(bool $breakOnFailure): static
     {
-        $this->breakOnFailure = (bool) $breakOnFailure;
+        $this->breakOnFailure = $breakOnFailure;
         return $this;
     }
 
-    /**
-     * @param bool $continueIfEmpty
-     * @return $this
-     */
-    public function setContinueIfEmpty($continueIfEmpty): static
+    public function setContinueIfEmpty(bool $continueIfEmpty): static
     {
-        $this->continueIfEmpty = (bool) $continueIfEmpty;
+        $this->continueIfEmpty = $continueIfEmpty;
         return $this;
     }
 
-    /**
-     * @param  string|null $errorMessage
-     * @return $this
-     */
-    public function setErrorMessage($errorMessage): static
+    public function setErrorMessage(string|null $errorMessage): static
     {
-        $this->errorMessage = null === $errorMessage ? null : (string) $errorMessage;
+        $this->errorMessage = $errorMessage;
         return $this;
     }
 
-    /**
-     * @return $this
-     */
-    public function setFilterChain(FilterChain $filterChain): static
+    public function setFilterChain(FilterChainInterface $filterChain): static
     {
         $this->filterChain = $filterChain;
         return $this;
@@ -124,10 +89,7 @@ class Input implements
         return $this;
     }
 
-    /**
-     * @return $this
-     */
-    public function setValidatorChain(ValidatorChain $validatorChain): static
+    public function setValidatorChain(ValidatorChainInterface $validatorChain): static
     {
         $this->validatorChain = $validatorChain;
         return $this;
@@ -141,11 +103,8 @@ class Input implements
      * @see Input::getValue() For retrieve the input value.
      * @see Input::hasValue() For to know if input value was set.
      * @see Input::resetValue() For reset the input value to the default state.
-     *
-     * @param  mixed $value
-     * @return $this
      */
-    public function setValue($value): static
+    public function setValue(mixed $value): static
     {
         $this->value    = $value;
         $this->hasValue = true;
@@ -178,26 +137,17 @@ class Input implements
         return $this;
     }
 
-    /**
-     * @return bool
-     */
-    public function allowEmpty()
+    public function allowEmpty(): bool
     {
         return $this->allowEmpty;
     }
 
-    /**
-     * @return bool
-     */
-    public function breakOnFailure()
+    public function breakOnFailure(): bool
     {
         return $this->breakOnFailure;
     }
 
-    /**
-     * @return bool
-     */
-    public function continueIfEmpty()
+    public function continueIfEmpty(): bool
     {
         return $this->continueIfEmpty;
     }
@@ -210,7 +160,7 @@ class Input implements
         return $this->errorMessage;
     }
 
-    public function getFilterChain(): FilterChain
+    public function getFilterChain(): FilterChainInterface
     {
         return $this->filterChain;
     }
@@ -223,34 +173,22 @@ class Input implements
         return $this->name;
     }
 
-    /**
-     * @return mixed
-     */
-    public function getRawValue()
+    public function getRawValue(): mixed
     {
         return $this->value;
     }
 
-    /**
-     * @return bool
-     */
-    public function isRequired()
+    public function isRequired(): bool
     {
         return $this->required;
     }
 
-    /**
-     * @return ValidatorChain
-     */
-    public function getValidatorChain()
+    public function getValidatorChain(): ValidatorChainInterface
     {
         return $this->validatorChain;
     }
 
-    /**
-     * @return mixed
-     */
-    public function getValue()
+    public function getValue(): mixed
     {
         $filter = $this->getFilterChain();
         return $filter->filter($this->value);
@@ -265,32 +203,23 @@ class Input implements
      * @see Input::getValue() For retrieve the input value.
      * @see Input::setValue() For set a new value.
      * @see Input::resetValue() For reset the input value to the default state.
-     *
-     * @return bool
      */
-    public function hasValue()
+    public function hasValue(): bool
     {
         return $this->hasValue;
     }
 
-    /**
-     * @return mixed
-     */
-    public function getFallbackValue()
+    public function getFallbackValue(): mixed
     {
         return $this->fallbackValue;
     }
 
-    /**
-     * @return bool
-     */
-    public function hasFallback()
+    public function hasFallback(): bool
     {
         return $this->hasFallback;
     }
 
-    /** @return void */
-    public function clearFallbackValue()
+    public function clearFallbackValue(): void
     {
         $this->hasFallback   = false;
         $this->fallbackValue = null;
@@ -313,11 +242,24 @@ class Input implements
             $this->setValue($input->getRawValue());
         }
 
-        $filterChain = $input->getFilterChain();
-        $this->getFilterChain()->merge($filterChain);
+        $sourceFilterChain = $input->getFilterChain();
+        $targetFilterChain = $this->getFilterChain();
 
-        $validatorChain = $input->getValidatorChain();
-        $this->getValidatorChain()->merge($validatorChain);
+        assert(
+            $sourceFilterChain instanceof FilterChain
+            &&
+            $targetFilterChain instanceof FilterChain
+        );
+        $targetFilterChain->merge($sourceFilterChain);
+
+        $sourceValidatorChain = $input->getValidatorChain();
+        $targetValidatorChain = $this->getValidatorChain();
+        assert(
+            $sourceValidatorChain instanceof ValidatorChain
+            &&
+            $targetValidatorChain instanceof ValidatorChain
+        );
+        $targetValidatorChain->merge($sourceValidatorChain);
         return $this;
     }
 
@@ -394,15 +336,16 @@ class Input implements
         return $validator->getMessages();
     }
 
-    /**
-     * @return void
-     */
-    protected function injectNotEmptyValidator()
+    protected function injectNotEmptyValidator(): void
     {
         if ((! $this->isRequired() && $this->allowEmpty()) || $this->notEmptyValidator) {
             return;
         }
         $chain = $this->getValidatorChain();
+        /**
+         * @todo Refactor injection of not-empty validator to use DI
+         */
+        assert($chain instanceof ValidatorChain);
 
         // Check if NotEmpty validator is already in chain
         $validators = $chain->getValidators();
@@ -431,7 +374,12 @@ class Input implements
      */
     protected function prepareRequiredValidationFailureMessage()
     {
-        $chain    = $this->getValidatorChain();
+        $chain = $this->getValidatorChain();
+        /**
+         * @todo Refactor "Empty" error message provision so that users can configure an acceptable validator,
+         *       translate error messages correctly etc.
+         */
+        assert($chain instanceof ValidatorChain);
         $notEmpty = null;
 
         foreach ($chain->getValidators() as $validator) {

--- a/src/Input.php
+++ b/src/Input.php
@@ -61,7 +61,7 @@ class Input implements
      * @param  bool $allowEmpty
      * @return $this
      */
-    public function setAllowEmpty($allowEmpty)
+    public function setAllowEmpty($allowEmpty): static
     {
         $this->allowEmpty = (bool) $allowEmpty;
         return $this;
@@ -71,7 +71,7 @@ class Input implements
      * @param  bool $breakOnFailure
      * @return $this
      */
-    public function setBreakOnFailure($breakOnFailure)
+    public function setBreakOnFailure($breakOnFailure): static
     {
         $this->breakOnFailure = (bool) $breakOnFailure;
         return $this;
@@ -81,7 +81,7 @@ class Input implements
      * @param bool $continueIfEmpty
      * @return $this
      */
-    public function setContinueIfEmpty($continueIfEmpty)
+    public function setContinueIfEmpty($continueIfEmpty): static
     {
         $this->continueIfEmpty = (bool) $continueIfEmpty;
         return $this;
@@ -91,7 +91,7 @@ class Input implements
      * @param  string|null $errorMessage
      * @return $this
      */
-    public function setErrorMessage($errorMessage)
+    public function setErrorMessage($errorMessage): static
     {
         $this->errorMessage = null === $errorMessage ? null : (string) $errorMessage;
         return $this;
@@ -100,14 +100,14 @@ class Input implements
     /**
      * @return $this
      */
-    public function setFilterChain(FilterChain $filterChain)
+    public function setFilterChain(FilterChain $filterChain): static
     {
         $this->filterChain = $filterChain;
         return $this;
     }
 
     /** @inheritDoc */
-    public function setName($name)
+    public function setName($name): static
     {
         $this->name = (string) $name;
         return $this;
@@ -117,7 +117,7 @@ class Input implements
      * @param  bool $required
      * @return $this
      */
-    public function setRequired($required)
+    public function setRequired($required): static
     {
         /** @psalm-suppress RedundantCastGivenDocblockType */
         $this->required = (bool) $required;
@@ -127,7 +127,7 @@ class Input implements
     /**
      * @return $this
      */
-    public function setValidatorChain(ValidatorChain $validatorChain)
+    public function setValidatorChain(ValidatorChain $validatorChain): static
     {
         $this->validatorChain = $validatorChain;
         return $this;
@@ -145,7 +145,7 @@ class Input implements
      * @param  mixed $value
      * @return $this
      */
-    public function setValue($value)
+    public function setValue($value): static
     {
         $this->value    = $value;
         $this->hasValue = true;
@@ -160,7 +160,7 @@ class Input implements
      *
      * @return $this
      */
-    public function resetValue()
+    public function resetValue(): static
     {
         $this->value    = null;
         $this->hasValue = false;
@@ -171,7 +171,7 @@ class Input implements
      * @param  mixed $value
      * @return $this
      */
-    public function setFallbackValue($value)
+    public function setFallbackValue($value): static
     {
         $this->fallbackValue = $value;
         $this->hasFallback   = true;
@@ -299,7 +299,7 @@ class Input implements
     /**
      * @return $this
      */
-    public function merge(InputInterface $input)
+    public function merge(InputInterface $input): static
     {
         $this->setBreakOnFailure($input->breakOnFailure());
         if ($input instanceof Input) {

--- a/src/Input.php
+++ b/src/Input.php
@@ -129,11 +129,7 @@ class Input implements
         return $this;
     }
 
-    /**
-     * @param  mixed $value
-     * @return $this
-     */
-    public function setFallbackValue($value): static
+    public function setFallbackValue(mixed $value): static
     {
         $this->fallbackValue = $value;
         $this->hasFallback   = true;

--- a/src/InputFilterInterface.php
+++ b/src/InputFilterInterface.php
@@ -103,7 +103,7 @@ interface InputFilterInterface extends Countable
      *
      * @return array<array-key, InputInterface|InputFilterInterface>
      */
-    public function getInvalidInput();
+    public function getInvalidInput(): array;
 
     /**
      * Return a list of inputs that were valid.
@@ -113,7 +113,7 @@ interface InputFilterInterface extends Countable
      *
      * @return array<array-key, InputInterface|InputFilterInterface>
      */
-    public function getValidInput();
+    public function getValidInput(): array;
 
     /**
      * Retrieve a value from a named input
@@ -129,7 +129,7 @@ interface InputFilterInterface extends Countable
      * @return array<array-key, mixed>
      * @psalm-return TFilteredValues
      */
-    public function getValues();
+    public function getValues(): array;
 
     /**
      * Retrieve a raw (unfiltered) value from a named input
@@ -144,7 +144,7 @@ interface InputFilterInterface extends Countable
      *
      * @return array<array-key, mixed>
      */
-    public function getRawValues();
+    public function getRawValues(): array;
 
     /**
      * Return a list of validation failure messages
@@ -154,5 +154,5 @@ interface InputFilterInterface extends Countable
      *
      * @return array<array-key, array<array-key, string|array>>
      */
-    public function getMessages();
+    public function getMessages(): array;
 }

--- a/src/InputFilterInterface.php
+++ b/src/InputFilterInterface.php
@@ -49,32 +49,23 @@ interface InputFilterInterface extends Countable
      *     raise an exception for any they cannot process.
      * @param  null|array-key $name Name used to retrieve this input
      * @throws Exception\InvalidArgumentException If unable to handle the input type.
-     * @return $this
      */
-    public function add($input, $name = null): static;
+    public function add($input, int|string|null $name = null): static;
 
     /**
      * Retrieve a named input
-     *
-     * @param array-key $name
      */
-    public function get($name): InputInterface|InputFilterInterface;
+    public function get(int|string $name): InputInterface|InputFilterInterface;
 
     /**
      * Test if an input or input filter by the given name is attached
-     *
-     * @param  array-key $name
-     * @return bool
      */
-    public function has($name);
+    public function has(int|string $name): bool;
 
     /**
      * Remove a named input
-     *
-     * @param  array-key $name
-     * @return InputFilterInterface
      */
-    public function remove($name);
+    public function remove(int|string $name): static;
 
     /**
      * Set data to use when validating and filtering
@@ -86,10 +77,8 @@ interface InputFilterInterface extends Countable
 
     /**
      * Is the data set valid?
-     *
-     * @return bool
      */
-    public function isValid();
+    public function isValid(): bool;
 
     /**
      * Provide a list of one or more elements indicating the complete set to validate
@@ -128,11 +117,8 @@ interface InputFilterInterface extends Countable
 
     /**
      * Retrieve a value from a named input
-     *
-     * @param  array-key $name
-     * @return mixed
      */
-    public function getValue($name);
+    public function getValue(int|string $name): mixed;
 
     /**
      * Return a list of filtered values
@@ -147,11 +133,8 @@ interface InputFilterInterface extends Countable
 
     /**
      * Retrieve a raw (unfiltered) value from a named input
-     *
-     * @param  array-key $name
-     * @return mixed
      */
-    public function getRawValue($name);
+    public function getRawValue(int|string $name): mixed;
 
     /**
      * Return a list of unfiltered values

--- a/src/InputFilterInterface.php
+++ b/src/InputFilterInterface.php
@@ -7,6 +7,7 @@ namespace Laminas\InputFilter;
 use Countable;
 use Laminas\Filter\FilterChain; // phpcs:ignore
 use Laminas\Filter\FilterInterface; // phpcs:ignore
+use Laminas\InputFilter\Exception\InputNotFoundException;
 use Laminas\Validator\ValidatorChain; // phpcs:ignore
 use Laminas\Validator\ValidatorInterface; // phpcs:ignore
 
@@ -36,6 +37,8 @@ use Laminas\Validator\ValidatorInterface; // phpcs:ignore
  *     required?: bool,
  *     required_message?: string,
  * }&array<array-key, InputSpecification>
+ * @psalm-type InputErrorMessages = array<string, string>
+ * @psalm-type InputFilterErrorMessages = array<array-key, InputErrorMessages|InputErrorMessages[]>
  */
 interface InputFilterInterface extends Countable
 {
@@ -50,10 +53,15 @@ interface InputFilterInterface extends Countable
      * @param  null|array-key $name Name used to retrieve this input
      * @throws Exception\InvalidArgumentException If unable to handle the input type.
      */
-    public function add($input, int|string|null $name = null): static;
+    public function add(
+        InputInterface|InputFilterInterface|array $input,
+        int|string|null $name = null,
+    ): static;
 
     /**
      * Retrieve a named input
+     *
+     * @throws InputNotFoundException
      */
     public function get(int|string $name): InputInterface|InputFilterInterface;
 
@@ -70,15 +78,16 @@ interface InputFilterInterface extends Countable
     /**
      * Set data to use when validating and filtering
      *
-     * @param  iterable|null $data
-     * @return InputFilterInterface
+     * @param  iterable<array-key, mixed>|null $data
      */
-    public function setData($data);
+    public function setData(iterable|null $data): static;
 
     /**
      * Is the data set valid?
+     *
+     * @param array<array-key, mixed>|null $context
      */
-    public function isValid(): bool;
+    public function isValid(array|null $context = null): bool;
 
     /**
      * Provide a list of one or more elements indicating the complete set to validate
@@ -91,9 +100,10 @@ interface InputFilterInterface extends Countable
      * Implementations should allow passing a single array value, or multiple arguments,
      * each specifying a single input.
      *
-     * @param  array-key|list<array-key> $name
+     * @param array-key|array<array-key, mixed> $name
+     * @throws InputNotFoundException
      */
-    public function setValidationGroup($name): static;
+    public function setValidationGroup(int|string|array $name): static;
 
     /**
      * Return a list of inputs that were invalid.
@@ -133,6 +143,8 @@ interface InputFilterInterface extends Countable
 
     /**
      * Retrieve a raw (unfiltered) value from a named input
+     *
+     * @throws InputNotFoundException
      */
     public function getRawValue(int|string $name): mixed;
 
@@ -152,7 +164,7 @@ interface InputFilterInterface extends Countable
      * Should return an associative array of named input/message list pairs.
      * Pairs should only be returned for inputs that failed validation.
      *
-     * @return array<array-key, array<array-key, string|array>>
+     * @return InputFilterErrorMessages|InputFilterErrorMessages[]
      */
     public function getMessages(): array;
 }

--- a/src/InputFilterInterface.php
+++ b/src/InputFilterInterface.php
@@ -103,9 +103,8 @@ interface InputFilterInterface extends Countable
      * each specifying a single input.
      *
      * @param  array-key|list<array-key> $name
-     * @return InputFilterInterface
      */
-    public function setValidationGroup($name);
+    public function setValidationGroup($name): static;
 
     /**
      * Return a list of inputs that were invalid.

--- a/src/InputInterface.php
+++ b/src/InputInterface.php
@@ -53,7 +53,7 @@ interface InputInterface
      * @param mixed $value
      * @return $this
      */
-    public function setValue($value);
+    public function setValue($value): static;
 
     /**
      * @return $this

--- a/src/InputInterface.php
+++ b/src/InputInterface.php
@@ -17,11 +17,7 @@ interface InputInterface
 
     public function setFilterChain(FilterChainInterface $filterChain): static;
 
-    /**
-     * @param array-key $name
-     * @return $this
-     */
-    public function setName($name);
+    public function setName(string|int $name): static;
 
     public function setRequired(bool $required): static;
 
@@ -35,17 +31,11 @@ interface InputInterface
 
     public function breakOnFailure(): bool;
 
-    /**
-     * @return string|null
-     */
-    public function getErrorMessage();
+    public function getErrorMessage(): string|null;
 
     public function getFilterChain(): FilterChainInterface;
 
-    /**
-     * @return string
-     */
-    public function getName();
+    public function getName(): int|string|null;
 
     public function getRawValue(): mixed;
 

--- a/src/InputInterface.php
+++ b/src/InputInterface.php
@@ -4,33 +4,18 @@ declare(strict_types=1);
 
 namespace Laminas\InputFilter;
 
-use Laminas\Filter\FilterChain;
-use Laminas\Validator\ValidatorChain;
+use Laminas\Filter\FilterChainInterface;
+use Laminas\Validator\ValidatorChainInterface;
 
 interface InputInterface
 {
-    /**
-     * @param bool $allowEmpty
-     * @return $this
-     */
-    public function setAllowEmpty($allowEmpty);
+    public function setAllowEmpty(bool $allowEmpty): static;
 
-    /**
-     * @param bool $breakOnFailure
-     * @return $this
-     */
-    public function setBreakOnFailure($breakOnFailure);
+    public function setBreakOnFailure(bool $breakOnFailure): static;
 
-    /**
-     * @param string|null $errorMessage
-     * @return $this
-     */
-    public function setErrorMessage($errorMessage);
+    public function setErrorMessage(string|null $errorMessage): static;
 
-    /**
-     * @return $this
-     */
-    public function setFilterChain(FilterChain $filterChain);
+    public function setFilterChain(FilterChainInterface $filterChain): static;
 
     /**
      * @param array-key $name
@@ -38,72 +23,37 @@ interface InputInterface
      */
     public function setName($name);
 
-    /**
-     * @param bool $required
-     * @return $this
-     */
-    public function setRequired($required);
+    public function setRequired(bool $required): static;
 
-    /**
-     * @return $this
-     */
-    public function setValidatorChain(ValidatorChain $validatorChain);
+    public function setValidatorChain(ValidatorChainInterface $validatorChain): static;
 
-    /**
-     * @param mixed $value
-     * @return $this
-     */
-    public function setValue($value): static;
+    public function setValue(mixed $value): static;
 
-    /**
-     * @return $this
-     */
-    public function merge(InputInterface $input);
+    public function merge(InputInterface $input): static;
 
-    /**
-     * @return bool
-     */
-    public function allowEmpty();
+    public function allowEmpty(): bool;
 
-    /**
-     * @return bool
-     */
-    public function breakOnFailure();
+    public function breakOnFailure(): bool;
 
     /**
      * @return string|null
      */
     public function getErrorMessage();
 
-    /**
-     * @return FilterChain
-     */
-    public function getFilterChain();
+    public function getFilterChain(): FilterChainInterface;
 
     /**
      * @return string
      */
     public function getName();
 
-    /**
-     * @return mixed
-     */
-    public function getRawValue();
+    public function getRawValue(): mixed;
 
-    /**
-     * @return bool
-     */
-    public function isRequired();
+    public function isRequired(): bool;
 
-    /**
-     * @return ValidatorChain
-     */
-    public function getValidatorChain();
+    public function getValidatorChain(): ValidatorChainInterface;
 
-    /**
-     * @return mixed
-     */
-    public function getValue();
+    public function getValue(): mixed;
 
     public function isValid(): bool;
 

--- a/src/InputInterface.php
+++ b/src/InputInterface.php
@@ -7,6 +7,7 @@ namespace Laminas\InputFilter;
 use Laminas\Filter\FilterChainInterface;
 use Laminas\Validator\ValidatorChainInterface;
 
+/** @psalm-import-type InputErrorMessages from InputFilterInterface */
 interface InputInterface
 {
     public function setAllowEmpty(bool $allowEmpty): static;
@@ -45,10 +46,9 @@ interface InputInterface
 
     public function getValue(): mixed;
 
-    public function isValid(): bool;
+    /** @param array<array-key, mixed>|null $context */
+    public function isValid(array|null $context = null): bool;
 
-    /**
-     * @return array<array-key, string>
-     */
-    public function getMessages();
+    /** @return InputErrorMessages */
+    public function getMessages(): array;
 }

--- a/src/OptionalInputFilter.php
+++ b/src/OptionalInputFilter.php
@@ -38,7 +38,7 @@ class OptionalInputFilter extends InputFilter
      *
      * {@inheritDoc}
      */
-    public function isValid($context = null)
+    public function isValid($context = null): bool
     {
         if (! $this->isEmpty($this->data)) {
             return parent::isValid($context);

--- a/src/OptionalInputFilter.php
+++ b/src/OptionalInputFilter.php
@@ -11,22 +11,15 @@ use function is_iterable;
 /**
  * InputFilter which only checks the containing Inputs when non-empty data is set,
  * else it reports valid
- * This is analog to {@see Input} with the option ->setRequired(false)
+ * This is analogous to {@see Input} with the option ->setRequired(false)
  *
  * @template TFilteredValues
  * @extends InputFilter<TFilteredValues>
  */
 class OptionalInputFilter extends InputFilter
 {
-    /**
-     * Set data to use when validating and filtering
-     *
-     * @param iterable|null $data must be a non-empty iterable in order trigger
-     *                            actual validation, else it is always valid
-     * @return $this
-     * @throws Exception\InvalidArgumentException
-     */
-    public function setData($data): static
+    /** @inheritDoc */
+    public function setData(iterable|null $data): static
     {
         parent::setData($this->isEmpty($data) ? [] : $data);
 
@@ -38,7 +31,7 @@ class OptionalInputFilter extends InputFilter
      *
      * {@inheritDoc}
      */
-    public function isValid($context = null): bool
+    public function isValid(array|null $context = null): bool
     {
         if (! $this->isEmpty($this->data)) {
             return parent::isValid($context);

--- a/src/OptionalInputFilter.php
+++ b/src/OptionalInputFilter.php
@@ -26,7 +26,7 @@ class OptionalInputFilter extends InputFilter
      * @return $this
      * @throws Exception\InvalidArgumentException
      */
-    public function setData($data)
+    public function setData($data): static
     {
         parent::setData($this->isEmpty($data) ? [] : $data);
 

--- a/src/OptionalInputFilter.php
+++ b/src/OptionalInputFilter.php
@@ -47,21 +47,6 @@ class OptionalInputFilter extends InputFilter
         return true;
     }
 
-    /**
-     * Return a list of filtered values, or null if the data was missing entirely
-     * Null is returned instead of an empty array to prevent it being passed to a hydrator,
-     *     which would likely cause failures later on in your program
-     * Fallbacks for the inputs are not respected by design
-     *
-     * @return TFilteredValues|null
-     */
-    public function getValues()
-    {
-        return ! $this->isEmpty($this->data)
-            ? parent::getValues()
-            : null;
-    }
-
     private function isEmpty(iterable|null $data): bool
     {
         $data = is_iterable($data) ? ArrayUtils::iteratorToArray($data) : $data;

--- a/src/ReplaceableInputInterface.php
+++ b/src/ReplaceableInputInterface.php
@@ -9,10 +9,8 @@ namespace Laminas\InputFilter;
  */
 interface ReplaceableInputInterface
 {
-    /**
-     * @param InputInterface $input
-     * @param string $name
-     * @return self
-     */
-    public function replace($input, $name);
+    public function replace(
+        InputInterface|InputFilterInterface|array $input,
+        int|string $name,
+    ): static;
 }

--- a/src/UnfilteredDataInterface.php
+++ b/src/UnfilteredDataInterface.php
@@ -12,11 +12,11 @@ interface UnfilteredDataInterface
     /**
      * @return array<array-key, mixed>
      */
-    public function getUnfilteredData();
+    public function getUnfilteredData(): array;
 
     /**
      * @param array<array-key, mixed> $data
      * @return $this
      */
-    public function setUnfilteredData($data);
+    public function setUnfilteredData(array $data): static;
 }

--- a/src/UnknownInputsCapableInterface.php
+++ b/src/UnknownInputsCapableInterface.php
@@ -11,18 +11,17 @@ namespace Laminas\InputFilter;
 interface UnknownInputsCapableInterface
 {
     /**
-     * Is the data set has unknown input ?
+     * Does the data set contain unknown inputs?
      *
      * @throws Exception\RuntimeException
-     * @return bool
      */
-    public function hasUnknown();
+    public function hasUnknown(): bool;
 
     /**
      * Return the unknown input
      *
      * @throws Exception\RuntimeException
-     * @return array
+     * @return array<array-key, mixed>
      */
-    public function getUnknown();
+    public function getUnknown(): array;
 }

--- a/test/ArrayInputTest.php
+++ b/test/ArrayInputTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace LaminasTest\InputFilter;
 
 use Laminas\Filter\FilterChain;
+use Laminas\Filter\FilterChainInterface;
 use Laminas\Filter\ToInt;
 use Laminas\Filter\ToNull;
 use Laminas\InputFilter\ArrayInput;
@@ -17,6 +18,7 @@ use Laminas\Validator\IsArray;
 use Laminas\Validator\NotEmpty as NotEmptyValidator;
 use Laminas\Validator\NumberComparison;
 use Laminas\Validator\ValidatorChain;
+use Laminas\Validator\ValidatorChainInterface;
 use Laminas\Validator\ValidatorInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -27,7 +29,6 @@ use stdClass;
 use function array_diff_key;
 use function array_merge;
 use function array_pop;
-use function count;
 use function iterator_to_array;
 use function json_encode;
 use function sprintf;
@@ -285,12 +286,12 @@ final class ArrayInputTest extends TestCase
         self::assertEquals(
             self::EMPTY_ERROR_MESSAGE,
             $messages[self::EMPTY_ERROR_MESSAGE_KEY],
-            $message . ' missing NotEmpty::IS_EMPTY key and/or contains additional messages'
+            $message . ' missing NotEmpty::IS_EMPTY key and/or contains additional messages',
         );
         self::assertCount(
             1,
             $messages,
-            $message . ' missing NotEmpty::IS_EMPTY key and/or contains additional messages'
+            $message . ' missing NotEmpty::IS_EMPTY key and/or contains additional messages',
         );
     }
 
@@ -403,7 +404,7 @@ final class ArrayInputTest extends TestCase
         array $fallbackValue,
         array $originalValue,
         bool $isValid,
-        array $expectedValue
+        array $expectedValue,
     ): void {
         $input = $this->input;
         $input->setContinueIfEmpty(true);
@@ -416,7 +417,7 @@ final class ArrayInputTest extends TestCase
         self::assertTrue(
             $input->isValid(),
             'isValid() should be return always true when fallback value is set. Detail: '
-            . json_encode($input->getMessages(), JSON_THROW_ON_ERROR)
+            . json_encode($input->getMessages(), JSON_THROW_ON_ERROR),
         );
         self::assertEquals([], $input->getMessages(), 'getMessages() should be empty because the input is valid');
         self::assertSame($expectedValue, $input->getRawValue(), 'getRawValue() value not match');
@@ -441,7 +442,7 @@ final class ArrayInputTest extends TestCase
         self::assertTrue(
             $input->isValid(),
             'isValid() should be return always true when fallback value is set. Detail: '
-            . json_encode($input->getMessages(), JSON_THROW_ON_ERROR)
+            . json_encode($input->getMessages(), JSON_THROW_ON_ERROR),
         );
         self::assertEquals([], $input->getMessages(), 'getMessages() should be empty because the input is valid');
         self::assertSame($expectedValue, $input->getRawValue(), 'getRawValue() value not match');
@@ -455,7 +456,7 @@ final class ArrayInputTest extends TestCase
 
         self::assertFalse(
             $input->isValid(),
-            'isValid() should be return always false when no fallback value, is required, and not data is set.'
+            'isValid() should be return always false when no fallback value, is required, and not data is set.',
         );
         $this->assertRequiredValidationErrorMessage($input);
     }
@@ -468,7 +469,7 @@ final class ArrayInputTest extends TestCase
 
         self::assertFalse(
             $input->isValid(),
-            'isValid() should be return always false when no fallback value, is required, and not data is set.'
+            'isValid() should be return always false when no fallback value, is required, and not data is set.',
         );
         self::assertSame(['FAILED TO VALIDATE'], $input->getMessages());
     }
@@ -481,7 +482,7 @@ final class ArrayInputTest extends TestCase
         self::assertFalse(
             $input->isValid(),
             'isValid() should always return false when no fallback value is present, '
-            . 'the input is required, and no data is set.'
+            . 'the input is required, and no data is set.',
         );
         $this->assertRequiredValidationErrorMessage($input);
     }
@@ -500,7 +501,7 @@ final class ArrayInputTest extends TestCase
         self::assertFalse(
             $input->isValid(),
             'isValid() should always return false when no fallback value is present, '
-            . 'the input is required, and no data is set.'
+            . 'the input is required, and no data is set.',
         );
         self::assertEquals($customMessage, $input->getMessages());
     }
@@ -514,7 +515,7 @@ final class ArrayInputTest extends TestCase
         self::assertFalse(
             $input->isValid(),
             'isValid() should always return false when no fallback value is present, '
-            . 'the input is required, and no data is set.'
+            . 'the input is required, and no data is set.',
         );
         self::assertSame(['FAILED TO VALIDATE'], $input->getMessages());
     }
@@ -532,7 +533,7 @@ final class ArrayInputTest extends TestCase
         self::assertTrue(
             $input->isValid(),
             'isValid() should be return always true when is not required, and no data is set. Detail: '
-            . json_encode($input->getMessages(), JSON_THROW_ON_ERROR)
+            . json_encode($input->getMessages(), JSON_THROW_ON_ERROR),
         );
         self::assertEquals([], $input->getMessages(), 'getMessages() should be empty because the input is valid');
     }
@@ -547,9 +548,8 @@ final class ArrayInputTest extends TestCase
         $input->setContinueIfEmpty(true);
         $input->setValue($raw);
         $input->isValid();
-        $validators = $input->getValidatorChain()
-            ->getValidators();
-        self::assertEmpty($validators);
+        $validators = self::assertValidatorChain($input->getValidatorChain());
+        self::assertCount(0, $validators);
     }
 
     public function testValueMayBeInjected(): void
@@ -597,7 +597,7 @@ final class ArrayInputTest extends TestCase
 
         self::assertTrue(
             $this->input->isValid(),
-            'isValid() value not match. Detail . ' . json_encode($this->input->getMessages(), JSON_THROW_ON_ERROR)
+            'isValid() value not match. Detail . ' . json_encode($this->input->getMessages(), JSON_THROW_ON_ERROR),
         );
     }
 
@@ -620,17 +620,17 @@ final class ArrayInputTest extends TestCase
     {
         self::assertTrue($this->input->isRequired());
         $this->input->setValue($raw);
-        $validatorChain = $this->input->getValidatorChain();
-        self::assertEquals(0, count($validatorChain->getValidators()));
+        $validatorChain = self::assertValidatorChain($this->input->getValidatorChain());
+        self::assertCount(0, $validatorChain->getValidators());
 
         self::assertFalse($this->input->isValid());
         $messages = $this->input->getMessages();
         self::assertArrayHasKey(self::EMPTY_ERROR_MESSAGE_KEY, $messages);
-        self::assertEquals(1, count($validatorChain->getValidators()));
+        self::assertCount(1, $validatorChain->getValidators());
 
         // Assert that NotEmpty validator wasn't added again
         self::assertFalse($this->input->isValid());
-        self::assertEquals(1, count($validatorChain->getValidators()));
+        self::assertCount(1, $validatorChain->getValidators());
     }
 
     /**
@@ -644,12 +644,12 @@ final class ArrayInputTest extends TestCase
 
         $notEmpty = new NotEmptyValidator();
 
-        $validatorChain = $this->input->getValidatorChain();
+        $validatorChain = self::assertValidatorChain($this->input->getValidatorChain());
         $validatorChain->prependValidator($notEmpty);
         self::assertFalse($this->input->isValid());
 
         $validators = $validatorChain->getValidators();
-        self::assertEquals(1, count($validators));
+        self::assertCount(1, $validators);
         self::assertEquals($notEmpty, $validators[0]['instance']);
     }
 
@@ -657,7 +657,7 @@ final class ArrayInputTest extends TestCase
     #[DataProvider('emptyValueProvider')]
     public function testDoNotInjectNotEmptyValidatorIfAnywhereInChain(mixed $raw, mixed $filtered): void
     {
-        $validatorChain = $this->input->getValidatorChain();
+        $validatorChain = self::assertValidatorChain($this->input->getValidatorChain());
 
         $this->input->setRequired(true);
         $this->input->setValue($raw);
@@ -671,7 +671,7 @@ final class ArrayInputTest extends TestCase
         self::assertFalse($this->input->isValid());
 
         $validators = $validatorChain->getValidators();
-        self::assertEquals(2, count($validators));
+        self::assertCount(2, $validators);
         self::assertEquals($mockValidator, $validators[0]['instance']);
         self::assertEquals($notEmpty, $validators[1]['instance']);
     }
@@ -685,7 +685,7 @@ final class ArrayInputTest extends TestCase
         ValidatorInterface $validator,
         mixed $value,
         bool $expectedIsValid,
-        array $expectedMessages
+        array $expectedMessages,
     ): void {
         $this->input->setRequired($required);
         $this->input->setAllowEmpty($allowEmpty);
@@ -697,7 +697,7 @@ final class ArrayInputTest extends TestCase
         self::assertEquals(
             $expectedIsValid,
             $this->input->isValid(),
-            'isValid() value not match. Detail: ' . json_encode($this->input->getMessages(), JSON_THROW_ON_ERROR)
+            'isValid() value not match. Detail: ' . json_encode($this->input->getMessages(), JSON_THROW_ON_ERROR),
         );
         self::assertEquals($expectedMessages, $this->input->getMessages(), 'getMessages() value not match');
         self::assertEquals($value, $this->input->getRawValue(), 'getRawValue() must return the value always');
@@ -806,16 +806,18 @@ final class ArrayInputTest extends TestCase
         $a = $this->createArrayInput('a');
         $b = $this->createArrayInput('b');
 
-        $a->getFilterChain()->attach($filter1);
+        $filterChain = self::assertFilterChain($a->getFilterChain());
+
+        $filterChain->attach($filter1);
         $b->getFilterChain()->attach($filter2);
 
-        self::assertNotContains($filter2, $a->getFilterChain());
-        self::assertCount(1, $a->getFilterChain());
+        self::assertNotContains($filter2, $filterChain);
+        self::assertCount(1, $filterChain);
 
         $a->merge($b);
 
-        self::assertContains($filter2, $a->getFilterChain());
-        self::assertCount(2, $a->getFilterChain());
+        self::assertContains($filter2, $filterChain);
+        self::assertCount(2, $filterChain);
     }
 
     public function testThatMergingTwoInputsMergesTheValidatorChain(): void
@@ -826,21 +828,37 @@ final class ArrayInputTest extends TestCase
         $a = $this->createArrayInput('a');
         $b = $this->createArrayInput('b');
 
-        $a->getValidatorChain()->attach($validator1);
+        $validatorChain = self::assertValidatorChain($a->getValidatorChain());
+        $validatorChain->attach($validator1);
         $b->getValidatorChain()->attach($validator2);
 
-        self::assertCount(1, $a->getValidatorChain());
-        self::assertValidatorChainNotContains($validator2, $a->getValidatorChain());
+        self::assertCount(1, $validatorChain);
+        self::assertValidatorChainNotContains($validator2, $validatorChain);
 
         $a->merge($b);
 
-        $chain = iterator_to_array($a->getValidatorChain()->getIterator());
+        $chain = iterator_to_array($validatorChain->getIterator());
         self::assertCount(2, $chain);
-        self::assertValidatorChainContains($validator2, $a->getValidatorChain());
+        self::assertValidatorChainContains($validator2, $validatorChain);
     }
 
-    private static function validatorChainContains(ValidatorInterface $validator, ValidatorChain $chain): bool
+    private static function assertFilterChain(FilterChainInterface $chain): FilterChain
     {
+        self::assertInstanceOf(FilterChain::class, $chain);
+
+        return $chain;
+    }
+
+    private static function assertValidatorChain(ValidatorChainInterface $chain): ValidatorChain
+    {
+        self::assertInstanceOf(ValidatorChain::class, $chain);
+
+        return $chain;
+    }
+
+    private static function validatorChainContains(ValidatorInterface $validator, ValidatorChainInterface $chain): bool
+    {
+        $chain = self::assertValidatorChain($chain);
         $found = false;
         foreach ($chain as $spec) {
             if ($spec['instance'] === $validator) {
@@ -852,16 +870,20 @@ final class ArrayInputTest extends TestCase
         return $found;
     }
 
-    private static function assertValidatorChainContains(ValidatorInterface $validator, ValidatorChain $chain): void
-    {
+    private static function assertValidatorChainContains(
+        ValidatorInterface $validator,
+        ValidatorChainInterface $chain,
+    ): void {
         self::assertTrue(self::validatorChainContains($validator, $chain), sprintf(
             'The validator of type "%s" was not found in the chain',
             $validator::class,
         ));
     }
 
-    private static function assertValidatorChainNotContains(ValidatorInterface $validator, ValidatorChain $chain): void
-    {
+    private static function assertValidatorChainNotContains(
+        ValidatorInterface $validator,
+        ValidatorChainInterface $chain,
+    ): void {
         self::assertFalse(self::validatorChainContains($validator, $chain), sprintf(
             'The validator of type "%s" was found in the chain and was not expected to be present',
             $validator::class,

--- a/test/ArrayInputTest.php
+++ b/test/ArrayInputTest.php
@@ -99,10 +99,10 @@ final class ArrayInputTest extends TestCase
     /**
      * @psalm-return array<string, array{
      *     0: bool,
-     *     1: string[],
-     *     2: string[],
+     *     1: list<string>,
+     *     2: list<string>,
      *     3: bool,
-     *     4: string[]
+     *     4: list<string>
      * }>
      */
     public static function fallbackValueVsIsValidProvider(): array
@@ -393,17 +393,17 @@ final class ArrayInputTest extends TestCase
     }
 
     /**
-     * @param string|string[] $fallbackValue
-     * @param string|string[] $originalValue
-     * @param string|string[] $expectedValue
+     * @param list<string> $fallbackValue
+     * @param list<string> $originalValue
+     * @param list<string> $expectedValue
      */
     #[DataProvider('fallbackValueVsIsValidProvider')]
     public function testFallbackValueVsIsValidRules(
         bool $required,
-        $fallbackValue,
-        $originalValue,
+        array $fallbackValue,
+        array $originalValue,
         bool $isValid,
-        $expectedValue
+        array $expectedValue
     ): void {
         $input = $this->input;
         $input->setContinueIfEmpty(true);
@@ -424,10 +424,10 @@ final class ArrayInputTest extends TestCase
     }
 
     /**
-     * @param string|string[] $fallbackValue
+     * @param list<string> $fallbackValue
      */
     #[DataProvider('fallbackValueVsIsValidProvider')]
-    public function testFallbackValueVsIsValidRulesWhenValueNotSet(bool $required, string|array $fallbackValue): void
+    public function testFallbackValueVsIsValidRulesWhenValueNotSet(bool $required, array $fallbackValue): void
     {
         $expectedValue = $fallbackValue; // Should always return the fallback value
 

--- a/test/BaseInputFilterTest.php
+++ b/test/BaseInputFilterTest.php
@@ -9,11 +9,11 @@ use ArrayIterator;
 use ArrayObject;
 use Closure;
 use Laminas\InputFilter\BaseInputFilter;
+use Laminas\InputFilter\Exception\InputNotFoundException;
 use Laminas\InputFilter\Exception\InvalidArgumentException;
 use Laminas\InputFilter\Exception\RuntimeException;
 use Laminas\InputFilter\Factory;
 use Laminas\InputFilter\Input;
-use Laminas\InputFilter\InputFilter;
 use Laminas\InputFilter\InputFilterInterface;
 use Laminas\InputFilter\InputInterface;
 use Laminas\InputFilter\UnfilteredDataInterface;
@@ -23,19 +23,14 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use ReflectionObject;
 use stdClass;
 
 use function array_keys;
 use function array_merge;
 use function array_walk;
-use function assert;
-use function count;
 use function in_array;
-use function is_array;
 use function json_encode;
 use function sprintf;
-use function uniqid;
 
 use const JSON_THROW_ON_ERROR;
 
@@ -61,60 +56,6 @@ final class BaseInputFilterTest extends TestCase
         return new Input(TestHelper::createFilterChain(), TestHelper::createValidatorChain(), $name);
     }
 
-    public function testInputFilterIsEmptyByDefault(): void
-    {
-        $filter = $this->inputFilter;
-        self::assertCount(0, $filter);
-    }
-
-    public function testAddWithInvalidInputTypeThrowsInvalidArgumentException(): void
-    {
-        $inputFilter = $this->inputFilter;
-
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage(
-            'expects an instance of Laminas\InputFilter\InputInterface or Laminas\InputFilter\InputFilterInterface '
-            . 'as its first argument; received "stdClass"'
-        );
-        /** @psalm-suppress InvalidArgument */
-        $inputFilter->add(new stdClass());
-    }
-
-    public function testGetThrowExceptionIfInputDoesNotExists(): void
-    {
-        $inputFilter = $this->inputFilter;
-
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('no input found matching "not exists"');
-        $inputFilter->get('not exists');
-    }
-
-    public function testReplaceWithInvalidInputTypeThrowsInvalidArgumentException(): void
-    {
-        $inputFilter = $this->inputFilter;
-        $inputFilter->add($this->createInput('foo'), 'replace_me');
-
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage(
-            'expects an instance of Laminas\InputFilter\InputInterface or Laminas\InputFilter\InputFilterInterface '
-            . 'as its first argument; received "stdClass"'
-        );
-        /** @psalm-suppress InvalidArgument */
-        $inputFilter->replace(new stdClass(), 'replace_me');
-    }
-
-    public function testReplaceThrowExceptionIfInputToReplaceDoesNotExists(): void
-    {
-        $inputFilter = $this->inputFilter;
-
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('no input found matching "not exists"');
-        $inputFilter->replace(
-            $this->createInput('foo'),
-            'not exists'
-        );
-    }
-
     public function testGetValueThrowExceptionIfInputDoesNotExists(): void
     {
         $inputFilter = $this->inputFilter;
@@ -128,19 +69,9 @@ final class BaseInputFilterTest extends TestCase
     {
         $inputFilter = $this->inputFilter;
 
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('"not exists" was not found in the filter');
+        $this->expectException(InputNotFoundException::class);
+        $this->expectExceptionMessage('"not exists"');
         $inputFilter->getRawValue('not exists');
-    }
-
-    public function testSetDataWithInvalidDataTypeThrowsInvalidArgumentException(): void
-    {
-        $inputFilter = $this->inputFilter;
-
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('expects an array or Traversable argument; received stdClass');
-        /** @psalm-suppress InvalidArgument */
-        $inputFilter->setData(new stdClass());
     }
 
     public function testIsValidThrowExceptionIfDataWasNotSetYet(): void
@@ -150,67 +81,6 @@ final class BaseInputFilterTest extends TestCase
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('no data present to validate');
         $inputFilter->isValid();
-    }
-
-    public function testSetValidationGroupSkipsRecursionWhenInputIsNotAnInputFilter(): void
-    {
-        $inputFilter = $this->inputFilter;
-
-        /** @var InputInterface&MockObject $nestedInput */
-        $nestedInput = $this->createMock(InputInterface::class);
-        $inputFilter->add($nestedInput, 'fooInput');
-
-        $inputFilter->setValidationGroup(['fooInput' => 'foo']);
-
-        $r = new ReflectionObject($inputFilter);
-        $p = $r->getProperty('validationGroup');
-        self::assertEquals(['fooInput'], $p->getValue($inputFilter));
-    }
-
-    public function testSetValidationGroupAllowsSpecifyingArrayOfInputsToNestedInputFilter(): void
-    {
-        $inputFilter = $this->inputFilter;
-
-        $nestedInputFilter = new BaseInputFilter($this->factory);
-
-        /** @var InputInterface&MockObject $nestedInput1 */
-        $nestedInput1 = $this->createMock(InputInterface::class);
-        $nestedInputFilter->add($nestedInput1, 'nested-input1');
-
-        /** @var InputInterface&MockObject $nestedInput2 */
-        $nestedInput2 = $this->createMock(InputInterface::class);
-        $nestedInputFilter->add($nestedInput2, 'nested-input2');
-
-        $inputFilter->add($nestedInputFilter, 'nested');
-
-        $inputFilter->setValidationGroup(['nested' => ['nested-input1', 'nested-input2']]);
-
-        $r = new ReflectionObject($inputFilter);
-        $p = $r->getProperty('validationGroup');
-        self::assertEquals(['nested'], $p->getValue($inputFilter));
-        self::assertEquals(['nested-input1', 'nested-input2'], $p->getValue($nestedInputFilter));
-    }
-
-    public function testSetValidationGroupThrowExceptionIfInputFilterNotExists(): void
-    {
-        $inputFilter = $this->inputFilter;
-
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage(
-            'expects a list of valid input names; "anotherNotExistsInputFilter" was not found'
-        );
-        $inputFilter->setValidationGroup(['notExistInputFilter' => 'anotherNotExistsInputFilter']);
-    }
-
-    public function testSetValidationGroupThrowExceptionIfInputFilterInArgumentListNotExists(): void
-    {
-        $inputFilter = $this->inputFilter;
-
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage(
-            'expects a list of valid input names; "notExistInputFilter" was not found'
-        );
-        $inputFilter->setValidationGroup('notExistInputFilter');
     }
 
     public function testHasUnknownThrowExceptionIfDataWasNotSetYet(): void
@@ -227,206 +97,6 @@ final class BaseInputFilterTest extends TestCase
 
         $this->expectException(RuntimeException::class);
         $inputFilter->getUnknown();
-    }
-
-    public function testAddHasFluentInterface(): void
-    {
-        $input = self::createInput('anything');
-        self::assertSame(
-            $this->inputFilter,
-            $this->inputFilter->add($input),
-        );
-    }
-
-    public function testRemoveHasFluentInterface(): void
-    {
-        $input = self::createInput('anything');
-        $this->inputFilter->add($input);
-
-        self::assertSame(
-            $this->inputFilter,
-            $this->inputFilter->remove('anything'),
-        );
-    }
-
-    /**
-     * @return array<string, array{
-     *     0: InputInterface|InputFilterInterface,
-     *     1: non-empty-string,
-     * }>
-     */
-    public static function addItemsDataProvider(): array
-    {
-        $input       = self::createInputInterfaceMock('anything', null);
-        $inputFilter = self::createInputFilterInterfaceMock();
-
-        return [
-            'Input with non-empty name'       => [
-                $input,
-                'example',
-            ],
-            'InputFilter with non-empty name' => [
-                $inputFilter,
-                'example',
-            ],
-        ];
-    }
-
-    /**
-     * Verify the state of the input filter is the desired after change it using the method `add()`
-     */
-    #[DataProvider('addItemsDataProvider')]
-    public function testAddHasGet(
-        InputInterface|InputFilterInterface $input,
-        string $name,
-    ): void {
-        self::assertFalse(
-            $this->inputFilter->has($name),
-            "InputFilter shouldn't have an input with the name $name yet"
-        );
-
-        $initialCount = count($this->inputFilter);
-
-        $this->inputFilter->add($input, $name);
-
-        self::assertTrue(
-            $this->inputFilter->has($name),
-            "There is no input with name $name",
-        );
-
-        self::assertCount(
-            $initialCount + 1,
-            $this->inputFilter,
-            'Number of inputs should have increased by 1',
-        );
-
-        self::assertSame(
-            $input,
-            $this->inputFilter->get($name),
-            'get() does not match the expected input',
-        );
-    }
-
-    /**
-     * Verify the state of the input filter is the desired after change it using the method `add()` and `remove()`
-     */
-    #[DataProvider('addItemsDataProvider')]
-    public function testAddRemove(
-        InputInterface|InputFilterInterface $input,
-        string $name,
-    ): void {
-        $this->inputFilter->add($input, $name);
-        $this->inputFilter->remove($name);
-
-        self::assertFalse(
-            $this->inputFilter->has($name),
-            "There is no input with name $name",
-        );
-
-        self::assertCount(
-            0,
-            $this->inputFilter,
-            'There should be zero inputs',
-        );
-    }
-
-    public function testAddingInputWithNameDoesNotInjectNameInInput(): void
-    {
-        $inputFilter = $this->inputFilter;
-
-        $foo = $this->createInput('foo');
-        $inputFilter->add($foo, 'bas');
-
-        $test = $inputFilter->get('bas');
-        self::assertSame($foo, $test, 'get() does not match the input added');
-        self::assertEquals('foo', $foo->getName(), 'Input name should not change');
-    }
-
-    /**
-     * @psalm-return array<string, array{
-     *     0: InputInterface|InputFilterInterface|InputSpecification|InputFilterSpecification,
-     *     1: class-string,
-     * }>
-     */
-    public static function inputProvider(): array
-    {
-        $input       = self::createInputInterfaceMock('fooInput', null);
-        $inputFilter = self::createInputFilterInterfaceMock();
-
-        return [
-            'InputInterface'       => [
-                $input,
-                $input::class,
-            ],
-            'InputFilterInterface' => [
-                $inputFilter,
-                $inputFilter::class,
-            ],
-            'Input Spec'           => [
-                [
-                    'name' => uniqid(),
-                ],
-                Input::class,
-            ],
-            'InputFilter Spec'     => [
-                [
-                    'type' => InputFilter::class,
-                    'foo'  => [
-                        'name' => 'foo',
-                    ],
-                    'bar'  => [
-                        'name' => 'bar',
-                    ],
-                ],
-                InputFilter::class,
-            ],
-        ];
-    }
-
-    /**
-     * @param InputInterface|InputFilterInterface|InputSpecification|InputFilterSpecification $input
-     * @param class-string $expectedType
-     */
-    #[DataProvider('inputProvider')]
-    public function testReplace(
-        InputInterface|InputFilterInterface|array $input,
-        string $expectedType,
-    ): void {
-        $nameToReplace  = 'replace_me';
-        $inputToReplace = $this->createInput($nameToReplace);
-
-        $this->inputFilter->add($inputToReplace);
-        $currentNumberOfFilters = count($this->inputFilter);
-
-        self::assertSame(
-            $this->inputFilter,
-            $this->inputFilter->replace($input, $nameToReplace),
-            'replace() must return it self',
-        );
-
-        self::assertCount($currentNumberOfFilters, $this->inputFilter, "Number of filters shouldn't change");
-
-        $object = $this->inputFilter->get($nameToReplace);
-
-        self::assertInstanceOf(
-            $expectedType,
-            $object,
-            sprintf(
-                'Expected "%s" but the instance was "%s"',
-                $expectedType,
-                $object::class,
-            ),
-        );
-
-        if (is_array($input)) {
-            return;
-        }
-
-        self::assertSame(
-            $input,
-            $object,
-            'get() does not match the expected input',
-        );
     }
 
     /**
@@ -447,7 +117,7 @@ final class BaseInputFilterTest extends TestCase
         bool $expectedIsValid,
         array $expectedInvalidInputs,
         array $expectedValidInputs,
-        array $expectedMessages
+        array $expectedMessages,
     ): void {
         $inputFilter = $this->inputFilter;
         foreach ($inputs as $inputName => $input) {
@@ -462,7 +132,7 @@ final class BaseInputFilterTest extends TestCase
             self::assertSame(
                 $expectedRawValue,
                 $inputFilter->getRawValue($inputName),
-                'getRawValue() value not match for input ' . $inputName
+                'getRawValue() value not match for input ' . $inputName,
             );
         }
 
@@ -471,7 +141,7 @@ final class BaseInputFilterTest extends TestCase
             self::assertSame(
                 $expectedValue,
                 $inputFilter->getValue($inputName),
-                'getValue() value not match for input ' . $inputName
+                'getValue() value not match for input ' . $inputName,
             );
         }
 
@@ -506,7 +176,7 @@ final class BaseInputFilterTest extends TestCase
         bool $expectedIsValid,
         array $expectedInvalidInputs,
         array $expectedValidInputs,
-        array $expectedMessages
+        array $expectedMessages,
     ): void {
         $dataTypes = $this->dataTypes();
         $this->testSetDataAndGetRawValueGetValue(
@@ -517,47 +187,8 @@ final class BaseInputFilterTest extends TestCase
             $expectedIsValid,
             $expectedInvalidInputs,
             $expectedValidInputs,
-            $expectedMessages
+            $expectedMessages,
         );
-    }
-
-    public function testResetEmptyValidationGroupRecursively(): void
-    {
-        $data         = [
-            'flat' => 'foo',
-            'deep' => [
-                'deep-input1' => 'deep-foo1',
-                'deep-input2' => 'deep-foo2',
-            ],
-        ];
-        $expectedData = array_merge($data, ['notSet' => null]);
-        $flatInput    = $this->createInput('flat');
-        // Inputs without value must be reset for to have clean states when use different setData arguments
-        $resetInput = $this->getMockBuilder(Input::class)
-            ->onlyMethods(['resetValue'])
-            ->setConstructorArgs([TestHelper::createFilterChain(), TestHelper::createValidatorChain(), 'notSet'])
-            ->getMock();
-        $resetInput->expects(self::once())
-            ->method('resetValue');
-
-        $filter = $this->inputFilter;
-        $filter->add($flatInput);
-        $filter->add($resetInput);
-        $deepInputFilter = new BaseInputFilter($this->factory);
-        $deepInputFilter->add(
-            $this->createInput(),
-            'deep-input1'
-        );
-        $deepInputFilter->add(
-            $this->createInput(),
-            'deep-input2'
-        );
-        $filter->add($deepInputFilter, 'deep');
-        $filter->setData($data);
-        $filter->setValidationGroup(['deep' => 'deep-input1']);
-        // reset validation group
-        $filter->setValidationGroup(InputFilterInterface::VALIDATE_ALL);
-        self::assertEquals($expectedData, $filter->getValues());
     }
 
     /*
@@ -568,8 +199,8 @@ final class BaseInputFilterTest extends TestCase
     /**
      * @psalm-return array<string, array{
      *     0: iterable<array-key, mixed>,
-     *     1: null|string,
-     *     2: array<string, string>|string
+     *     1: null|array<array-key, mixed>,
+     *     2: array<array-key, mixed>,
      * }>
      */
     public static function contextProvider(): array
@@ -582,19 +213,19 @@ final class BaseInputFilterTest extends TestCase
             // Description => [$data, $customContext, $expectedContext]
             'by default get context from data (array)'       => [$data, null, $expectedFromData],
             'by default get context from data (Traversable)' => [$traversableData, null, $expectedFromData],
-            'use custom context'                             => [[], 'fooContext', 'fooContext'],
+            'use custom context'                             => [[], ['fooContext'], ['fooContext']],
         ];
     }
 
     /**
      * @param iterable<array-key, mixed> $data
-     * @param string|array<string, string> $expectedContext
+     * @param array<array-key, mixed> $expectedContext
      */
     #[DataProvider('contextProvider')]
     public function testValidationContext(
         iterable $data,
-        ?string $customContext,
-        string|array $expectedContext,
+        array|null $customContext,
+        array $expectedContext,
     ): void {
         $filter = $this->inputFilter;
 
@@ -605,7 +236,7 @@ final class BaseInputFilterTest extends TestCase
 
         self::assertTrue(
             $filter->isValid($customContext),
-            'isValid() value not match. Detail: ' . json_encode($filter->getMessages(), JSON_THROW_ON_ERROR)
+            'isValid() value not match. Detail: ' . json_encode($filter->getMessages(), JSON_THROW_ON_ERROR),
         );
     }
 
@@ -622,7 +253,7 @@ final class BaseInputFilterTest extends TestCase
 
         self::assertTrue(
             $filter->isValid(),
-            'isValid() value not match. Detail: ' . json_encode($filter->getMessages(), JSON_THROW_ON_ERROR)
+            'isValid() value not match. Detail: ' . json_encode($filter->getMessages(), JSON_THROW_ON_ERROR),
         );
     }
 
@@ -646,7 +277,7 @@ final class BaseInputFilterTest extends TestCase
 
         self::assertTrue(
             $filter->isValid(),
-            'isValid() value not match. Detail: ' . json_encode($filter->getMessages(), JSON_THROW_ON_ERROR)
+            'isValid() value not match. Detail: ' . json_encode($filter->getMessages(), JSON_THROW_ON_ERROR),
         );
     }
 
@@ -669,17 +300,17 @@ final class BaseInputFilterTest extends TestCase
 
         self::assertTrue(
             $filter->isValid(),
-            'isValid() value not match. Detail . ' . json_encode($filter->getMessages(), JSON_THROW_ON_ERROR)
+            'isValid() value not match. Detail . ' . json_encode($filter->getMessages(), JSON_THROW_ON_ERROR),
         );
         self::assertArrayNotHasKey(
             $optionalInputName,
             $filter->getValidInput(),
-            'Missing optional fields must not appear as valid input neither invalid input'
+            'Missing optional fields must not appear as valid input neither invalid input',
         );
         self::assertArrayNotHasKey(
             $optionalInputName,
             $filter->getInvalidInput(),
-            'Missing optional fields must not appear as valid input neither invalid input'
+            'Missing optional fields must not appear as valid input neither invalid input',
         );
     }
 
@@ -697,85 +328,13 @@ final class BaseInputFilterTest extends TestCase
         self::assertEquals($hasUnknown, $inputFilter->hasUnknown(), 'hasUnknown() value not match');
     }
 
-    public function testGetInputs(): void
-    {
-        $filter = $this->inputFilter;
-
-        $foo = $this->createInput('foo');
-        $bar = $this->createInput('bar');
-
-        $filter->add($foo);
-        $filter->add($bar);
-
-        $filters = $filter->getInputs();
-
-        self::assertCount(2, $filters);
-        self::assertInstanceOf(Input::class, $filters['foo']);
-        self::assertInstanceOf(Input::class, $filters['bar']);
-        self::assertEquals('foo', $filters['foo']->getName());
-        self::assertEquals('bar', $filters['bar']->getName());
-    }
-
-    public function testAddingExistingInputWillMergeIntoExisting(): void
-    {
-        $filter = $this->inputFilter;
-
-        $foo1 = $this->createInput('foo');
-        $foo1->setRequired(true);
-        $filter->add($foo1);
-
-        $foo2 = $this->createInput('foo');
-        $foo2->setRequired(false);
-        $filter->add($foo2);
-
-        $input = $filter->get('foo');
-        assert($input instanceof Input);
-        self::assertFalse($input->isRequired());
-    }
-
-    public function testAddingAnInputFilterWithTheSameNameAsTheInputWillReplace(): void
-    {
-        $input  = $this->createInput('a');
-        $filter = new InputFilter($this->factory);
-
-        $this->inputFilter->add($input);
-
-        self::assertSame($input, $this->inputFilter->get('a'));
-
-        $this->inputFilter->add($filter, 'a');
-
-        self::assertSame($filter, $this->inputFilter->get('a'));
-    }
-
-    public function testMerge(): void
-    {
-        $inputFilter       = $this->inputFilter;
-        $originInputFilter = new BaseInputFilter($this->factory);
-
-        $inputFilter->add($this->createInput(), 'foo');
-        $inputFilter->add($this->createInput(), 'bar');
-
-        $originInputFilter->add($this->createInput(), 'baz');
-
-        $inputFilter->merge($originInputFilter);
-
-        self::assertEquals(
-            [
-                'foo',
-                'bar',
-                'baz',
-            ],
-            array_keys($inputFilter->getInputs())
-        );
-    }
-
     public function testNestedInputFilterShouldAllowNonArrayValueForData(): void
     {
         /** @psalm-var BaseInputFilter<array{nested: array{nestedField1: mixed}}> $filter1 */
         $filter1      = new BaseInputFilter($this->factory);
         $nestedFilter = new BaseInputFilter($this->factory);
         $nestedFilter->add(
-            $this->createInput('nestedField1')
+            $this->createInput('nestedField1'),
         );
         $filter1->add($nestedFilter, 'nested');
 
@@ -797,7 +356,7 @@ final class BaseInputFilterTest extends TestCase
         self::assertInstanceOf(
             UnfilteredDataInterface::class,
             $baseInputFilter,
-            sprintf('%s should implement %s', BaseInputFilter::class, UnfilteredDataInterface::class)
+            sprintf('%s should implement %s', BaseInputFilter::class, UnfilteredDataInterface::class),
         );
     }
 
@@ -849,7 +408,7 @@ final class BaseInputFilterTest extends TestCase
             $filteredArray,
             [
                 'foo' => 'bar',
-            ]
+            ],
         );
 
         /** @var BaseInputFilter $baseInputFilter */
@@ -909,7 +468,7 @@ final class BaseInputFilterTest extends TestCase
                 $vRaw,
                 $vFiltered,
                 $msg,
-                $bOnFail
+                $bOnFail,
             );
 
         $inputFilter = fn(bool $isValid, array $msg = []): callable =>
@@ -982,7 +541,7 @@ final class BaseInputFilterTest extends TestCase
                         $set[6][$name] = $input;
                     }
                 }
-            }
+            },
         );
 
         return $dataSets;
@@ -1025,14 +584,14 @@ final class BaseInputFilterTest extends TestCase
         bool|null $isValid = null,
         array $getRawValues = [],
         array $getValues = [],
-        array $getMessages = []
+        array $getMessages = [],
     ): InputFilterInterfaceStub {
         return new InputFilterInterfaceStub(
             TestHelper::createInputFilterFactory(),
             $isValid,
             $getRawValues,
             $getValues,
-            $getMessages
+            $getMessages,
         );
     }
 
@@ -1045,7 +604,7 @@ final class BaseInputFilterTest extends TestCase
         mixed $getRawValue = null,
         mixed $getValue = null,
         array $getMessages = [],
-        bool $breakOnFailure = false
+        bool $breakOnFailure = false,
     ): InputInterfaceStub {
         return new InputInterfaceStub(
             $name,

--- a/test/BaseInputFilterTest.php
+++ b/test/BaseInputFilterTest.php
@@ -591,8 +591,11 @@ final class BaseInputFilterTest extends TestCase
      * @param string|array<string, string> $expectedContext
      */
     #[DataProvider('contextProvider')]
-    public function testValidationContext($data, ?string $customContext, $expectedContext): void
-    {
+    public function testValidationContext(
+        iterable $data,
+        ?string $customContext,
+        string|array $expectedContext,
+    ): void {
         $filter = $this->inputFilter;
 
         $input = self::createInputInterfaceMock('fooInput', true, true, $expectedContext);

--- a/test/CollectionInputFilterTest.php
+++ b/test/CollectionInputFilterTest.php
@@ -24,7 +24,6 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use stdClass;
 use Traversable;
 
 use function count;
@@ -54,18 +53,6 @@ final class CollectionInputFilterTest extends TestCase
     protected function tearDown(): void
     {
         AbstractValidator::setDefaultTranslator();
-    }
-
-    public function testSetInputFilterWithInvalidTypeThrowsInvalidArgumentException(): void
-    {
-        $inputFilter = $this->inputFilter;
-
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage(
-            'expects an instance of Laminas\InputFilter\BaseInputFilter; received "stdClass"'
-        );
-        /** @psalm-suppress InvalidArgument */
-        $inputFilter->setInputFilter(new stdClass());
     }
 
     /**
@@ -499,44 +486,6 @@ final class CollectionInputFilterTest extends TestCase
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('invalid item in collection');
-        $collectionInputFilter->setData($data);
-    }
-
-    #[DataProvider('invalidCollections')]
-    public function testSettingDataAsTraversableWithInvalidCollectionsRaisesException(array $data): void
-    {
-        $collectionInputFilter = $this->inputFilter;
-        $data                  = new ArrayIterator($data);
-
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('invalid item in collection');
-        $collectionInputFilter->setData($data);
-    }
-
-    /** @psalm-return array<string, array{0: mixed}> */
-    public static function invalidDataType(): array
-    {
-        return [
-            'null'       => [null],
-            'false'      => [false],
-            'true'       => [true],
-            'zero'       => [0],
-            'int'        => [1],
-            'zero-float' => [0.0],
-            'float'      => [1.1],
-            'string'     => ['this is not'],
-            'object'     => [(object) ['this' => 'is invalid']],
-        ];
-    }
-
-    #[DataProvider('invalidDataType')]
-    public function testSettingDataWithNonArrayNonTraversableRaisesException(mixed $data): void
-    {
-        $collectionInputFilter = $this->inputFilter;
-
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('invalid collection');
-        /** @psalm-suppress MixedArgument */
         $collectionInputFilter->setData($data);
     }
 

--- a/test/CollectionInputFilterTest.php
+++ b/test/CollectionInputFilterTest.php
@@ -643,7 +643,6 @@ final class CollectionInputFilterTest extends TestCase
     {
         $factory = TestHelper::createInputFilterFactory();
 
-        /** @psalm-suppress InvalidArgument */
         $inputFilter = $factory->createInputFilter(
             [
                 'element' => [

--- a/test/FactoryTest.php
+++ b/test/FactoryTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace LaminasTest\InputFilter;
 
 use Laminas\Filter;
+use Laminas\Filter\FilterChain;
+use Laminas\Filter\FilterChainInterface;
 use Laminas\Filter\FilterPluginManager;
 use Laminas\InputFilter\CollectionInputFilter;
 use Laminas\InputFilter\Exception\InvalidArgumentException;
@@ -193,6 +195,7 @@ final class FactoryTest extends TestCase
         ]);
 
         $inputFilterChain = $input->getFilterChain();
+        self::assertInstanceOf(FilterChain::class, $inputFilterChain);
         self::assertSame(
             $plugins,
             TestHelper::getFilterPluginManagerFromFilterChain($inputFilterChain),
@@ -209,6 +212,7 @@ final class FactoryTest extends TestCase
         ]);
 
         $inputValidatorChain = $input->getValidatorChain();
+        self::assertInstanceOf(ValidatorChain::class, $inputValidatorChain);
         self::assertSame(
             $plugins,
             $inputValidatorChain->getPluginManager(),
@@ -232,8 +236,10 @@ final class FactoryTest extends TestCase
         self::assertCount(1, $inputFilter);
         $input = $inputFilter->get('foo');
         self::assertInstanceOf(InputInterface::class, $input);
-        $inputFilterChain    = $input->getFilterChain();
+        $inputFilterChain = $input->getFilterChain();
+        self::assertInstanceOf(FilterChain::class, $inputFilterChain);
         $inputValidatorChain = $input->getValidatorChain();
+        self::assertInstanceOf(ValidatorChain::class, $inputValidatorChain);
         self::assertSame(
             $filterPlugins,
             (new ReflectionObject($inputFilterChain))->getProperty('plugins')->getValue($inputFilterChain)
@@ -260,7 +266,9 @@ final class FactoryTest extends TestCase
         ]);
         self::assertInstanceOf(InputInterface::class, $input);
         self::assertEquals('foo', $input->getName());
-        self::assertCount(2, $input->getFilterChain());
+        $filterChain = $input->getFilterChain();
+        self::assertInstanceOf(FilterChain::class, $filterChain);
+        self::assertCount(2, $filterChain);
 
         $input->setValue('   Encodable with ISO-8859-1  ');
 
@@ -312,7 +320,8 @@ final class FactoryTest extends TestCase
         self::assertInstanceOf(InputInterface::class, $input);
         self::assertEquals('foo', $input->getName());
         $chain = $input->getValidatorChain();
-        self::assertCount(3, $chain->getValidators());
+        self::assertInstanceOf(ValidatorChain::class, $chain);
+        self::assertCount(3, $chain);
 
         $input->setValue($value);
 
@@ -492,12 +501,16 @@ final class FactoryTest extends TestCase
                 case 'foo':
                     self::assertInstanceOf(Input::class, $input);
                     self::assertFalse($input->isRequired());
-                    self::assertCount(2, $input->getValidatorChain());
+                    $validatorChain = $input->getValidatorChain();
+                    self::assertInstanceOf(ValidatorChain::class, $validatorChain);
+                    self::assertCount(2, $validatorChain);
                     break;
                 case 'bar':
                     self::assertInstanceOf(Input::class, $input);
                     self::assertTrue($input->allowEmpty());
-                    self::assertCount(2, $input->getFilterChain());
+                    $filterChain = $input->getFilterChain();
+                    self::assertInstanceOf(FilterChain::class, $filterChain);
+                    self::assertCount(2, $filterChain);
                     break;
                 case 'baz':
                     self::assertInstanceOf(InputFilter::class, $input);
@@ -505,11 +518,15 @@ final class FactoryTest extends TestCase
                     $foo = $input->get('foo');
                     self::assertInstanceOf(Input::class, $foo);
                     self::assertFalse($foo->isRequired());
-                    self::assertCount(2, $foo->getValidatorChain());
+                    $validatorChain = $foo->getValidatorChain();
+                    self::assertInstanceOf(ValidatorChain::class, $validatorChain);
+                    self::assertCount(2, $validatorChain);
                     $bar = $input->get('bar');
                     self::assertInstanceOf(Input::class, $bar);
                     self::assertTrue($bar->allowEmpty());
-                    self::assertCount(2, $bar->getFilterChain());
+                    $filterChain = $bar->getFilterChain();
+                    self::assertInstanceOf(FilterChain::class, $filterChain);
+                    self::assertCount(2, $filterChain);
                     break;
                 case 'bat':
                     self::assertInstanceOf(CustomInput::class, $input);
@@ -599,11 +616,11 @@ final class FactoryTest extends TestCase
             'filters' => [
                 [
                     'name'     => 'StringTrim',
-                    'priority' => Filter\FilterChain::DEFAULT_PRIORITY - 1, // 999
+                    'priority' => FilterChainInterface::DEFAULT_PRIORITY - 1, // 999
                 ],
                 [
                     'name'     => 'StringToUpper',
-                    'priority' => Filter\FilterChain::DEFAULT_PRIORITY + 1, //1001
+                    'priority' => FilterChainInterface::DEFAULT_PRIORITY + 1, //1001
                 ],
                 [
                     'name' => 'StringToLower', // default priority 1000
@@ -613,12 +630,14 @@ final class FactoryTest extends TestCase
         self::assertInstanceOf(InputInterface::class, $input);
 
         // We should have 3 filters
-        self::assertEquals(3, $input->getFilterChain()->count());
+        $filterChain = $input->getFilterChain();
+        self::assertInstanceOf(FilterChain::class, $filterChain);
+        self::assertCount(3, $filterChain);
 
         // Filters should pop in the following order:
         // string_to_upper (1001), string_to_lower (1000), string_trim (999)
         $index = 0;
-        foreach ($input->getFilterChain()->getIterator() as $filter) {
+        foreach ($filterChain as $filter) {
             switch ($index) {
                 case 0:
                     self::assertInstanceOf(Filter\StringToUpper::class, $filter);
@@ -685,7 +704,9 @@ final class FactoryTest extends TestCase
         self::assertInstanceOf(InputInterface::class, $input);
 
         // We should have 3 validators
-        self::assertEquals(3, $input->getValidatorChain()->count());
+        $validatorChain = $input->getValidatorChain();
+        self::assertInstanceOf(ValidatorChain::class, $validatorChain);
+        self::assertCount(3, $validatorChain);
 
         $input->setValue(['foo' => false]);
         self::assertTrue($input->isValid());
@@ -916,7 +937,7 @@ final class FactoryTest extends TestCase
         $inputFilterPluginManager = $container->get(InputFilterPluginManager::class);
         $factory                  = $container->get(Factory::class);
 
-        $filterChain    = new Filter\FilterChain($filterPluginManager);
+        $filterChain    = new FilterChain($filterPluginManager);
         $validatorChain = new ValidatorChain();
         $validatorChain->setPluginManager($validatorPlugins);
 

--- a/test/FactoryTest.php
+++ b/test/FactoryTest.php
@@ -399,8 +399,10 @@ final class FactoryTest extends TestCase
         $inputFilterPluginManager = $serviceManager->get(InputFilterPluginManager::class);
         $inputFilterPluginManager->configure([
             'factories' => [
-                CustomInput::class
-                    => fn () => new CustomInput(TestHelper::createFilterChain(), TestHelper::createValidatorChain()),
+                CustomInput::class => static fn (): CustomInput => new CustomInput(
+                    TestHelper::createFilterChain(),
+                    TestHelper::createValidatorChain(),
+                ),
             ],
         ]);
 
@@ -659,7 +661,7 @@ final class FactoryTest extends TestCase
                     'name'     => 'Callback',
                     'priority' => ValidatorChainInterface::DEFAULT_PRIORITY + 1, // 2
                     'options'  => [
-                        'callback' => static function () use (&$order) {
+                        'callback' => static function () use (&$order): true {
                             self::assertSame(0, $order);
                             ++$order;
 

--- a/test/FactoryTest.php
+++ b/test/FactoryTest.php
@@ -174,16 +174,6 @@ final class FactoryTest extends TestCase
         ]);
     }
 
-    public function testCreateInputFilterWithInvalidDataTypeThrowsInvalidArgumentException(): void
-    {
-        $factory = $this->createDefaultFactory();
-
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('expects an array or Traversable; received "string"');
-        /** @psalm-suppress InvalidArgument */
-        $factory->createInputFilter('invalid_value');
-    }
-
     public function testFactoryCreatesFilterChainWithComposedPluginManagerWhenCreatingNewInputObjects(): void
     {
         $container = TestHelper::getContainer();
@@ -417,7 +407,6 @@ final class FactoryTest extends TestCase
 
         $factory = $serviceManager->get(Factory::class);
 
-        /** @psalm-suppress InvalidArgument This appears valid but the Psalm diff makes my eyes bleed */
         $inputFilter = $factory->createInputFilter([
             'foo'  => [
                 'name'       => 'foo',
@@ -753,11 +742,6 @@ final class FactoryTest extends TestCase
     {
         $factory = $this->createDefaultFactory();
 
-        /**
-         * null is not acceptable as an input spec for the psalm type
-         *
-         * @psalm-suppress InvalidArgument
-         */
         $inputFilter = $factory->createInputFilter([
             'foo' => [
                 'name' => 'foo',

--- a/test/FileInput/FileInputTest.php
+++ b/test/FileInput/FileInputTest.php
@@ -146,6 +146,7 @@ final class FileInputTest extends TestCase
             'error'    => 0,
         ]);
         $validatorChain = $this->input->getValidatorChain();
+        self::assertInstanceOf(ValidatorChain::class, $validatorChain);
         self::assertCount(0, $validatorChain->getValidators());
 
         self::assertFalse($this->input->isValid());
@@ -160,6 +161,7 @@ final class FileInputTest extends TestCase
         self::assertTrue($this->input->isRequired());
         $this->input->setValue(['tmp_name' => 'bar']);
         $validatorChain = $this->input->getValidatorChain();
+        self::assertInstanceOf(ValidatorChain::class, $validatorChain);
         self::assertCount(0, $validatorChain->getValidators());
 
         self::assertTrue(
@@ -181,6 +183,7 @@ final class FileInputTest extends TestCase
         $uploadValidator = new UploadValidator();
 
         $validatorChain = $this->input->getValidatorChain();
+        self::assertInstanceOf(ValidatorChain::class, $validatorChain);
         $validatorChain->prependValidator($uploadValidator);
         self::assertFalse(
             $this->input->isValid(),
@@ -237,7 +240,8 @@ final class FileInputTest extends TestCase
     {
         $input          = $this->createFileInput('foo');
         $validatorChain = $input->getValidatorChain();
-        $pluginManager  = $validatorChain->getPluginManager();
+        self::assertInstanceOf(ValidatorChain::class, $validatorChain);
+        $pluginManager = $validatorChain->getPluginManager();
         $pluginManager->setInvokableClass(UploadValidator::class, TestAsset\FileUploadMock::class);
         $input->setValue([]);
 
@@ -476,9 +480,9 @@ final class FileInputTest extends TestCase
         $input->setContinueIfEmpty(true);
         $input->setValue($raw);
         $input->isValid();
-        $validators = $input->getValidatorChain()
-            ->getValidators();
-        self::assertEmpty($validators);
+        $validators = $input->getValidatorChain();
+        self::assertInstanceOf(ValidatorChain::class, $validators);
+        self::assertCount(0, $validators);
     }
 
     public function testDefaultGetValue(): void
@@ -510,6 +514,7 @@ final class FileInputTest extends TestCase
     {
         $filterChain    = TestHelper::createFilterChainFixture($raw, $filtered);
         $validatorChain = $this->input->getValidatorChain();
+        self::assertInstanceOf(ValidatorChain::class, $validatorChain);
 
         $this->input->setRequired(true);
         $this->input->setFilterChain($filterChain);
@@ -519,8 +524,7 @@ final class FileInputTest extends TestCase
 
         self::assertTrue($this->input->isValid());
 
-        $validators = $validatorChain->getValidators();
-        self::assertEquals(1, count($validators));
+        self::assertCount(1, $validatorChain);
     }
 
     #[DataProvider('isRequiredVsAllowEmptyVsContinueIfEmptyVsIsValidProvider')]
@@ -653,16 +657,19 @@ final class FileInputTest extends TestCase
         $a = $this->createFileInput('a');
         $b = $this->createFileInput('b');
 
-        $a->getFilterChain()->attach($filter1);
+        $filterChain = $a->getFilterChain();
+        self::assertInstanceOf(FilterChain::class, $filterChain);
+
+        $filterChain->attach($filter1);
         $b->getFilterChain()->attach($filter2);
 
-        self::assertNotContains($filter2, $a->getFilterChain());
-        self::assertCount(1, $a->getFilterChain());
+        self::assertNotContains($filter2, $filterChain);
+        self::assertCount(1, $filterChain);
 
         $a->merge($b);
 
-        self::assertContains($filter2, $a->getFilterChain());
-        self::assertCount(2, $a->getFilterChain());
+        self::assertContains($filter2, $filterChain);
+        self::assertCount(2, $filterChain);
     }
 
     public function testThatMergingTwoInputsMergesTheValidatorChain(): void
@@ -673,17 +680,20 @@ final class FileInputTest extends TestCase
         $a = $this->createFileInput('a');
         $b = $this->createFileInput('b');
 
-        $a->getValidatorChain()->attach($validator1);
+        $validatorChain = $a->getValidatorChain();
+        self::assertInstanceOf(ValidatorChain::class, $validatorChain);
+
+        $validatorChain->attach($validator1);
         $b->getValidatorChain()->attach($validator2);
 
-        self::assertCount(1, $a->getValidatorChain());
-        self::assertValidatorChainNotContains($validator2, $a->getValidatorChain());
+        self::assertCount(1, $validatorChain);
+        self::assertValidatorChainNotContains($validator2, $validatorChain);
 
         $a->merge($b);
 
-        $chain = iterator_to_array($a->getValidatorChain()->getIterator());
+        $chain = iterator_to_array($validatorChain->getIterator());
         self::assertCount(2, $chain);
-        self::assertValidatorChainContains($validator2, $a->getValidatorChain());
+        self::assertValidatorChainContains($validator2, $validatorChain);
     }
 
     private static function validatorChainContains(ValidatorInterface $validator, ValidatorChain $chain): bool
@@ -838,6 +848,7 @@ final class FileInputTest extends TestCase
         $input->setValue($uploadedFile);
 
         $validatorChain = $input->getValidatorChain();
+        self::assertInstanceOf(ValidatorChain::class, $validatorChain);
         self::assertCount(0, $validatorChain->getValidators());
 
         self::assertFalse($input->isValid());
@@ -855,13 +866,17 @@ final class FileInputTest extends TestCase
 
         $this->input->setValue($uploadedFile);
         $validatorChain = $this->input->getValidatorChain();
-        self::assertCount(0, $validatorChain->getValidators());
+        self::assertInstanceOf(ValidatorChain::class, $validatorChain);
+        self::assertCount(0, $validatorChain);
 
         self::assertTrue(
             $this->input->isValid(),
             'isValid() value not match. Detail . ' . json_encode($this->input->getMessages(), JSON_THROW_ON_ERROR)
         );
-        self::assertCount(0, $validatorChain->getValidators());
+
+        $validatorChain = $this->input->getValidatorChain();
+        self::assertInstanceOf(ValidatorChain::class, $validatorChain);
+        self::assertCount(0, $validatorChain);
     }
 
     /**

--- a/test/InputFilterAbstractServiceFactoryTest.php
+++ b/test/InputFilterAbstractServiceFactoryTest.php
@@ -265,14 +265,6 @@ final class InputFilterAbstractServiceFactoryTest extends TestCase
             ],
         ]);
 
-        $this->filterPluginManager->configure(['services' => ['CustomFilter' => $filter]]);
-
-        $services->get(InputFilterPluginManager::class)->configure([
-            'abstract_factories' => [
-                InputFilterAbstractServiceFactory::class,
-            ],
-        ]);
-
         $inputFilter = $services->get(InputFilterPluginManager::class)->get('test');
         self::assertInstanceOf(InputFilterInterface::class, $inputFilter);
 

--- a/test/InputFilterAbstractServiceFactoryTest.php
+++ b/test/InputFilterAbstractServiceFactoryTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace LaminasTest\InputFilter;
 
+use Laminas\Filter\FilterChain;
 use Laminas\Filter\FilterInterface;
 use Laminas\Filter\FilterPluginManager;
 use Laminas\InputFilter\Factory;
@@ -141,7 +142,9 @@ final class InputFilterAbstractServiceFactoryTest extends TestCase
         $input = $inputFilter->get('input');
         self::assertInstanceOf(InputInterface::class, $input);
 
-        $filterChain = iterator_to_array($input->getFilterChain(), false);
+        $filterChain = $input->getFilterChain();
+        self::assertInstanceOf(FilterChain::class, $filterChain);
+        $filterChain = iterator_to_array($filterChain, false);
         self::assertCount(1, $filterChain);
         self::assertSame($filter, $filterChain[0]);
 
@@ -277,8 +280,6 @@ final class InputFilterAbstractServiceFactoryTest extends TestCase
         self::assertInstanceOf(InputInterface::class, $input);
 
         $filters = $input->getFilterChain();
-        self::assertCount(1, $filters);
-
         self::assertSame('oof', $filters->filter('foo'));
     }
 }

--- a/test/InputFilterInputMutationsTest.php
+++ b/test/InputFilterInputMutationsTest.php
@@ -22,6 +22,7 @@ use PHPUnit\Framework\TestCase;
  * - has()
  * - get()
  * - getInputs()
+ * - count()
  */
 final class InputFilterInputMutationsTest extends TestCase
 {
@@ -289,6 +290,16 @@ final class InputFilterInputMutationsTest extends TestCase
 
         self::assertCount(1, $inputFilter, 'There should only be 1 input still');
         self::assertCount(1, $filterChain1, 'The Filter chain for the existing input should have been mutated');
+    }
+
+    public function testExplicitCallToCountMethod(): void
+    {
+        $inputFilter = $this->createEmptyInputFilter();
+        self::assertSame(0, $inputFilter->count());
+
+        $inputFilter->add($this->factory->createInput(['name' => 'fred']));
+
+        self::assertSame(1, $inputFilter->count());
     }
 
     public function testAddingAnInputFilterWithTheSameNameAsTheInputWillReplace(): void

--- a/test/InputFilterInputMutationsTest.php
+++ b/test/InputFilterInputMutationsTest.php
@@ -179,8 +179,8 @@ final class InputFilterInputMutationsTest extends TestCase
     public function testReplaceHasFluentInterface(): void
     {
         $inputFilter = $this->createEmptyInputFilter();
-        $input1       = $this->factory->createInput(['name' => 'goat']);
-        $input2       = $this->factory->createInput(['name' => 'goat']);
+        $input1      = $this->factory->createInput(['name' => 'goat']);
+        $input2      = $this->factory->createInput(['name' => 'goat']);
 
         $inputFilter->add($input1);
 

--- a/test/InputFilterInputMutationsTest.php
+++ b/test/InputFilterInputMutationsTest.php
@@ -1,0 +1,352 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\InputFilter;
+
+use Laminas\Filter\FilterChain;
+use Laminas\Filter\StringTrim;
+use Laminas\InputFilter\Exception\InputNotFoundException;
+use Laminas\InputFilter\Exception\InvalidArgumentException;
+use Laminas\InputFilter\Factory;
+use Laminas\InputFilter\Input;
+use Laminas\InputFilter\InputFilter;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * This test case covers the base input filter operations for:
+ * - add()
+ * - remove()
+ * - merge()
+ * - replace()
+ * - has()
+ * - get()
+ * - getInputs()
+ */
+final class InputFilterInputMutationsTest extends TestCase
+{
+    private Factory $factory;
+
+    protected function setUp(): void
+    {
+        $this->factory = TestHelper::createInputFilterFactory();
+    }
+
+    private function createEmptyInputFilter(): InputFilter
+    {
+        return new InputFilter($this->factory);
+    }
+
+    public function testInputFilterIsEmptyByDefault(): void
+    {
+        $inputFilter = $this->createEmptyInputFilter();
+        self::assertCount(0, $inputFilter);
+    }
+
+    public function testGetIsExceptionalWhenTheInputDoesNotExist(): void
+    {
+        $inputFilter = $this->createEmptyInputFilter();
+        $this->expectException(InputNotFoundException::class);
+        $inputFilter->get('not-there');
+    }
+
+    public function testAddedInputInstancesAreAccessible(): void
+    {
+        $inputFilter = $this->createEmptyInputFilter();
+        $input       = $this->factory->createInput(['name' => 'fred']);
+
+        $inputFilter->add($input);
+
+        self::assertTrue($inputFilter->has('fred'));
+        self::assertSame($input, $inputFilter->get('fred'));
+    }
+
+    public function testAddingInstanceWithDefinedNameOverridesInputName(): void
+    {
+        $inputFilter = $this->createEmptyInputFilter();
+        $input       = $this->factory->createInput(['name' => 'fred']);
+
+        $inputFilter->add($input, 'piglet');
+
+        self::assertFalse($inputFilter->has('fred'));
+        self::assertTrue($inputFilter->has('piglet'));
+        self::assertSame($input, $inputFilter->get('piglet'));
+    }
+
+    public function testAddingViaSpec(): void
+    {
+        $inputFilter = $this->createEmptyInputFilter();
+        $inputFilter->add(['name' => 'fred']);
+
+        self::assertTrue($inputFilter->has('fred'));
+        self::assertInstanceOf(Input::class, $inputFilter->get('fred'));
+    }
+
+    public function testAddingViaSpecWithDefinedNameOverridesName(): void
+    {
+        $inputFilter = $this->createEmptyInputFilter();
+        $inputFilter->add(['name' => 'fred'], 'doughnut');
+
+        self::assertFalse($inputFilter->has('fred'));
+        self::assertTrue($inputFilter->has('doughnut'));
+        $input = $inputFilter->get('doughnut');
+        self::assertInstanceOf(Input::class, $input);
+    }
+
+    public function testAddingWithDefinedNameDoesNotChangeTheInputName(): void
+    {
+        $inputFilter = $this->createEmptyInputFilter();
+        $inputFilter->add(['name' => 'fred'], 'doughnut');
+
+        $input = $inputFilter->get('doughnut');
+        self::assertInstanceOf(Input::class, $input);
+
+        self::assertSame('fred', $input->getName());
+    }
+
+    public function testInputsCanBeRemoved(): void
+    {
+        $inputFilter = $this->createEmptyInputFilter();
+        $input       = $this->factory->createInput(['name' => 'fred']);
+        $inputFilter->add($input);
+        $inputFilter->remove('fred');
+        self::assertFalse($inputFilter->has('fred'));
+    }
+
+    public function testInputsCanBeReplaced(): void
+    {
+        $inputFilter = $this->createEmptyInputFilter();
+        $input1      = $this->factory->createInput(['name' => 'fred']);
+        $input2      = $this->factory->createInput(['name' => 'fred']);
+
+        $inputFilter->add($input1);
+        $inputFilter->replace($input2, 'fred');
+
+        self::assertTrue($inputFilter->has('fred'));
+        self::assertSame($input2, $inputFilter->get('fred'));
+    }
+
+    public function testReplacementInputDoesNotAssumeReplacedName(): void
+    {
+        $inputFilter = $this->createEmptyInputFilter();
+        $input1      = $this->factory->createInput(['name' => 'goat']);
+        $input2      = $this->factory->createInput(['name' => 'donkey']);
+
+        $inputFilter->add($input1);
+        $inputFilter->replace($input2, 'goat');
+
+        self::assertTrue($inputFilter->has('goat'));
+        self::assertSame($input2, $inputFilter->get('goat'));
+        self::assertSame('donkey', $input2->getName());
+    }
+
+    public function testAddHasFluentInterface(): void
+    {
+        $inputFilter = $this->createEmptyInputFilter();
+        self::assertSame(
+            $inputFilter,
+            $inputFilter->add(['name' => 'ding-dong']),
+        );
+    }
+
+    public function testRemoveHasFluentInterface(): void
+    {
+        $inputFilter = $this->createEmptyInputFilter();
+        $inputFilter->add(['name' => 'ding-dong']);
+        self::assertSame(
+            $inputFilter,
+            $inputFilter->remove('ding-dong'),
+        );
+    }
+
+    public function testYouCanRemoveInputsThatDontExist(): void
+    {
+        $inputFilter = $this->createEmptyInputFilter();
+        self::assertFalse($inputFilter->has('ding-dong'));
+
+        $inputFilter->remove('ding-dong');
+    }
+
+    public function testYouCantReplaceInputsThatDontExist(): void
+    {
+        $inputFilter = $this->createEmptyInputFilter();
+
+        $this->expectException(InputNotFoundException::class);
+
+        $inputFilter->replace(['name' => 'fred'], 'fred');
+    }
+
+    public function testReplaceHasFluentInterface(): void
+    {
+        $inputFilter = $this->createEmptyInputFilter();
+        $input1       = $this->factory->createInput(['name' => 'goat']);
+        $input2       = $this->factory->createInput(['name' => 'goat']);
+
+        $inputFilter->add($input1);
+
+        self::assertSame(
+            $inputFilter,
+            $inputFilter->replace($input2, 'goat'),
+        );
+    }
+
+    public function testAddInputFilter(): void
+    {
+        $inputFilter = $this->createEmptyInputFilter();
+        $nested      = $this->createEmptyInputFilter();
+
+        $inputFilter->add($nested, 'foo');
+
+        self::assertSame($nested, $inputFilter->get('foo'));
+    }
+
+    public function testReplaceInputWithInputFilter(): void
+    {
+        $inputFilter = $this->createEmptyInputFilter();
+        $input       = $this->factory->createInput(['name' => 'goat']);
+        $inputFilter->add($input);
+
+        $nested = $this->createEmptyInputFilter();
+
+        $inputFilter->replace($nested, 'goat');
+
+        self::assertSame($nested, $inputFilter->get('goat'));
+    }
+
+    public function testCountIncreasesOnlyWithTopLevelAdditions(): void
+    {
+        $inputFilter = $this->createEmptyInputFilter();
+
+        self::assertCount(0, $inputFilter);
+
+        $inputFilter->add($this->factory->createInput(['name' => 'goat']));
+
+        self::assertCount(1, $inputFilter);
+
+        $nestedInputFilter = $this->createEmptyInputFilter();
+        $inputFilter->add($nestedInputFilter, 'donkey');
+
+        self::assertCount(2, $inputFilter);
+
+        $nestedInputFilter->add($this->factory->createInput(['name' => 'horse']));
+
+        self::assertCount(2, $inputFilter);
+
+        $inputFilter->remove('donkey');
+
+        self::assertCount(1, $inputFilter);
+
+        $inputFilter->remove('goat');
+
+        self::assertCount(0, $inputFilter);
+    }
+
+    public function testYouCantAddANestedInputFilterWithoutSpecifyingAName(): void
+    {
+        $inputFilter       = $this->createEmptyInputFilter();
+        $nestedInputFilter = $this->createEmptyInputFilter();
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Input or InputFilter name must be a non-empty string or an int, null given');
+
+        $inputFilter->add($nestedInputFilter);
+    }
+
+    public function testYouCantAddAnInputWithoutSpecifyingAName(): void
+    {
+        $inputFilter = $this->createEmptyInputFilter();
+        $input       = $this->factory->createInput([]);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Input or InputFilter name must be a non-empty string or an int, null given');
+
+        $inputFilter->add($input);
+    }
+
+    public function testAddingAnInputWithAnExistingNameWillCauseTheInputsToBeMerged(): void
+    {
+        $inputFilter = $this->createEmptyInputFilter();
+        $input1      = $this->factory->createInput(['name' => 'fred']);
+        $input2      = $this->factory->createInput([
+            'name'    => 'fred',
+            'filters' => [
+                ['name' => StringTrim::class],
+            ],
+        ]);
+
+        $filterChain1 = $input1->getFilterChain();
+        self::assertInstanceOf(FilterChain::class, $filterChain1);
+        self::assertCount(0, $filterChain1);
+
+        $filterChain2 = $input2->getFilterChain();
+        self::assertInstanceOf(FilterChain::class, $filterChain2);
+        self::assertCount(1, $filterChain2);
+
+        $inputFilter->add($input1);
+        $inputFilter->add($input2);
+
+        self::assertSame($input1, $inputFilter->get('fred'));
+
+        self::assertCount(1, $inputFilter, 'There should only be 1 input still');
+        self::assertCount(1, $filterChain1, 'The Filter chain for the existing input should have been mutated');
+    }
+
+    public function testAddingAnInputFilterWithTheSameNameAsTheInputWillReplace(): void
+    {
+        $inputFilter = $this->createEmptyInputFilter();
+        $input       = $this->factory->createInput(['name' => 'fred']);
+        $inputFilter->add($input);
+
+        $replacement = $this->createEmptyInputFilter();
+
+        $inputFilter->add($replacement, 'fred');
+
+        self::assertSame($replacement, $inputFilter->get('fred'));
+    }
+
+    public function testGetInputs(): void
+    {
+        $inputFilter = $this->createEmptyInputFilter();
+        $input1      = $this->factory->createInput(['name' => 'foo']);
+        $input2      = $this->factory->createInput(['name' => 'bar']);
+
+        $inputFilter->add($input1);
+        $inputFilter->add($input2);
+
+        self::assertSame([
+            'foo' => $input1,
+            'bar' => $input2,
+        ], $inputFilter->getInputs());
+    }
+
+    public function testMerge(): void
+    {
+        $original    = $this->createEmptyInputFilter();
+        $replacement = $this->createEmptyInputFilter();
+
+        $input1 = $this->factory->createInput(['name' => 'foo']);
+        $input2 = $this->factory->createInput(['name' => 'bar']);
+        $input3 = $this->factory->createInput(['name' => 'baz']);
+        $input4 = $this->factory->createInput(['name' => 'bat']);
+
+        $original->add($input1);
+        $original->add($input2);
+
+        $replacement->add($input3);
+        $replacement->add($input4);
+
+        $original->merge($replacement);
+
+        self::assertSame([
+            'foo' => $input1,
+            'bar' => $input2,
+            'baz' => $input3,
+            'bat' => $input4,
+        ], $original->getInputs());
+
+        self::assertSame([
+            'baz' => $input3,
+            'bat' => $input4,
+        ], $replacement->getInputs());
+    }
+}

--- a/test/InputTest.php
+++ b/test/InputTest.php
@@ -169,18 +169,13 @@ final class InputTest extends TestCase
         self::assertFalse($input->hasFallback(), 'hasFallback() value not match');
     }
 
-    /**
-     * @param string|string[] $fallbackValue
-     * @param string|string[] $originalValue
-     * @param string|string[] $expectedValue
-     */
     #[DataProvider('fallbackValueVsIsValidProvider')]
     public function testFallbackValueVsIsValidRules(
         bool $required,
-        $fallbackValue,
-        $originalValue,
+        string $fallbackValue,
+        string $originalValue,
         bool $isValid,
-        $expectedValue
+        string $expectedValue
     ): void {
         $input = $this->input;
         $input->setContinueIfEmpty(true);
@@ -200,11 +195,8 @@ final class InputTest extends TestCase
         self::assertSame($expectedValue, $input->getValue(), 'getValue() value not match');
     }
 
-    /**
-     * @param string|string[] $fallbackValue
-     */
     #[DataProvider('fallbackValueVsIsValidProvider')]
-    public function testFallbackValueVsIsValidRulesWhenValueNotSet(bool $required, $fallbackValue): void
+    public function testFallbackValueVsIsValidRulesWhenValueNotSet(bool $required, string $fallbackValue): void
     {
         $expectedValue = $fallbackValue; // Should always return the fallback value
 

--- a/test/InputTest.php
+++ b/test/InputTest.php
@@ -1032,4 +1032,44 @@ final class InputTest extends TestCase
             ],
         ];
     }
+
+    public function testFluentInterfaceIsProvidedByCommonMethods(): void
+    {
+        self::assertSame(
+            $this->input,
+            $this->input->setRequired(true),
+        );
+        self::assertSame(
+            $this->input,
+            $this->input->setAllowEmpty(true),
+        );
+        self::assertSame(
+            $this->input,
+            $this->input->setName('foo'),
+        );
+        self::assertSame(
+            $this->input,
+            $this->input->setBreakOnFailure(true),
+        );
+        self::assertSame(
+            $this->input,
+            $this->input->setContinueIfEmpty(true),
+        );
+        self::assertSame(
+            $this->input,
+            $this->input->setFallbackValue('muppet'),
+        );
+        self::assertSame(
+            $this->input,
+            $this->input->setValue('muppet'),
+        );
+        self::assertSame(
+            $this->input,
+            $this->input->setFilterChain(TestHelper::createFilterChain()),
+        );
+        self::assertSame(
+            $this->input,
+            $this->input->setValidatorChain(TestHelper::createValidatorChain()),
+        );
+    }
 }

--- a/test/InputTest.php
+++ b/test/InputTest.php
@@ -8,6 +8,7 @@ use Laminas\Filter\FilterChain;
 use Laminas\Filter\FilterChainInterface;
 use Laminas\Filter\ToInt;
 use Laminas\Filter\ToNull;
+use Laminas\InputFilter\Exception\InvalidArgumentException;
 use Laminas\InputFilter\Input;
 use Laminas\InputFilter\InputInterface;
 use Laminas\Translator\TranslatorInterface;
@@ -75,9 +76,41 @@ final class InputTest extends TestCase
         );
     }
 
-    public function testConstructorRequiresAName(): void
+    public function testAnEmptyStringNameIsExceptionalViaTheConstructor(): void
     {
-        self::assertEquals('foo', $this->input->getName());
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Input names cannot be an empty string');
+        new Input(TestHelper::createFilterChain(), TestHelper::createValidatorChain(), '');
+    }
+
+    public function testAnEmptyStringNameInSetNameIsExceptional(): void
+    {
+        $input = new Input(TestHelper::createFilterChain(), TestHelper::createValidatorChain(), null);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Input names cannot be an empty string');
+        $input->setName('');
+    }
+
+    /** @return list<array{0: string|int}> */
+    public static function validNamesForSetName(): array
+    {
+        return [
+            ['any-string'],
+            ['really, any string'],
+            [0],
+            [-10],
+            [99],
+        ];
+    }
+
+    #[DataProvider('validNamesForSetName')]
+    public function testValidInputNames(int|string $name): void
+    {
+        $input = new Input(TestHelper::createFilterChain(), TestHelper::createValidatorChain(), null);
+        self::assertNull($input->getName());
+        $input->setName($name);
+        self::assertSame($name, $input->getName());
     }
 
     public function testInputHasEmptyFilterChainByDefault(): void

--- a/test/InputTest.php
+++ b/test/InputTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace LaminasTest\InputFilter;
 
 use Laminas\Filter\FilterChain;
+use Laminas\Filter\FilterChainInterface;
 use Laminas\Filter\ToInt;
 use Laminas\Filter\ToNull;
 use Laminas\InputFilter\Input;
@@ -14,6 +15,7 @@ use Laminas\Validator\AbstractValidator;
 use Laminas\Validator\NotEmpty as NotEmptyValidator;
 use Laminas\Validator\NumberComparison;
 use Laminas\Validator\ValidatorChain;
+use Laminas\Validator\ValidatorChainInterface;
 use Laminas\Validator\ValidatorInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
@@ -64,12 +66,12 @@ final class InputTest extends TestCase
         self::assertEquals(
             self::EMPTY_ERROR_MESSAGE,
             $messages[self::EMPTY_ERROR_MESSAGE_KEY],
-            $message . ' missing NotEmpty::IS_EMPTY key and/or contains additional messages'
+            $message . ' missing NotEmpty::IS_EMPTY key and/or contains additional messages',
         );
         self::assertCount(
             1,
             $messages,
-            $message . ' missing NotEmpty::IS_EMPTY key and/or contains additional messages'
+            $message . ' missing NotEmpty::IS_EMPTY key and/or contains additional messages',
         );
     }
 
@@ -175,7 +177,7 @@ final class InputTest extends TestCase
         string $fallbackValue,
         string $originalValue,
         bool $isValid,
-        string $expectedValue
+        string $expectedValue,
     ): void {
         $input = $this->input;
         $input->setContinueIfEmpty(true);
@@ -188,7 +190,7 @@ final class InputTest extends TestCase
         self::assertTrue(
             $input->isValid(),
             'isValid() should be return always true when fallback value is set. Detail: '
-            . json_encode($input->getMessages(), JSON_THROW_ON_ERROR)
+            . json_encode($input->getMessages(), JSON_THROW_ON_ERROR),
         );
         self::assertEquals([], $input->getMessages(), 'getMessages() should be empty because the input is valid');
         self::assertSame($expectedValue, $input->getRawValue(), 'getRawValue() value not match');
@@ -210,7 +212,7 @@ final class InputTest extends TestCase
         self::assertTrue(
             $input->isValid(),
             'isValid() should be return always true when fallback value is set. Detail: '
-            . json_encode($input->getMessages(), JSON_THROW_ON_ERROR)
+            . json_encode($input->getMessages(), JSON_THROW_ON_ERROR),
         );
         self::assertEquals([], $input->getMessages(), 'getMessages() should be empty because the input is valid');
         self::assertSame($expectedValue, $input->getRawValue(), 'getRawValue() value not match');
@@ -224,7 +226,7 @@ final class InputTest extends TestCase
 
         self::assertFalse(
             $input->isValid(),
-            'isValid() should be return always false when no fallback value, is required, and not data is set.'
+            'isValid() should be return always false when no fallback value, is required, and not data is set.',
         );
         $this->assertRequiredValidationErrorMessage($input);
     }
@@ -237,7 +239,7 @@ final class InputTest extends TestCase
 
         self::assertFalse(
             $input->isValid(),
-            'isValid() should be return always false when no fallback value, is required, and not data is set.'
+            'isValid() should be return always false when no fallback value, is required, and not data is set.',
         );
         self::assertSame(['FAILED TO VALIDATE'], $input->getMessages());
     }
@@ -250,7 +252,7 @@ final class InputTest extends TestCase
         self::assertFalse(
             $input->isValid(),
             'isValid() should always return false when no fallback value is present, '
-            . 'the input is required, and no data is set.'
+            . 'the input is required, and no data is set.',
         );
         $this->assertRequiredValidationErrorMessage($input);
     }
@@ -269,7 +271,7 @@ final class InputTest extends TestCase
         self::assertFalse(
             $input->isValid(),
             'isValid() should always return false when no fallback value is present, '
-            . 'the input is required, and no data is set.'
+            . 'the input is required, and no data is set.',
         );
         self::assertEquals($customMessage, $input->getMessages());
     }
@@ -283,7 +285,7 @@ final class InputTest extends TestCase
         self::assertFalse(
             $input->isValid(),
             'isValid() should always return false when no fallback value is present, '
-            . 'the input is required, and no data is set.'
+            . 'the input is required, and no data is set.',
         );
         self::assertSame(['FAILED TO VALIDATE'], $input->getMessages());
     }
@@ -301,7 +303,7 @@ final class InputTest extends TestCase
         self::assertTrue(
             $input->isValid(),
             'isValid() should be return always true when is not required, and no data is set. Detail: '
-            . json_encode($input->getMessages(), JSON_THROW_ON_ERROR)
+            . json_encode($input->getMessages(), JSON_THROW_ON_ERROR),
         );
         self::assertEquals([], $input->getMessages(), 'getMessages() should be empty because the input is valid');
     }
@@ -316,9 +318,8 @@ final class InputTest extends TestCase
         $input->setContinueIfEmpty(true);
         $input->setValue($raw);
         $input->isValid();
-        $validators = $input->getValidatorChain()
-                                ->getValidators();
-        self::assertEmpty($validators);
+        $validators = self::assertValidatorChain($input->getValidatorChain())->getValidators();
+        self::assertCount(0, $validators);
     }
 
     public function testDefaultGetValue(): void
@@ -371,7 +372,7 @@ final class InputTest extends TestCase
 
         self::assertTrue(
             $this->input->isValid(),
-            'isValid() value not match. Detail . ' . json_encode($this->input->getMessages(), JSON_THROW_ON_ERROR)
+            'isValid() value not match. Detail . ' . json_encode($this->input->getMessages(), JSON_THROW_ON_ERROR),
         );
     }
 
@@ -394,17 +395,17 @@ final class InputTest extends TestCase
     {
         self::assertTrue($this->input->isRequired());
         $this->input->setValue($raw);
-        $validatorChain = $this->input->getValidatorChain();
-        self::assertEquals(0, count($validatorChain->getValidators()));
+        $validatorChain = self::assertValidatorChain($this->input->getValidatorChain());
+        self::assertCount(0, $validatorChain->getValidators());
 
         self::assertFalse($this->input->isValid());
         $messages = $this->input->getMessages();
         self::assertArrayHasKey(self::EMPTY_ERROR_MESSAGE_KEY, $messages);
-        self::assertEquals(1, count($validatorChain->getValidators()));
+        self::assertCount(1, $validatorChain->getValidators());
 
         // Assert that NotEmpty validator wasn't added again
         self::assertFalse($this->input->isValid());
-        self::assertEquals(1, count($validatorChain->getValidators()));
+        self::assertCount(1, $validatorChain->getValidators());
     }
 
     /**
@@ -418,7 +419,7 @@ final class InputTest extends TestCase
 
         $notEmptyMock = new NotEmptyValidator();
 
-        $validatorChain = $this->input->getValidatorChain();
+        $validatorChain = self::assertValidatorChain($this->input->getValidatorChain());
         $validatorChain->prependValidator($notEmptyMock);
         self::assertFalse($this->input->isValid());
 
@@ -431,7 +432,7 @@ final class InputTest extends TestCase
     #[DataProvider('emptyValueProvider')]
     public function testDoNotInjectNotEmptyValidatorIfAnywhereInChain(mixed $raw, mixed $filtered): void
     {
-        $validatorChain = $this->input->getValidatorChain();
+        $validatorChain = self::assertValidatorChain($this->input->getValidatorChain());
 
         $this->input->setRequired(true);
         $this->input->setValue($raw);
@@ -459,7 +460,7 @@ final class InputTest extends TestCase
         ValidatorInterface $validator,
         mixed $value,
         bool $expectedIsValid,
-        array $expectedMessages
+        array $expectedMessages,
     ): void {
         $this->input->setRequired($required);
         $this->input->setAllowEmpty($allowEmpty);
@@ -471,7 +472,7 @@ final class InputTest extends TestCase
         self::assertEquals(
             $expectedIsValid,
             $this->input->isValid(),
-            'isValid() value not match. Detail: ' . json_encode($this->input->getMessages(), JSON_THROW_ON_ERROR)
+            'isValid() value not match. Detail: ' . json_encode($this->input->getMessages(), JSON_THROW_ON_ERROR),
         );
         self::assertEquals($expectedMessages, $this->input->getMessages(), 'getMessages() value not match');
         self::assertEquals($value, $this->input->getRawValue(), 'getRawValue() must return the value always');
@@ -580,16 +581,17 @@ final class InputTest extends TestCase
         $a = $this->createInput('a');
         $b = $this->createInput('b');
 
-        $a->getFilterChain()->attach($filter1);
+        $filterChainA = self::assertFilterChain($a->getFilterChain());
+        $filterChainA->attach($filter1);
         $b->getFilterChain()->attach($filter2);
 
-        self::assertNotContains($filter2, $a->getFilterChain());
-        self::assertCount(1, $a->getFilterChain());
+        self::assertNotContains($filter2, $filterChainA);
+        self::assertCount(1, $filterChainA);
 
         $a->merge($b);
 
-        self::assertContains($filter2, $a->getFilterChain());
-        self::assertCount(2, $a->getFilterChain());
+        self::assertContains($filter2, $filterChainA);
+        self::assertCount(2, $filterChainA);
     }
 
     public function testThatMergingTwoInputsMergesTheValidatorChain(): void
@@ -600,21 +602,46 @@ final class InputTest extends TestCase
         $a = $this->createInput('a');
         $b = $this->createInput('b');
 
-        $a->getValidatorChain()->attach($validator1);
+        $validatorChainA = self::assertValidatorChain($a->getValidatorChain());
+        $validatorChainA->attach($validator1);
         $b->getValidatorChain()->attach($validator2);
 
-        self::assertCount(1, $a->getValidatorChain());
-        self::assertValidatorChainNotContains($validator2, $a->getValidatorChain());
+        self::assertCount(1, $validatorChainA);
+        self::assertValidatorChainNotContains($validator2, $validatorChainA);
 
         $a->merge($b);
 
-        $chain = iterator_to_array($a->getValidatorChain()->getIterator());
+        $chain = iterator_to_array($validatorChainA->getIterator());
         self::assertCount(2, $chain);
-        self::assertValidatorChainContains($validator2, $a->getValidatorChain());
+        self::assertValidatorChainContains($validator2, $validatorChainA);
     }
 
-    private static function validatorChainContains(ValidatorInterface $validator, ValidatorChain $chain): bool
+    private static function assertValidatorChain(ValidatorChainInterface $chain): ValidatorChain
     {
+        self::assertInstanceOf(
+            ValidatorChain::class,
+            $chain,
+        );
+
+        return $chain;
+    }
+
+    private static function assertFilterChain(FilterChainInterface $chain): FilterChain
+    {
+        self::assertInstanceOf(
+            FilterChain::class,
+            $chain,
+        );
+
+        return $chain;
+    }
+
+    private static function validatorChainContains(
+        ValidatorInterface $validator,
+        ValidatorChainInterface $chain,
+    ): bool {
+        $chain = self::assertValidatorChain($chain);
+
         $found = false;
         foreach ($chain as $spec) {
             if ($spec['instance'] === $validator) {
@@ -626,16 +653,20 @@ final class InputTest extends TestCase
         return $found;
     }
 
-    private static function assertValidatorChainContains(ValidatorInterface $validator, ValidatorChain $chain): void
-    {
+    private static function assertValidatorChainContains(
+        ValidatorInterface $validator,
+        ValidatorChainInterface $chain,
+    ): void {
         self::assertTrue(self::validatorChainContains($validator, $chain), sprintf(
             'The validator of type "%s" was not found in the chain',
             $validator::class,
         ));
     }
 
-    private static function assertValidatorChainNotContains(ValidatorInterface $validator, ValidatorChain $chain): void
-    {
+    private static function assertValidatorChainNotContains(
+        ValidatorInterface $validator,
+        ValidatorChainInterface $chain,
+    ): void {
         self::assertFalse(self::validatorChainContains($validator, $chain), sprintf(
             'The validator of type "%s" was found in the chain and was not expected to be present',
             $validator::class,

--- a/test/OptionalInputFilterTest.php
+++ b/test/OptionalInputFilterTest.php
@@ -47,7 +47,7 @@ final class OptionalInputFilterTest extends TestCase
         $inputFilter->setData($data);
 
         self::assertTrue($inputFilter->isValid());
-        self::assertEquals($data, $inputFilter->getValues());
+        self::assertEquals(['car' => ['brand' => null, 'model' => null]], $inputFilter->getValues());
     }
 
     public function testValidatesSuccessfullyWhenNoDataProvided(): void
@@ -58,7 +58,7 @@ final class OptionalInputFilterTest extends TestCase
         $inputFilter->setData($data);
 
         self::assertTrue($inputFilter->isValid());
-        self::assertEquals(['car' => null], $inputFilter->getValues());
+        self::assertEquals(['car' => ['brand' => null, 'model' => null]], $inputFilter->getValues());
     }
 
     public function testValidationFailureWhenInvalidDataSetIsProvided(): void
@@ -84,7 +84,7 @@ final class OptionalInputFilterTest extends TestCase
         $inputFilter->setData($data);
 
         self::assertTrue($inputFilter->isValid());
-        self::assertEquals($data, $inputFilter->getValues());
+        self::assertEquals(['car' => ['brand' => null, 'model' => null]], $inputFilter->getValues());
     }
 
     /**

--- a/test/StaticAnalysis/CollectionWithTemplatedValues.php
+++ b/test/StaticAnalysis/CollectionWithTemplatedValues.php
@@ -8,8 +8,7 @@ use Laminas\InputFilter\CollectionInputFilter;
 
 /**
  * @psalm-import-type FilteredValues from InputFilterWithTemplatedValues as CollectionShape
- * @psalm-type FilteredValues = array<array-key, CollectionShape>
- * @extends CollectionInputFilter<FilteredValues>
+ * @extends CollectionInputFilter<CollectionShape>
  */
 final class CollectionWithTemplatedValues extends CollectionInputFilter
 {

--- a/test/TestAsset/InputFilterInterfaceStub.php
+++ b/test/TestAsset/InputFilterInterfaceStub.php
@@ -30,18 +30,20 @@ final class InputFilterInterfaceStub extends InputFilter
     }
 
     /** @inheritDoc */
-    public function isValid($context = null): bool
+    public function isValid(array|null $context = null): bool
     {
         assertNotNull($this->isValid, 'isValid was not expected to be called');
 
         return $this->isValid;
     }
 
+    /** @inheritDoc */
     public function getValues(): array
     {
         return $this->getValues;
     }
 
+    /** @inheritDoc */
     public function getRawValues(): array
     {
         return $this->getRawValues;

--- a/test/TestAsset/InputFilterInterfaceStub.php
+++ b/test/TestAsset/InputFilterInterfaceStub.php
@@ -30,7 +30,7 @@ final class InputFilterInterfaceStub extends InputFilter
     }
 
     /** @inheritDoc */
-    public function isValid($context = null)
+    public function isValid($context = null): bool
     {
         assertNotNull($this->isValid, 'isValid was not expected to be called');
 

--- a/test/TestAsset/InputInterfaceStub.php
+++ b/test/TestAsset/InputInterfaceStub.php
@@ -122,7 +122,7 @@ final readonly class InputInterfaceStub implements InputInterface
     }
 
     /** @inheritDoc */
-    public function isValid(): bool
+    public function isValid(array|null $context = null): bool
     {
         assertNotNull($this->isValid, 'isValid was not expected to be called');
 

--- a/test/TestAsset/InputInterfaceStub.php
+++ b/test/TestAsset/InputInterfaceStub.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace LaminasTest\InputFilter\TestAsset;
 
 use Exception;
-use Laminas\Filter\FilterChain;
+use Laminas\Filter\FilterChainInterface;
 use Laminas\InputFilter\InputInterface;
-use Laminas\Validator\ValidatorChain;
+use Laminas\Validator\ValidatorChainInterface;
 
 use function func_get_arg;
 use function func_num_args;
@@ -29,26 +29,22 @@ final readonly class InputInterfaceStub implements InputInterface
     ) {
     }
 
-    /** @inheritDoc */
-    public function setAllowEmpty($allowEmpty): static
+    public function setAllowEmpty(bool $allowEmpty): static
     {
         return $this;
     }
 
-    /** @inheritDoc */
-    public function setBreakOnFailure($breakOnFailure): static
+    public function setBreakOnFailure(bool $breakOnFailure): static
     {
         return $this;
     }
 
-    /** @inheritDoc */
-    public function setErrorMessage($errorMessage): static
+    public function setErrorMessage(string|null $errorMessage): static
     {
         return $this;
     }
 
-    /** @inheritDoc */
-    public function setFilterChain(FilterChain $filterChain): never
+    public function setFilterChain(FilterChainInterface $filterChain): never
     {
         throw new Exception('Not implemented');
     }
@@ -59,67 +55,56 @@ final readonly class InputInterfaceStub implements InputInterface
         throw new Exception('Not implemented');
     }
 
-    /** @inheritDoc */
-    public function setRequired($required): never
+    public function setRequired(bool $required): never
     {
         throw new Exception('Not implemented');
     }
 
-    /** @inheritDoc */
-    public function setValidatorChain(ValidatorChain $validatorChain): never
+    public function setValidatorChain(ValidatorChainInterface $validatorChain): never
     {
         throw new Exception('Not implemented');
     }
 
-    /** @inheritDoc */
-    public function setValue($value): static
+    public function setValue(mixed $value): static
     {
         return $this;
     }
 
-    /** @inheritDoc */
     public function merge(InputInterface $input): never
     {
         throw new Exception('Not implemented');
     }
 
-    /** @inheritDoc */
     public function allowEmpty(): never
     {
         throw new Exception('Not implemented');
     }
 
-    /** @inheritDoc */
     public function breakOnFailure(): bool
     {
         return $this->breakOnFailure;
     }
 
-    /** @inheritDoc */
     public function getErrorMessage(): never
     {
         throw new Exception('Not implemented');
     }
 
-    /** @inheritDoc */
     public function getFilterChain(): never
     {
         throw new Exception('Not implemented');
     }
 
-    /** @inheritDoc */
     public function getName(): string
     {
         return $this->name;
     }
 
-    /** @inheritDoc */
     public function getRawValue(): mixed
     {
         return $this->getRawValue;
     }
 
-    /** @inheritDoc */
     public function isRequired(): bool
     {
         assertNotNull($this->isRequired, 'isRequired was not expected to be called');
@@ -127,13 +112,11 @@ final readonly class InputInterfaceStub implements InputInterface
         return $this->isRequired;
     }
 
-    /** @inheritDoc */
     public function getValidatorChain(): never
     {
         throw new Exception('Not implemented');
     }
 
-    /** @inheritDoc */
     public function getValue(): mixed
     {
         return $this->getValue;

--- a/test/TestAsset/InputInterfaceStub.php
+++ b/test/TestAsset/InputInterfaceStub.php
@@ -30,19 +30,19 @@ final readonly class InputInterfaceStub implements InputInterface
     }
 
     /** @inheritDoc */
-    public function setAllowEmpty($allowEmpty)
+    public function setAllowEmpty($allowEmpty): static
     {
         return $this;
     }
 
     /** @inheritDoc */
-    public function setBreakOnFailure($breakOnFailure)
+    public function setBreakOnFailure($breakOnFailure): static
     {
         return $this;
     }
 
     /** @inheritDoc */
-    public function setErrorMessage($errorMessage)
+    public function setErrorMessage($errorMessage): static
     {
         return $this;
     }
@@ -72,7 +72,7 @@ final readonly class InputInterfaceStub implements InputInterface
     }
 
     /** @inheritDoc */
-    public function setValue($value)
+    public function setValue($value): static
     {
         return $this;
     }

--- a/test/TestAsset/InputInterfaceStub.php
+++ b/test/TestAsset/InputInterfaceStub.php
@@ -49,8 +49,7 @@ final readonly class InputInterfaceStub implements InputInterface
         throw new Exception('Not implemented');
     }
 
-    /** @inheritDoc */
-    public function setName($name): never
+    public function setName(string|int $name): never
     {
         throw new Exception('Not implemented');
     }

--- a/test/ValidationGroup/InputFilterCollectionsValidationGroupTest.php
+++ b/test/ValidationGroup/InputFilterCollectionsValidationGroupTest.php
@@ -203,4 +203,15 @@ final class InputFilterCollectionsValidationGroupTest extends TestCase
 
         self::assertTrue($this->inputFilter->isValid());
     }
+
+    public function testSetValidationGroupOnACollectionHasAFluentInterface(): void
+    {
+        $collection = $this->inputFilter->get('stuff');
+        self::assertInstanceOf(CollectionInputFilter::class, $collection);
+
+        self::assertSame(
+            $collection,
+            $collection->setValidationGroup(['first']),
+        );
+    }
 }

--- a/test/ValidationGroup/InputFilterCollectionsValidationGroupTest.php
+++ b/test/ValidationGroup/InputFilterCollectionsValidationGroupTest.php
@@ -5,32 +5,28 @@ declare(strict_types=1);
 namespace LaminasTest\InputFilter\ValidationGroup;
 
 use Laminas\InputFilter\CollectionInputFilter;
-use Laminas\InputFilter\Exception\RuntimeException;
-use Laminas\InputFilter\Input;
 use Laminas\InputFilter\InputFilter;
 use LaminasTest\InputFilter\TestHelper;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
-use function restore_error_handler;
-use function set_error_handler;
-
+/**
+ * Test case to cover behaviour of validation groups with collections
+ */
 final class InputFilterCollectionsValidationGroupTest extends TestCase
 {
     private InputFilter $inputFilter;
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         $factory = TestHelper::createInputFilterFactory();
 
         $collection = new CollectionInputFilter($factory);
         $collection->setIsRequired(true);
 
-        $first = new Input(TestHelper::createFilterChain(), TestHelper::createValidatorChain(), 'first');
+        $first = $factory->createInput(['name' => 'first']);
         $first->setRequired(true);
-        $second = new Input(TestHelper::createFilterChain(), TestHelper::createValidatorChain(), 'second');
+        $second = $factory->createInput(['name' => 'second']);
         $second->setRequired(true);
 
         $nestedFilter = new InputFilter($factory);
@@ -135,7 +131,6 @@ final class InputFilterCollectionsValidationGroupTest extends TestCase
         $this->setCollectionCount($count);
         $collection = $this->inputFilter->get('stuff');
         self::assertInstanceOf(CollectionInputFilter::class, $collection);
-        /** @psalm-suppress InvalidArgument */
         $collection->setValidationGroup([
             0 => 'first',
             1 => 'second',
@@ -165,7 +160,6 @@ final class InputFilterCollectionsValidationGroupTest extends TestCase
         $collection = $this->inputFilter->get('stuff');
         self::assertInstanceOf(CollectionInputFilter::class, $collection);
 
-        /** @psalm-suppress InvalidArgument */
         $collection->setValidationGroup([
             0 => 'first',
         ]);
@@ -179,25 +173,16 @@ final class InputFilterCollectionsValidationGroupTest extends TestCase
             ],
         ]);
 
-        set_error_handler(function (int $num, string $msg): never {
-            throw new RuntimeException($msg, $num);
-        });
-
-        try {
-            $this->inputFilter->isValid();
-            self::fail('A warning was not issued');
-        } catch (RuntimeException $e) {
-            self::assertStringContainsString('Undefined array key 1', $e->getMessage());
-        } finally {
-            restore_error_handler();
-        }
+        /**
+         * This behaviour is incorrect, items 1, 2 & 3 should all fail validation
+         */
+        self::assertTrue($this->inputFilter->isValid());
     }
 
     #[DataProvider('collectionCountProvider')]
     public function testValidationGroupViaTopLevelInputFilter(?int $count): void
     {
         $this->setCollectionCount($count);
-        /** @psalm-suppress InvalidArgument */
         $this->inputFilter->setValidationGroup([
             'stuff' => [
                 0 => 'first',

--- a/test/ValidationGroup/InputFilterNestedValidationGroupTest.php
+++ b/test/ValidationGroup/InputFilterNestedValidationGroupTest.php
@@ -1,0 +1,200 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\InputFilter\ValidationGroup;
+
+use Laminas\InputFilter\Exception\InputNotFoundException;
+use Laminas\InputFilter\InputFilter;
+use Laminas\InputFilter\InputFilterInterface;
+use Laminas\Validator\StringLength;
+use LaminasTest\InputFilter\TestHelper;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test case to cover validationGroups with nested input filters
+ */
+final class InputFilterNestedValidationGroupTest extends TestCase
+{
+    private InputFilter $inputFilter;
+
+    protected function setUp(): void
+    {
+        $factory = TestHelper::createInputFilterFactory();
+
+        $first = $factory->createInput([
+            'name'       => 'first',
+            'required'   => true,
+            'validators' => [
+                [
+                    'name'    => StringLength::class,
+                    'options' => ['min' => 5],
+                ],
+            ],
+        ]);
+
+        $second = $factory->createInput([
+            'name'       => 'second',
+            'required'   => true,
+            'validators' => [
+                [
+                    'name'    => StringLength::class,
+                    'options' => ['min' => 5],
+                ],
+            ],
+        ]);
+
+        $third = $factory->createInput([
+            'name'       => 'third',
+            'required'   => true,
+            'validators' => [
+                [
+                    'name'    => StringLength::class,
+                    'options' => ['min' => 5],
+                ],
+            ],
+        ]);
+
+        $fourth = $factory->createInput([
+            'name'       => 'fourth',
+            'required'   => true,
+            'validators' => [
+                [
+                    'name'    => StringLength::class,
+                    'options' => ['min' => 5],
+                ],
+            ],
+        ]);
+
+        $this->inputFilter = new InputFilter($factory);
+        $this->inputFilter->add($first);
+        $this->inputFilter->add($second);
+        $nested = new InputFilter($factory);
+        $nested->add($third);
+        $nested->add($fourth);
+
+        $this->inputFilter->add($nested, 'nested');
+    }
+
+    public function testValidationFailsForMissingInput(): void
+    {
+        $this->inputFilter->setData([]);
+        self::assertFalse($this->inputFilter->isValid());
+    }
+
+    public function testValidationSucceedsForValidInput(): void
+    {
+        $this->inputFilter->setData([
+            'first'  => 'Muppet',
+            'second' => 'Muppet',
+            'nested' => [
+                'third'  => 'Muppet',
+                'fourth' => 'Muppet',
+            ],
+        ]);
+
+        self::assertTrue($this->inputFilter->isValid());
+    }
+
+    public function testValidateSingleInputByName(): void
+    {
+        $this->inputFilter->setValidationGroup('first');
+        $this->inputFilter->setData([
+            'first' => 'Muppet',
+        ]);
+
+        self::assertTrue($this->inputFilter->isValid());
+    }
+
+    public function testNestedValidationGroup(): void
+    {
+        $this->inputFilter->setValidationGroup([
+            'first',
+            'nested' => ['third'],
+        ]);
+
+        $this->inputFilter->setData([
+            'first'  => 'Muppet',
+            'nested' => [
+                'third' => 'Muppet',
+            ],
+        ]);
+
+        self::assertTrue($this->inputFilter->isValid());
+
+        $this->inputFilter->setData([
+            'first' => 'Muppet',
+        ]);
+
+        self::assertFalse($this->inputFilter->isValid());
+    }
+
+    public function testValidationGroupIsResetRecursivelyWithValidateAllArgument(): void
+    {
+        $this->inputFilter->setValidationGroup([
+            'first',
+            'nested' => ['third'],
+        ]);
+
+        $this->inputFilter->setValidationGroup(InputFilterInterface::VALIDATE_ALL);
+
+        $this->inputFilter->setData([
+            'first'  => 'Muppet',
+            'nested' => [
+                'third' => 'Muppet',
+            ],
+        ]);
+
+        self::assertFalse($this->inputFilter->isValid());
+
+        $this->inputFilter->setData([
+            'first'  => 'Muppet',
+            'second' => 'Muppet',
+            'nested' => [
+                'third'  => 'Muppet',
+                'fourth' => 'Muppet',
+            ],
+        ]);
+
+        self::assertTrue($this->inputFilter->isValid());
+    }
+
+    public function testValidationGroupWithUnknownInputInNestedFilterIsExceptional(): void
+    {
+        $this->expectException(InputNotFoundException::class);
+        $this->expectExceptionMessage('The input or input filter named "not-there" cannot be found');
+        $this->inputFilter->setValidationGroup(['nested' => ['not-there']]);
+    }
+
+    public function testValuesRetrievalIsInfluencedByValidationGroup(): void
+    {
+        $this->inputFilter->setValidationGroup([
+            'first',
+            'nested' => ['third'],
+        ]);
+
+        $completeData = [
+            'first'  => 'Muppet',
+            'second' => 'Muppet',
+            'nested' => [
+                'third'  => 'Muppet',
+                'fourth' => 'Muppet',
+            ],
+        ];
+
+        $this->inputFilter->setData($completeData);
+
+        $expect = [
+            'first'  => 'Muppet',
+            'nested' => [
+                'third' => 'Muppet',
+            ],
+        ];
+
+        self::assertSame($expect, $this->inputFilter->getValues());
+
+        $this->inputFilter->setValidationGroup(InputFilterInterface::VALIDATE_ALL);
+
+        self::assertSame($completeData, $this->inputFilter->getValues());
+    }
+}

--- a/test/ValidationGroup/InputFilterStringValidationGroupTest.php
+++ b/test/ValidationGroup/InputFilterStringValidationGroupTest.php
@@ -120,4 +120,12 @@ final class InputFilterStringValidationGroupTest extends TestCase
         $this->inputFilter->setData(['second' => 'Freddy']);
         self::assertFalse($this->inputFilter->isValid());
     }
+
+    public function testSetValidationGroupHasFluentInterface(): void
+    {
+        self::assertSame(
+            $this->inputFilter,
+            $this->inputFilter->setValidationGroup('first'),
+        );
+    }
 }

--- a/test/ValidationGroup/InputFilterStringValidationGroupTest.php
+++ b/test/ValidationGroup/InputFilterStringValidationGroupTest.php
@@ -4,31 +4,57 @@ declare(strict_types=1);
 
 namespace LaminasTest\InputFilter\ValidationGroup;
 
-use Laminas\InputFilter\Exception\InvalidArgumentException;
-use Laminas\InputFilter\Input;
+use Laminas\InputFilter\Exception\InputNotFoundException;
 use Laminas\InputFilter\InputFilter;
 use Laminas\Validator\StringLength;
 use LaminasTest\InputFilter\TestHelper;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * Test case for basic behaviour of validation groups
+ */
 final class InputFilterStringValidationGroupTest extends TestCase
 {
     private InputFilter $inputFilter;
 
     protected function setUp(): void
     {
-        parent::setUp();
-        $first = new Input(TestHelper::createFilterChain(), TestHelper::createValidatorChain(), 'first');
-        $first->setRequired(true);
-        $first->getValidatorChain()->attach(new StringLength(['min' => 5]));
-        $second = new Input(TestHelper::createFilterChain(), TestHelper::createValidatorChain(), 'second');
-        $second->setRequired(true);
-        $second->getValidatorChain()->attach(new StringLength(['min' => 5]));
-        $third = new Input(TestHelper::createFilterChain(), TestHelper::createValidatorChain(), 'third');
-        $third->setRequired(true);
-        $third->getValidatorChain()->attach(new StringLength(['min' => 5]));
+        $factory = TestHelper::createInputFilterFactory();
 
-        $this->inputFilter = new InputFilter(TestHelper::createInputFilterFactory());
+        $first = $factory->createInput([
+            'name'       => 'first',
+            'required'   => true,
+            'validators' => [
+                [
+                    'name'    => StringLength::class,
+                    'options' => ['min' => 5],
+                ],
+            ],
+        ]);
+
+        $second = $factory->createInput([
+            'name'       => 'second',
+            'required'   => true,
+            'validators' => [
+                [
+                    'name'    => StringLength::class,
+                    'options' => ['min' => 5],
+                ],
+            ],
+        ]);
+
+        $third = $factory->createInput([
+            'name'       => 'third',
+            'required'   => true,
+            'validators' => [
+                [
+                    'name'    => StringLength::class,
+                    'options' => ['min' => 5],
+                ],
+            ],
+        ]);
+
+        $this->inputFilter = new InputFilter($factory);
         $this->inputFilter->add($first);
         $this->inputFilter->add($second);
         $this->inputFilter->add($third);
@@ -70,10 +96,28 @@ final class InputFilterStringValidationGroupTest extends TestCase
         self::assertTrue($this->inputFilter->isValid());
     }
 
-    public function testValidationGroupWithUnknownInput(): void
+    public function testValidationGroupArrayWithUnknownInputIsExceptional(): void
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('"doughnuts" was not found');
+        $this->expectException(InputNotFoundException::class);
+        $this->expectExceptionMessage('The input or input filter named "doughnuts" cannot be found');
         $this->inputFilter->setValidationGroup(['doughnuts']);
+    }
+
+    public function testValidationGroupStringWithUnknownInputIsExceptional(): void
+    {
+        $this->expectException(InputNotFoundException::class);
+        $this->expectExceptionMessage('The input or input filter named "not-there" cannot be found');
+        $this->inputFilter->setValidationGroup('not-there');
+    }
+
+    public function testArrayArgumentsForAnInputInAValidationGroupIsIgnored(): void
+    {
+        $this->inputFilter->setValidationGroup(['first' => ['not-there']]);
+
+        $this->inputFilter->setData(['first' => 'Freddy']);
+        self::assertTrue($this->inputFilter->isValid());
+
+        $this->inputFilter->setData(['second' => 'Freddy']);
+        self::assertFalse($this->inputFilter->isValid());
     }
 }

--- a/tools/rector/rector.php
+++ b/tools/rector/rector.php
@@ -11,4 +11,7 @@ return RectorConfig::configure()
     ->withPaths([
         __DIR__ . '/../../src',
         __DIR__ . '/../../test',
-    ]);
+    ])
+    ->withPreparedSets(
+        typeDeclarations: true,
+    );


### PR DESCRIPTION
This is a _really_ big patch but it was pretty difficult not to touch everything…

- Adds types everywhere
- makes improvements to tests
- Introduces specific exception for not-found inputs
- lots of general QA improvements

Note there are roughly 10 Psalm issues that will be fixed by https://github.com/laminas/laminas-validator/pull/454
