### PR TITLE
Introduce `ErrorMessages` Type

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -17,14 +17,9 @@
   <file src="src/BaseInputFilter.php">
     <InvalidReturnStatement>
       <code><![CDATA[$values]]></code>
-      <code><![CDATA[array_map(
-            static fn (InputInterface|InputFilterInterface $input): array => $input->getMessages(),
-            $this->getInvalidInput(),
-        )]]></code>
     </InvalidReturnStatement>
     <InvalidReturnType>
       <code><![CDATA[TFilteredValues]]></code>
-      <code><![CDATA[array]]></code>
     </InvalidReturnType>
     <MixedArgumentTypeCoercion>
       <code><![CDATA[$value]]></code>
@@ -35,10 +30,6 @@
     </MixedAssignment>
   </file>
   <file src="src/CollectionInputFilter.php">
-    <InvalidPropertyAssignmentValue>
-      <code><![CDATA[$this->collectionMessages]]></code>
-      <code><![CDATA[$this->collectionMessages]]></code>
-    </InvalidPropertyAssignmentValue>
     <PropertyTypeCoercion>
       <code><![CDATA[$name]]></code>
     </PropertyTypeCoercion>
@@ -88,12 +79,6 @@
     </MoreSpecificImplementedParamType>
   </file>
   <file src="src/Input.php">
-    <InvalidReturnStatement>
-      <code><![CDATA[(array) $this->errorMessage]]></code>
-    </InvalidReturnStatement>
-    <InvalidReturnType>
-      <code><![CDATA[array]]></code>
-    </InvalidReturnType>
     <LessSpecificReturnStatement>
       <code><![CDATA[$this]]></code>
       <code><![CDATA[$this]]></code>

--- a/src/BaseInputFilter.php
+++ b/src/BaseInputFilter.php
@@ -408,13 +408,12 @@ class BaseInputFilter implements
         return $values;
     }
 
-    /** @inheritDoc */
-    public function getMessages(): array
+    public function getMessages(): ErrorMessages
     {
-        return array_map(
-            static fn (InputInterface|InputFilterInterface $input): array => $input->getMessages(),
+        return new ErrorMessages(array_map(
+            static fn (InputInterface|InputFilterInterface $input): ErrorMessages => $input->getMessages(),
             $this->getInvalidInput(),
-        );
+        ));
     }
 
     /**

--- a/src/CollectionInputFilter.php
+++ b/src/CollectionInputFilter.php
@@ -28,7 +28,7 @@ class CollectionInputFilter extends InputFilter
     protected array $collectionValues = [];
     /** @var array<array-key, array> */
     protected array $collectionRawValues = [];
-    /** @var array<array-key, array<string, array<array-key, string>>> */
+    /** @var array<array-key, ErrorMessages> */
     protected array $collectionMessages = [];
     /** @var InputFilterInterface<TFilteredValues>|null */
     protected InputFilterInterface|null $inputFilter = null;
@@ -268,12 +268,9 @@ class CollectionInputFilter extends InputFilter
         $this->collectionRawValues = [];
     }
 
-    /**
-     * @return array<array-key, array<string, array<array-key, string>>>
-     */
-    public function getMessages(): array
+    public function getMessages(): ErrorMessages
     {
-        return $this->collectionMessages;
+        return new ErrorMessages($this->collectionMessages);
     }
 
     /** @inheritDoc */
@@ -304,8 +301,7 @@ class CollectionInputFilter extends InputFilter
         return $unknownInputs;
     }
 
-    /** @return array<string, string> */
-    private function getEmptyValidationErrorMessages(): array
+    private function getEmptyValidationErrorMessages(): ErrorMessages
     {
         $options = $this->emptyErrorMessage === null
             ? []
@@ -315,6 +311,6 @@ class CollectionInputFilter extends InputFilter
 
         $validator->isValid(null);
 
-        return $validator->getMessages();
+        return new ErrorMessages($validator->getMessages());
     }
 }

--- a/src/ErrorMessages.php
+++ b/src/ErrorMessages.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\InputFilter;
+
+use ArrayAccess;
+use ArrayIterator;
+use Countable;
+use IteratorAggregate;
+use JsonSerializable;
+use Laminas\InputFilter\Exception\BadMethodCallException;
+use Traversable;
+
+/**
+ * @psalm-type ValueType = string|self
+ * @implements ArrayAccess<array-key, ValueType>
+ * @implements IteratorAggregate<array-key, ValueType>
+ * @immutable
+ */
+final readonly class ErrorMessages implements Countable, IteratorAggregate, ArrayAccess, JsonSerializable
+{
+    /**
+     * @param array<array-key, ValueType> $messages
+     */
+    public function __construct(
+        private array $messages,
+    ) {
+    }
+
+    public function getIterator(): Traversable
+    {
+        return new ArrayIterator($this->messages);
+    }
+
+    public function count(): int
+    {
+        $count = 0;
+        foreach ($this->messages as $message) {
+            if ($message instanceof self) {
+                $count += $message->count();
+            } else {
+                $count++;
+            }
+        }
+
+        return $count;
+    }
+
+    public function toArray(): array
+    {
+        $result = [];
+        foreach ($this->messages as $key => $message) {
+            if ($message instanceof self) {
+                $result[$key] = $message->toArray();
+            } else {
+                $result[$key] = $message;
+            }
+        }
+
+        return $result;
+    }
+
+    public function offsetExists(mixed $offset): bool
+    {
+        return isset($this->messages[$offset]);
+    }
+
+    public function offsetGet(mixed $offset): string|self|null
+    {
+        return $this->messages[$offset] ?? null;
+    }
+
+    public function offsetSet(mixed $offset, mixed $value): never
+    {
+        throw new BadMethodCallException('Error messages are immutable');
+    }
+
+    public function offsetUnset(mixed $offset): never
+    {
+        throw new BadMethodCallException('Error messages are immutable');
+    }
+
+    /** @return array<array-key, ValueType> */
+    public function jsonSerialize(): array
+    {
+        return $this->messages;
+    }
+}

--- a/src/Exception/BadMethodCallException.php
+++ b/src/Exception/BadMethodCallException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\InputFilter\Exception;
+
+final class BadMethodCallException extends \BadMethodCallException implements ExceptionInterface
+{
+}

--- a/src/Input.php
+++ b/src/Input.php
@@ -323,19 +323,18 @@ class Input implements
         return $result;
     }
 
-    /** @inheritDoc */
-    public function getMessages(): array
+    public function getMessages(): ErrorMessages
     {
-        if (null !== $this->errorMessage) {
-            return (array) $this->errorMessage;
+        if ($this->errorMessage !== null) {
+            return new ErrorMessages((array) $this->errorMessage);
         }
 
         if ($this->hasFallback()) {
-            return [];
+            return new ErrorMessages([]);
         }
 
         $validator = $this->getValidatorChain();
-        return $validator->getMessages();
+        return new ErrorMessages($validator->getMessages());
     }
 
     protected function injectNotEmptyValidator(): void

--- a/src/InputFilterInterface.php
+++ b/src/InputFilterInterface.php
@@ -37,8 +37,6 @@ use Laminas\Validator\ValidatorInterface; // phpcs:ignore
  *     required?: bool,
  *     required_message?: string,
  * }&array<array-key, InputSpecification>
- * @psalm-type InputErrorMessages = array<string, string>
- * @psalm-type InputFilterErrorMessages = array<array-key, InputErrorMessages|InputErrorMessages[]>
  */
 interface InputFilterInterface extends Countable
 {
@@ -159,12 +157,7 @@ interface InputFilterInterface extends Countable
     public function getRawValues(): array;
 
     /**
-     * Return a list of validation failure messages
-     *
-     * Should return an associative array of named input/message list pairs.
-     * Pairs should only be returned for inputs that failed validation.
-     *
-     * @return InputFilterErrorMessages|InputFilterErrorMessages[]
+     * Return validation failure messages
      */
-    public function getMessages(): array;
+    public function getMessages(): ErrorMessages;
 }

--- a/src/InputInterface.php
+++ b/src/InputInterface.php
@@ -7,7 +7,6 @@ namespace Laminas\InputFilter;
 use Laminas\Filter\FilterChainInterface;
 use Laminas\Validator\ValidatorChainInterface;
 
-/** @psalm-import-type InputErrorMessages from InputFilterInterface */
 interface InputInterface
 {
     public function setAllowEmpty(bool $allowEmpty): static;
@@ -49,6 +48,5 @@ interface InputInterface
     /** @param array<array-key, mixed>|null $context */
     public function isValid(array|null $context = null): bool;
 
-    /** @return InputErrorMessages */
-    public function getMessages(): array;
+    public function getMessages(): ErrorMessages;
 }

--- a/test/ArrayInputTest.php
+++ b/test/ArrayInputTest.php
@@ -91,9 +91,10 @@ final class ArrayInputTest extends TestCase
 
         self::assertFalse($input->isValid());
 
-        $messages = $input->getMessages();
+        $messages = $input->getMessages()->toArray();
         self::assertCount(1, $messages);
         $message = array_pop($messages);
+        self::assertIsString($message);
         self::assertEquals($expected, $message);
     }
 
@@ -265,7 +266,7 @@ final class ArrayInputTest extends TestCase
 
         $inputFilter->setData(['myInput' => $value]);
         self::assertFalse($inputFilter->isValid());
-        $messages = $inputFilter->getMessages()['myInput'] ?? null;
+        $messages = $inputFilter->getMessages()->toArray()['myInput'] ?? null;
         self::assertIsArray($messages);
         self::assertArrayHasKey(IsArray::NOT_ARRAY, $messages);
         self::assertIsString($messages[IsArray::NOT_ARRAY]);
@@ -280,7 +281,7 @@ final class ArrayInputTest extends TestCase
         $message  = $message ?: 'Expected failure message for required input';
         $message .= ';';
 
-        $messages = $input->getMessages();
+        $messages = $input->getMessages()->toArray();
 
         self::assertArrayHasKey(self::EMPTY_ERROR_MESSAGE_KEY, $messages);
         self::assertEquals(
@@ -419,7 +420,11 @@ final class ArrayInputTest extends TestCase
             'isValid() should be return always true when fallback value is set. Detail: '
             . json_encode($input->getMessages(), JSON_THROW_ON_ERROR),
         );
-        self::assertEquals([], $input->getMessages(), 'getMessages() should be empty because the input is valid');
+        self::assertEquals(
+            [],
+            $input->getMessages()->toArray(),
+            'getMessages() should be empty because the input is valid',
+        );
         self::assertSame($expectedValue, $input->getRawValue(), 'getRawValue() value not match');
         self::assertSame($expectedValue, $input->getValue(), 'getValue() value not match');
     }
@@ -444,7 +449,11 @@ final class ArrayInputTest extends TestCase
             'isValid() should be return always true when fallback value is set. Detail: '
             . json_encode($input->getMessages(), JSON_THROW_ON_ERROR),
         );
-        self::assertEquals([], $input->getMessages(), 'getMessages() should be empty because the input is valid');
+        self::assertEquals(
+            [],
+            $input->getMessages()->toArray(),
+            'getMessages() should be empty because the input is valid',
+        );
         self::assertSame($expectedValue, $input->getRawValue(), 'getRawValue() value not match');
         self::assertSame($expectedValue, $input->getValue(), 'getValue() value not match');
     }
@@ -471,7 +480,7 @@ final class ArrayInputTest extends TestCase
             $input->isValid(),
             'isValid() should be return always false when no fallback value, is required, and not data is set.',
         );
-        self::assertSame(['FAILED TO VALIDATE'], $input->getMessages());
+        self::assertSame(['FAILED TO VALIDATE'], $input->getMessages()->toArray());
     }
 
     public function testRequiredWithoutFallbackAndValueNotSetProvidesNotEmptyValidatorIsEmptyErrorMessage(): void
@@ -503,7 +512,7 @@ final class ArrayInputTest extends TestCase
             'isValid() should always return false when no fallback value is present, '
             . 'the input is required, and no data is set.',
         );
-        self::assertEquals($customMessage, $input->getMessages());
+        self::assertEquals($customMessage, $input->getMessages()->toArray());
     }
 
     public function testRequiredWithoutFallbackAndValueNotSetProvidesCustomErrorMessageWhenSet(): void
@@ -517,7 +526,7 @@ final class ArrayInputTest extends TestCase
             'isValid() should always return false when no fallback value is present, '
             . 'the input is required, and no data is set.',
         );
-        self::assertSame(['FAILED TO VALIDATE'], $input->getMessages());
+        self::assertSame(['FAILED TO VALIDATE'], $input->getMessages()->toArray());
     }
 
     public function testNotRequiredWithoutFallbackAndValueNotSetThenIsValid(): void
@@ -535,7 +544,11 @@ final class ArrayInputTest extends TestCase
             'isValid() should be return always true when is not required, and no data is set. Detail: '
             . json_encode($input->getMessages(), JSON_THROW_ON_ERROR),
         );
-        self::assertEquals([], $input->getMessages(), 'getMessages() should be empty because the input is valid');
+        self::assertEquals(
+            [],
+            $input->getMessages()->toArray(),
+            'getMessages() should be empty because the input is valid',
+        );
     }
 
     /**
@@ -624,7 +637,7 @@ final class ArrayInputTest extends TestCase
         self::assertCount(0, $validatorChain->getValidators());
 
         self::assertFalse($this->input->isValid());
-        $messages = $this->input->getMessages();
+        $messages = $this->input->getMessages()->toArray();
         self::assertArrayHasKey(self::EMPTY_ERROR_MESSAGE_KEY, $messages);
         self::assertCount(1, $validatorChain->getValidators());
 
@@ -699,7 +712,7 @@ final class ArrayInputTest extends TestCase
             $this->input->isValid(),
             'isValid() value not match. Detail: ' . json_encode($this->input->getMessages(), JSON_THROW_ON_ERROR),
         );
-        self::assertEquals($expectedMessages, $this->input->getMessages(), 'getMessages() value not match');
+        self::assertEquals($expectedMessages, $this->input->getMessages()->toArray(), 'getMessages() value not match');
         self::assertEquals($value, $this->input->getRawValue(), 'getRawValue() must return the value always');
         self::assertEquals($value, $this->input->getValue(), 'getValue() must return the filtered value always');
     }
@@ -994,7 +1007,7 @@ final class ArrayInputTest extends TestCase
             ->willReturn($translatedMessage);
 
         self::assertFalse($this->input->isValid());
-        $messages = $this->input->getMessages();
+        $messages = $this->input->getMessages()->toArray();
         self::assertArrayHasKey(self::EMPTY_ERROR_MESSAGE_KEY, $messages);
         self::assertSame($translatedMessage, $messages[self::EMPTY_ERROR_MESSAGE_KEY]);
     }

--- a/test/BaseInputFilterTest.php
+++ b/test/BaseInputFilterTest.php
@@ -150,7 +150,7 @@ final class BaseInputFilterTest extends TestCase
         self::assertEquals($expectedIsValid, $inputFilter->isValid(), 'isValid() value not match');
         self::assertEquals($expectedInvalidInputs, $inputFilter->getInvalidInput(), 'getInvalidInput() value not match');
         self::assertEquals($expectedValidInputs, $inputFilter->getValidInput(), 'getValidInput() value not match');
-        self::assertEquals($expectedMessages, $inputFilter->getMessages(), 'getMessages() value not match');
+        self::assertEquals($expectedMessages, $inputFilter->getMessages()->toArray(), 'getMessages() value not match');
         // phpcs:enable Generic.Files.LineLength.TooLong
 
         // ** Check unknown fields **

--- a/test/CollectionInputFilterTest.php
+++ b/test/CollectionInputFilterTest.php
@@ -8,6 +8,7 @@ use ArrayIterator;
 use ArrayObject;
 use Laminas\InputFilter\BaseInputFilter;
 use Laminas\InputFilter\CollectionInputFilter;
+use Laminas\InputFilter\ErrorMessages;
 use Laminas\InputFilter\Exception\InvalidArgumentException;
 use Laminas\InputFilter\Exception\RuntimeException;
 use Laminas\InputFilter\Factory;
@@ -134,7 +135,11 @@ final class CollectionInputFilterTest extends TestCase
         );
         self::assertEquals($expectedRaw, $this->inputFilter->getRawValues(), 'getRawValues() value not match');
         self::assertEquals($expectedValues, $this->inputFilter->getValues(), 'getValues() value not match');
-        self::assertEquals($expectedMessages, $this->inputFilter->getMessages(), 'getMessages() value not match');
+        self::assertEquals(
+            $expectedMessages,
+            $this->inputFilter->getMessages()->toArray(),
+            'getMessages() value not match',
+        );
     }
 
     /**
@@ -235,7 +240,7 @@ final class CollectionInputFilterTest extends TestCase
         );
         self::assertEquals($colRaw, $this->inputFilter->getRawValues(), 'getRawValues() value not match');
         self::assertEquals($colFiltered, $this->inputFilter->getValues(), 'getValues() value not match');
-        self::assertEquals([], $this->inputFilter->getMessages(), 'getMessages() value not match');
+        self::assertEquals([], $this->inputFilter->getMessages()->toArray(), 'getMessages() value not match');
     }
 
     /** @psalm-return array<string, array{count: null|int, isValid: bool}> */
@@ -407,7 +412,7 @@ final class CollectionInputFilterTest extends TestCase
                 ->method('isValid');
         }
         $inputFilter->method('getMessages')
-            ->willReturn($getMessages);
+            ->willReturn(new ErrorMessages($getMessages));
 
         return $inputFilter;
     }
@@ -522,21 +527,23 @@ final class CollectionInputFilterTest extends TestCase
         ]);
 
         $isValid  = $collectionInputFilter->isValid();
-        $messages = $collectionInputFilter->getMessages();
+        $messages = $collectionInputFilter->getMessages()->toArray();
 
-        // @codingStandardsIgnoreStart
         self::assertFalse($isValid);
         self::assertCount(2, $messages);
 
+        self::assertIsArray($messages[0]);
         self::assertArrayHasKey('phone', $messages[0]);
+        self::assertIsArray($messages[0]['phone']);
         self::assertCount(1, $messages[0]['phone']);
         self::assertContains(self::EMPTY_ERROR_MESSAGE, $messages[0]['phone']);
 
+        self::assertIsArray($messages[1]);
         self::assertArrayHasKey('phone', $messages[1]);
+        self::assertIsArray($messages[1]['phone']);
         self::assertCount(1, $messages[1]['phone']);
         self::assertNotContains(self::EMPTY_ERROR_MESSAGE, $messages[1]['phone']);
         self::assertContains('The input must contain only digits', $messages[1]['phone']);
-        // @codingStandardsIgnoreEnd
     }
 
     public function testCollectionValidationUsesCustomInputErrorMessages(): void
@@ -573,17 +580,21 @@ final class CollectionInputFilterTest extends TestCase
         ]);
 
         $isValid  = $collectionInputFilter->isValid();
-        $messages = $collectionInputFilter->getMessages();
+        $messages = $collectionInputFilter->getMessages()->toArray();
 
         self::assertFalse($isValid);
         self::assertCount(2, $messages);
 
+        self::assertIsArray($messages[0]);
         self::assertArrayHasKey('phone', $messages[0]);
+        self::assertIsArray($messages[0]['phone']);
         self::assertCount(1, $messages[0]['phone']);
         self::assertContains('CUSTOM ERROR MESSAGE', $messages[0]['phone']);
         self::assertNotContains(self::EMPTY_ERROR_MESSAGE, $messages[0]['phone']);
 
+        self::assertIsArray($messages[1]);
         self::assertArrayHasKey('phone', $messages[1]);
+        self::assertIsArray($messages[1]['phone']);
         self::assertCount(1, $messages[1]['phone']);
         self::assertContains('CUSTOM ERROR MESSAGE', $messages[1]['phone']);
     }
@@ -720,7 +731,7 @@ final class CollectionInputFilterTest extends TestCase
                     ],
                 ],
             ],
-        ], $inputFilter->getMessages());
+        ], $inputFilter->getMessages()->toArray());
     }
 
     public function testNotEmptyMessageIsTranslated(): void
@@ -738,7 +749,10 @@ final class CollectionInputFilterTest extends TestCase
         $this->inputFilter->setData([]);
 
         self::assertFalse($this->inputFilter->isValid());
-        self::assertEquals([[self::EMPTY_ERROR_MESSAGE_KEY => $translatedMessage]], $this->inputFilter->getMessages());
+        self::assertEquals(
+            [[self::EMPTY_ERROR_MESSAGE_KEY => $translatedMessage]],
+            $this->inputFilter->getMessages()->toArray(),
+        );
     }
 
     public function testSetDataUsingSetDataAndRunningIsValidReturningSameAsOriginalForUnfilteredData(): void
@@ -823,7 +837,10 @@ final class CollectionInputFilterTest extends TestCase
         $inputFilter->setData([]);
 
         self::assertFalse($inputFilter->isValid());
-        self::assertEquals([[self::EMPTY_ERROR_MESSAGE_KEY => self::EMPTY_ERROR_MESSAGE]], $inputFilter->getMessages());
+        self::assertEquals(
+            [[self::EMPTY_ERROR_MESSAGE_KEY => self::EMPTY_ERROR_MESSAGE]],
+            $inputFilter->getMessages()->toArray(),
+        );
     }
 
     public function testSettingCustomValidationMessageViaFactory(): void
@@ -843,7 +860,7 @@ final class CollectionInputFilterTest extends TestCase
         $inputFilter->setData([]);
 
         self::assertFalse($inputFilter->isValid());
-        self::assertEquals([[self::EMPTY_ERROR_MESSAGE_KEY => $customMessage]], $inputFilter->getMessages());
+        self::assertEquals([[self::EMPTY_ERROR_MESSAGE_KEY => $customMessage]], $inputFilter->getMessages()->toArray());
     }
 
     public function testSetIsRequiredValidationMessage(): void
@@ -854,6 +871,9 @@ final class CollectionInputFilterTest extends TestCase
         $this->inputFilter->setData([]);
 
         self::assertFalse($this->inputFilter->isValid());
-        self::assertEquals([[self::EMPTY_ERROR_MESSAGE_KEY => $customMessage]], $this->inputFilter->getMessages());
+        self::assertEquals(
+            [[self::EMPTY_ERROR_MESSAGE_KEY => $customMessage]],
+            $this->inputFilter->getMessages()->toArray(),
+        );
     }
 }

--- a/test/ErrorMessagesTest.php
+++ b/test/ErrorMessagesTest.php
@@ -1,0 +1,156 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\InputFilter;
+
+use Laminas\InputFilter\ErrorMessages;
+use Laminas\InputFilter\Exception\BadMethodCallException;
+use PHPUnit\Framework\TestCase;
+
+use function iterator_to_array;
+use function json_decode;
+use function json_encode;
+
+final class ErrorMessagesTest extends TestCase
+{
+    public function testIterationOverNestedSets(): void
+    {
+        $errors = new ErrorMessages(
+            [
+                'foo'    => 'Error 1',
+                'bar'    => 'Error 2',
+                'level2' => new ErrorMessages(
+                    [
+                        'baz'    => 'Error 3',
+                        'level3' => new ErrorMessages([
+                            'bat' => 'Error 4',
+                        ]),
+                    ],
+                ),
+            ],
+        );
+
+        self::assertSame([
+            'foo'    => 'Error 1',
+            'bar'    => 'Error 2',
+            'level2' => [
+                'baz'    => 'Error 3',
+                'level3' => [
+                    'bat' => 'Error 4',
+                ],
+            ],
+        ], $errors->toArray());
+    }
+
+    public function testCountOfNestedEmptySetsIsZero(): void
+    {
+        $errors = new ErrorMessages([
+            'foo'  => new ErrorMessages([
+                'bar' => new ErrorMessages([]),
+            ]),
+            'bing' => new ErrorMessages([
+                'bong' => new ErrorMessages([]),
+            ]),
+        ]);
+
+        self::assertCount(0, $errors);
+    }
+
+    public function testCountIsCorrect(): void
+    {
+        $errors = new ErrorMessages([
+            'foo'  => new ErrorMessages([
+                'bar' => new ErrorMessages([
+                    'baz' => 'Bad News',
+                ]),
+            ]),
+            'bing' => new ErrorMessages([
+                'bong' => new ErrorMessages([
+                    'bung' => 'More bad news',
+                ]),
+            ]),
+        ]);
+
+        self::assertCount(2, $errors);
+    }
+
+    public function testArrayAccessCannotBeAbusedToAddErrors(): void
+    {
+        $errors = new ErrorMessages([]);
+        $this->expectException(BadMethodCallException::class);
+        $this->expectExceptionMessage('Error messages are immutable');
+
+        $errors['foo'] = 'bar';
+    }
+
+    public function testArrayAccessCannotBeAbusedToRemoveErrors(): void
+    {
+        $errors = new ErrorMessages([
+            'foo' => 'bar',
+        ]);
+        $this->expectException(BadMethodCallException::class);
+        $this->expectExceptionMessage('Error messages are immutable');
+
+        unset($errors['foo']);
+    }
+
+    public function testArrayAccessImplementation(): void
+    {
+        $nested = new ErrorMessages([
+            'bar' => 'bat',
+        ]);
+        $errors = new ErrorMessages([
+            'foo' => 'bar',
+            'baz' => $nested,
+        ]);
+
+        self::assertTrue(isset($errors['foo']));
+        self::assertFalse(isset($errors['bar']));
+
+        self::assertSame('bar', $errors['foo']);
+        self::assertInstanceOf(ErrorMessages::class, $errors['baz']);
+        self::assertSame('bat', $errors['baz']['bar']);
+    }
+
+    public function testJsonEncodeProducesANestedArray(): void
+    {
+        $nested = new ErrorMessages([
+            'bar' => 'bat',
+        ]);
+        $errors = new ErrorMessages([
+            'foo' => 'bar',
+            'baz' => $nested,
+        ]);
+
+        $expect = [
+            'foo' => 'bar',
+            'baz' => [
+                'bar' => 'bat',
+            ],
+        ];
+
+        $json = json_encode($errors);
+        self::assertIsString($json);
+        $data = json_decode($json, true);
+        self::assertSame($expect, $data);
+    }
+
+    public function testIteratorAggregate(): void
+    {
+        $nested = new ErrorMessages([
+            'bar' => 'bat',
+        ]);
+        $errors = new ErrorMessages([
+            'foo' => 'bar',
+            'baz' => $nested,
+        ]);
+
+        $expect = [
+            'foo' => 'bar',
+            'baz' => $nested,
+        ];
+
+        self::assertSame($expect, iterator_to_array($errors));
+    }
+}

--- a/test/FactoryTest.php
+++ b/test/FactoryTest.php
@@ -971,11 +971,11 @@ final class FactoryTest extends TestCase
         self::assertInstanceOf(CollectionInputFilter::class, $inputFilter);
 
         self::assertFalse($inputFilter->isValid());
-        self::assertSame([[NotEmpty::IS_EMPTY => $message]], $inputFilter->getMessages());
+        self::assertSame([[NotEmpty::IS_EMPTY => $message]], $inputFilter->getMessages()->toArray());
 
         $inputFilter->setIsRequired(false);
         self::assertTrue($inputFilter->isValid());
-        self::assertSame([], $inputFilter->getMessages());
+        self::assertSame([], $inputFilter->getMessages()->toArray());
     }
 
     protected function createDefaultFactory(): Factory

--- a/test/FileInput/FileInputTest.php
+++ b/test/FileInput/FileInputTest.php
@@ -273,7 +273,7 @@ final class FileInputTest extends TestCase
         $message  = $message ?: 'Expected failure message for required input';
         $message .= ';';
 
-        $messages = $input->getMessages();
+        $messages = $input->getMessages()->toArray();
         self::assertArrayHasKey(self::EMPTY_ERROR_MESSAGE_KEY, $messages);
         self::assertEquals(
             self::EMPTY_ERROR_MESSAGE,
@@ -405,7 +405,7 @@ final class FileInputTest extends TestCase
             $input->isValid(),
             'isValid() should be return always false when no fallback value, is required, and not data is set.'
         );
-        self::assertSame(['FAILED TO VALIDATE'], $input->getMessages());
+        self::assertSame(['FAILED TO VALIDATE'], $input->getMessages()->toArray());
     }
 
     public function testRequiredWithoutFallbackAndValueNotSetProvidesNotEmptyValidatorIsEmptyErrorMessage(): void
@@ -435,7 +435,7 @@ final class FileInputTest extends TestCase
             'isValid() should always return false when no fallback value is present, '
             . 'the input is required, and no data is set.'
         );
-        self::assertEquals($customMessage, $input->getMessages());
+        self::assertEquals($customMessage, $input->getMessages()->toArray());
     }
 
     public function testRequiredWithoutFallbackAndValueNotSetProvidesCustomErrorMessageWhenSet(): void
@@ -449,7 +449,7 @@ final class FileInputTest extends TestCase
             'isValid() should always return false when no fallback value is present, '
             . 'the input is required, and no data is set.'
         );
-        self::assertSame(['FAILED TO VALIDATE'], $input->getMessages());
+        self::assertSame(['FAILED TO VALIDATE'], $input->getMessages()->toArray());
     }
 
     public function testNotRequiredWithoutFallbackAndValueNotSetThenIsValid(): void
@@ -467,7 +467,11 @@ final class FileInputTest extends TestCase
             'isValid() should be return always true when is not required, and no data is set. Detail: '
             . json_encode($input->getMessages(), JSON_THROW_ON_ERROR)
         );
-        self::assertEquals([], $input->getMessages(), 'getMessages() should be empty because the input is valid');
+        self::assertEquals(
+            [],
+            $input->getMessages()->toArray(),
+            'getMessages() should be empty because the input is valid',
+        );
     }
 
     /**
@@ -549,7 +553,7 @@ final class FileInputTest extends TestCase
             $this->input->isValid(),
             'isValid() value not match. Detail: ' . json_encode($this->input->getMessages(), JSON_THROW_ON_ERROR)
         );
-        self::assertEquals($expectedMessages, $this->input->getMessages(), 'getMessages() value not match');
+        self::assertEquals($expectedMessages, $this->input->getMessages()->toArray(), 'getMessages() value not match');
         self::assertEquals($value, $this->input->getRawValue(), 'getRawValue() must return the value always');
         self::assertEquals($value, $this->input->getValue(), 'getValue() must return the filtered value always');
     }
@@ -831,7 +835,7 @@ final class FileInputTest extends TestCase
             ->willReturn($translatedMessage);
 
         self::assertFalse($this->input->isValid());
-        $messages = $this->input->getMessages();
+        $messages = $this->input->getMessages()->toArray();
         self::assertArrayHasKey(self::EMPTY_ERROR_MESSAGE_KEY, $messages);
         self::assertSame($translatedMessage, $messages[self::EMPTY_ERROR_MESSAGE_KEY]);
     }

--- a/test/InputTest.php
+++ b/test/InputTest.php
@@ -62,7 +62,7 @@ final class InputTest extends TestCase
         $message  = $message ?: 'Expected failure message for required input';
         $message .= ';';
 
-        $messages = $input->getMessages();
+        $messages = $input->getMessages()->toArray();
         self::assertArrayHasKey(self::EMPTY_ERROR_MESSAGE_KEY, $messages);
         self::assertEquals(
             self::EMPTY_ERROR_MESSAGE,
@@ -225,7 +225,11 @@ final class InputTest extends TestCase
             'isValid() should be return always true when fallback value is set. Detail: '
             . json_encode($input->getMessages(), JSON_THROW_ON_ERROR),
         );
-        self::assertEquals([], $input->getMessages(), 'getMessages() should be empty because the input is valid');
+        self::assertEquals(
+            [],
+            $input->getMessages()->toArray(),
+            'getMessages() should be empty because the input is valid',
+        );
         self::assertSame($expectedValue, $input->getRawValue(), 'getRawValue() value not match');
         self::assertSame($expectedValue, $input->getValue(), 'getValue() value not match');
     }
@@ -247,7 +251,11 @@ final class InputTest extends TestCase
             'isValid() should be return always true when fallback value is set. Detail: '
             . json_encode($input->getMessages(), JSON_THROW_ON_ERROR),
         );
-        self::assertEquals([], $input->getMessages(), 'getMessages() should be empty because the input is valid');
+        self::assertEquals(
+            [],
+            $input->getMessages()->toArray(),
+            'getMessages() should be empty because the input is valid',
+        );
         self::assertSame($expectedValue, $input->getRawValue(), 'getRawValue() value not match');
         self::assertSame($expectedValue, $input->getValue(), 'getValue() value not match');
     }
@@ -274,7 +282,7 @@ final class InputTest extends TestCase
             $input->isValid(),
             'isValid() should be return always false when no fallback value, is required, and not data is set.',
         );
-        self::assertSame(['FAILED TO VALIDATE'], $input->getMessages());
+        self::assertSame(['FAILED TO VALIDATE'], $input->getMessages()->toArray());
     }
 
     public function testRequiredWithoutFallbackAndValueNotSetProvidesNotEmptyValidatorIsEmptyErrorMessage(): void
@@ -306,7 +314,7 @@ final class InputTest extends TestCase
             'isValid() should always return false when no fallback value is present, '
             . 'the input is required, and no data is set.',
         );
-        self::assertEquals($customMessage, $input->getMessages());
+        self::assertEquals($customMessage, $input->getMessages()->toArray());
     }
 
     public function testRequiredWithoutFallbackAndValueNotSetProvidesCustomErrorMessageWhenSet(): void
@@ -320,7 +328,7 @@ final class InputTest extends TestCase
             'isValid() should always return false when no fallback value is present, '
             . 'the input is required, and no data is set.',
         );
-        self::assertSame(['FAILED TO VALIDATE'], $input->getMessages());
+        self::assertSame(['FAILED TO VALIDATE'], $input->getMessages()->toArray());
     }
 
     public function testNotRequiredWithoutFallbackAndValueNotSetThenIsValid(): void
@@ -338,7 +346,11 @@ final class InputTest extends TestCase
             'isValid() should be return always true when is not required, and no data is set. Detail: '
             . json_encode($input->getMessages(), JSON_THROW_ON_ERROR),
         );
-        self::assertEquals([], $input->getMessages(), 'getMessages() should be empty because the input is valid');
+        self::assertEquals(
+            [],
+            $input->getMessages()->toArray(),
+            'getMessages() should be empty because the input is valid',
+        );
     }
 
     /**
@@ -432,7 +444,7 @@ final class InputTest extends TestCase
         self::assertCount(0, $validatorChain->getValidators());
 
         self::assertFalse($this->input->isValid());
-        $messages = $this->input->getMessages();
+        $messages = $this->input->getMessages()->toArray();
         self::assertArrayHasKey(self::EMPTY_ERROR_MESSAGE_KEY, $messages);
         self::assertCount(1, $validatorChain->getValidators());
 
@@ -507,7 +519,7 @@ final class InputTest extends TestCase
             $this->input->isValid(),
             'isValid() value not match. Detail: ' . json_encode($this->input->getMessages(), JSON_THROW_ON_ERROR),
         );
-        self::assertEquals($expectedMessages, $this->input->getMessages(), 'getMessages() value not match');
+        self::assertEquals($expectedMessages, $this->input->getMessages()->toArray(), 'getMessages() value not match');
         self::assertEquals($value, $this->input->getRawValue(), 'getRawValue() must return the value always');
         self::assertEquals($value, $this->input->getValue(), 'getValue() must return the filtered value always');
     }
@@ -813,7 +825,7 @@ final class InputTest extends TestCase
             ->willReturn($translatedMessage);
 
         self::assertFalse($this->input->isValid());
-        $messages = $this->input->getMessages();
+        $messages = $this->input->getMessages()->toArray();
         self::assertArrayHasKey(self::EMPTY_ERROR_MESSAGE_KEY, $messages);
         self::assertSame($translatedMessage, $messages[self::EMPTY_ERROR_MESSAGE_KEY]);
     }
@@ -852,7 +864,7 @@ final class InputTest extends TestCase
      */
     public static function setValueProvider(): array
     {
-        return array_merge(static::emptyValueProvider(), static::mixedValueProvider());
+        return array_merge(self::emptyValueProvider(), self::mixedValueProvider());
     }
 
     /**
@@ -868,8 +880,8 @@ final class InputTest extends TestCase
      */
     public static function isRequiredVsAllowEmptyVsContinueIfEmptyVsIsValidProvider(): array
     {
-        $allValues   = static::setValueProvider();
-        $emptyValues = static::emptyValueProvider();
+        $allValues   = self::setValueProvider();
+        $emptyValues = self::emptyValueProvider();
 
         $nonEmptyValues = array_diff_key($allValues, $emptyValues);
 

--- a/test/TestAsset/InputFilterInterfaceStub.php
+++ b/test/TestAsset/InputFilterInterfaceStub.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace LaminasTest\InputFilter\TestAsset;
 
+use Laminas\InputFilter\ErrorMessages;
 use Laminas\InputFilter\Factory;
 use Laminas\InputFilter\InputFilter;
 
+use function array_map;
 use function PHPUnit\Framework\assertNotNull;
 
 /**
@@ -50,8 +52,11 @@ final class InputFilterInterfaceStub extends InputFilter
     }
 
     /** @inheritDoc */
-    public function getMessages(): array
+    public function getMessages(): ErrorMessages
     {
-        return $this->getMessages;
+        return new ErrorMessages(array_map(
+            static fn (array $messages): ErrorMessages => new ErrorMessages($messages),
+            $this->getMessages,
+        ));
     }
 }

--- a/test/TestAsset/InputInterfaceStub.php
+++ b/test/TestAsset/InputInterfaceStub.php
@@ -6,6 +6,7 @@ namespace LaminasTest\InputFilter\TestAsset;
 
 use Exception;
 use Laminas\Filter\FilterChainInterface;
+use Laminas\InputFilter\ErrorMessages;
 use Laminas\InputFilter\InputInterface;
 use Laminas\Validator\ValidatorChainInterface;
 
@@ -133,9 +134,8 @@ final readonly class InputInterfaceStub implements InputInterface
         return $this->isValid;
     }
 
-    /** @return array<string, string> */
-    public function getMessages(): array
+    public function getMessages(): ErrorMessages
     {
-        return $this->getMessages;
+        return new ErrorMessages($this->getMessages);
     }
 }


### PR DESCRIPTION
The nested structure of error messages is difficult to manage and somewhat squishy…

Validators always return `array<string, string>`, but input filter error message arrays can be nested indefinitely - these types of recursive structures are a nightmare for static analysis and can easily be mutated unintentionally.

An object is easier to reason about, easier to process recursively in a type-safe way and easier to refactor and identify.

Additionally, we can get an accurate count of actual error messages instead of counting empty arrays - i.e. `count($inputFilter->getMessages())` will be zero, even if it contains an empty set of errors for each valid input.

Array access has been retained, so users will still be able to access the same error messages as the same indexes, regardless of how deeply nested the result is.

This type may also be useful in future for translation purposes