### PR TITLE
Feature Removal: Runtime mutation of filter chain and validator chain

### DIFF
--- a/src/Input.php
+++ b/src/Input.php
@@ -74,12 +74,6 @@ class Input implements
         return $this;
     }
 
-    public function setFilterChain(FilterChainInterface $filterChain): static
-    {
-        $this->filterChain = $filterChain;
-        return $this;
-    }
-
     public function setName(string|int $name): static
     {
         if ($name === '') {
@@ -93,12 +87,6 @@ class Input implements
     public function setRequired(bool $required): static
     {
         $this->required = $required;
-        return $this;
-    }
-
-    public function setValidatorChain(ValidatorChainInterface $validatorChain): static
-    {
-        $this->validatorChain = $validatorChain;
         return $this;
     }
 

--- a/src/InputInterface.php
+++ b/src/InputInterface.php
@@ -15,13 +15,9 @@ interface InputInterface
 
     public function setErrorMessage(string|null $errorMessage): static;
 
-    public function setFilterChain(FilterChainInterface $filterChain): static;
-
     public function setName(string|int $name): static;
 
     public function setRequired(bool $required): static;
-
-    public function setValidatorChain(ValidatorChainInterface $validatorChain): static;
 
     public function setValue(mixed $value): static;
 

--- a/test/ArrayInputTest.php
+++ b/test/ArrayInputTest.php
@@ -6,6 +6,7 @@ namespace LaminasTest\InputFilter;
 
 use Laminas\Filter\FilterChain;
 use Laminas\Filter\FilterChainInterface;
+use Laminas\Filter\StringTrim;
 use Laminas\Filter\ToInt;
 use Laminas\Filter\ToNull;
 use Laminas\InputFilter\ArrayInput;
@@ -17,6 +18,7 @@ use Laminas\Validator\AbstractValidator;
 use Laminas\Validator\IsArray;
 use Laminas\Validator\NotEmpty as NotEmptyValidator;
 use Laminas\Validator\NumberComparison;
+use Laminas\Validator\Regex;
 use Laminas\Validator\ValidatorChain;
 use Laminas\Validator\ValidatorChainInterface;
 use Laminas\Validator\ValidatorInterface;
@@ -48,7 +50,7 @@ final class ArrayInputTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->input = new ArrayInput(TestHelper::createFilterChain(), TestHelper::createValidatorChain(), 'foo');
+        $this->input = $this->createArrayInput('foo');
     }
 
     protected function tearDown(): void
@@ -56,9 +58,15 @@ final class ArrayInputTest extends TestCase
         AbstractValidator::setDefaultTranslator();
     }
 
-    private function createArrayInput(?string $name = null): ArrayInput
-    {
-        return new ArrayInput(TestHelper::createFilterChain(), TestHelper::createValidatorChain(), $name);
+    private function createArrayInput(
+        ?string $name = null,
+        ?FilterChainInterface $filterChain = null,
+        ?ValidatorChainInterface $validatorChain = null,
+    ): ArrayInput {
+        $filterChain    ??= TestHelper::createFilterChain();
+        $validatorChain ??= TestHelper::createValidatorChain();
+
+        return new ArrayInput($filterChain, $validatorChain, $name);
     }
 
     /**
@@ -315,22 +323,6 @@ final class ArrayInputTest extends TestCase
         self::assertCount(0, $validators);
     }
 
-    public function testCanInjectFilterChain(): void
-    {
-        $filterChain = TestHelper::createFilterChain();
-
-        $this->input->setFilterChain($filterChain);
-        self::assertSame($filterChain, $this->input->getFilterChain());
-    }
-
-    public function testCanInjectValidatorChain(): void
-    {
-        $validatorChain = new ValidatorChain();
-
-        $this->input->setValidatorChain($validatorChain);
-        self::assertSame($validatorChain, $this->input->getValidatorChain());
-    }
-
     public function testInputIsMarkedAsRequiredByDefault(): void
     {
         self::assertTrue($this->input->isRequired());
@@ -407,11 +399,14 @@ final class ArrayInputTest extends TestCase
         bool $isValid,
         array $expectedValue,
     ): void {
-        $input = $this->input;
-        $input->setContinueIfEmpty(true);
+        $input = $this->createArrayInput(
+            'foo',
+            null,
+            TestHelper::createValidatorChain($originalValue[0], $isValid),
+        );
 
+        $input->setContinueIfEmpty(true);
         $input->setRequired($required);
-        $input->setValidatorChain(TestHelper::createValidatorChain($originalValue[0], $isValid));
         $input->setFallbackValue($fallbackValue);
         $input->setValue($originalValue);
 
@@ -441,7 +436,6 @@ final class ArrayInputTest extends TestCase
         $input->setContinueIfEmpty(true);
 
         $input->setRequired($required);
-        $input->setValidatorChain(new ValidatorChain());
         $input->setFallbackValue($fallbackValue);
 
         self::assertTrue(
@@ -575,41 +569,41 @@ final class ArrayInputTest extends TestCase
 
     public function testRetrievingValueFiltersTheValue(): void
     {
-        $valueRaw      = ['foo'];
-        $valueFiltered = ['filtered'];
+        $filterChain = TestHelper::createFilterChain();
+        $filterChain->attachByName(StringTrim::class);
 
-        $filterChain = TestHelper::createFilterChainFixture($valueRaw[0], $valueFiltered[0]);
+        $input = $this->createArrayInput('foo', $filterChain, TestHelper::createValidatorChain());
+        $input->setValue(['  foo  ']);
 
-        $this->input->setFilterChain($filterChain);
-        $this->input->setValue($valueRaw);
-
-        self::assertSame($valueFiltered, $this->input->getValue());
+        self::assertSame(['foo'], $input->getValue());
     }
 
     public function testCanRetrieveRawValue(): void
     {
-        $valueRaw = 'foo';
+        $filterChain = TestHelper::createFilterChain();
+        $filterChain->attachByName(StringTrim::class);
 
-        $this->input->setFilterChain(TestHelper::createFilterChain());
-        $this->input->setValue($valueRaw);
+        $input = $this->createArrayInput('foo', $filterChain, TestHelper::createValidatorChain());
+        $input->setValue(['  foo  ']);
 
-        self::assertEquals($valueRaw, $this->input->getRawValue());
+        self::assertSame(['  foo  '], $input->getRawValue());
     }
 
     public function testValidationOperatesOnFilteredValue(): void
     {
-        $valueRaw      = ['foo'];
-        $valueFiltered = ['filtered'];
+        $filterChain = TestHelper::createFilterChain();
+        $filterChain->attachByName(StringTrim::class);
 
-        $filterChain = TestHelper::createFilterChainFixture($valueRaw[0], $valueFiltered[0]);
+        $validatorChain = TestHelper::createValidatorChain();
+        $validatorChain->attachByName(Regex::class, [
+            'pattern' => '/^[a-z]+$/',
+        ]);
 
-        $this->input->setAllowEmpty(true);
-        $this->input->setFilterChain($filterChain);
-        $this->input->setValidatorChain(TestHelper::createValidatorChain($valueFiltered[0], true));
-        $this->input->setValue($valueRaw);
+        $input = $this->createArrayInput('foo', $filterChain, TestHelper::createValidatorChain());
+        $input->setValue(['  foo  ']);
 
         self::assertTrue(
-            $this->input->isValid(),
+            $input->isValid(),
             'isValid() value not match. Detail . ' . json_encode($this->input->getMessages(), JSON_THROW_ON_ERROR),
         );
     }
@@ -906,21 +900,22 @@ final class ArrayInputTest extends TestCase
     public function testMerge(): void
     {
         $source = $this->createMock(InputInterface::class);
-        $source->method('getName')->willReturn('bazInput');
-        $source->method('getErrorMessage')->willReturn('bazErrorMessage');
-        $source->method('breakOnFailure')->willReturn(true);
-        $source->method('isRequired')->willReturn(true);
-        $source->method('getRawValue')->willReturn('foo');
-        $source->method('getFilterChain')->willReturn(TestHelper::createFilterChain());
-        $source->method('getValidatorChain')->willReturn(new ValidatorChain());
+        $source->expects($this->once())->method('getName')->willReturn('bazInput');
+        $source->expects($this->once())->method('getErrorMessage')->willReturn('bazErrorMessage');
+        $source->expects($this->once())->method('breakOnFailure')->willReturn(true);
+        $source->expects($this->once())->method('isRequired')->willReturn(true);
+        $source->expects($this->once())->method('getRawValue')->willReturn('foo');
+        $source->expects($this->once())->method('getFilterChain')->willReturn(TestHelper::createFilterChain());
+        $source->expects($this->once())->method('getValidatorChain')->willReturn(new ValidatorChain());
 
-        $target = $this->input;
-        $target->setName('fooInput');
+        $target = $this->createArrayInput(
+            'fooInput',
+            TestHelper::createFilterChain(),
+            TestHelper::createValidatorChain(),
+        );
         $target->setErrorMessage('fooErrorMessage');
         $target->setBreakOnFailure(false);
         $target->setRequired(false);
-        $target->setFilterChain(TestHelper::createFilterChain());
-        $target->setValidatorChain(new ValidatorChain());
 
         $return = $target->merge($source);
         self::assertSame($target, $return, 'merge() must return it self');

--- a/test/FileInput/FileInputTest.php
+++ b/test/FileInput/FileInputTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace LaminasTest\InputFilter\FileInput;
 
 use Laminas\Filter\FilterChain;
+use Laminas\Filter\FilterChainInterface;
 use Laminas\Filter\ToInt;
 use Laminas\Filter\ToNull;
 use Laminas\InputFilter\FileInput;
@@ -55,8 +56,6 @@ final class FileInputTest extends TestCase
     protected function setUp(): void
     {
         $this->input = $this->createFileInput('foo');
-        // Upload validator does not work in CLI test environment, disable
-        $this->input->setAutoPrependUploadValidator(false);
     }
 
     protected function tearDown(): void
@@ -64,73 +63,90 @@ final class FileInputTest extends TestCase
         AbstractValidator::setDefaultTranslator();
     }
 
-    private function createFileInput(?string $name = null): FileInput
-    {
-        return new FileInput(TestHelper::createFilterChain(), TestHelper::createValidatorChain(), $name);
+    private function createFileInput(
+        ?string $name = null,
+        ?FilterChainInterface $filterChain = null,
+        ?Validator\ValidatorChainInterface $validatorChain = null,
+    ): FileInput {
+        $filterChain    ??= TestHelper::createFilterChain();
+        $validatorChain ??= TestHelper::createValidatorChain();
+
+        $input = new FileInput($filterChain, $validatorChain, $name);
+        // Upload validator does not work in CLI test environment, disable
+        $input->setAutoPrependUploadValidator(false);
+
+        return $input;
     }
 
     #[DataProvider('validSingleValueProvider')]
     public function testRetrievingValueFiltersTheValueOnlyAfterValidating(mixed $raw, mixed $filtered): void
     {
-        $this->input->setValue($raw);
-        $this->input->setFilterChain(TestHelper::createFilterChainFixture($raw, $filtered));
-
-        self::assertEquals($raw, $this->input->getValue());
-        self::assertTrue(
-            $this->input->isValid(),
-            'isValid() value not match. Detail . ' . json_encode($this->input->getMessages(), JSON_THROW_ON_ERROR)
+        $input = $this->createFileInput(
+            'foo',
+            TestHelper::createFilterChainFixture($raw, $filtered),
         );
-        self::assertEquals($filtered, $this->input->getValue());
+        $input->setValue($raw);
+
+        self::assertEquals($raw, $input->getValue());
+        self::assertTrue(
+            $input->isValid(),
+            'isValid() value not match. Detail . ' . json_encode($input->getMessages(), JSON_THROW_ON_ERROR)
+        );
+        self::assertEquals($filtered, $input->getValue());
     }
 
     #[DAtaProvider('validMultiValueProvider')]
     public function testCanFilterArrayOfMultiFileData(array $raw, array $filtered): void
     {
-        $this->input->resetValue();
-        $this->input->setValue($raw);
-
         $map = [];
         for ($i = 0; $i < count($filtered); $i += 1) {
             $map[] = [$raw[$i], $filtered[$i]];
         }
 
-        $this->input->setFilterChain(TestHelper::createFilterChainFixtureFromMap($map));
+        $input = $this->createFileInput('foo', TestHelper::createFilterChainFixtureFromMap($map));
+        $input->setValue($raw);
 
-        self::assertEquals($raw, $this->input->getValue());
+        self::assertEquals($raw, $input->getValue());
         self::assertTrue(
-            $this->input->isValid(),
-            'isValid() value not match. Detail . ' . json_encode($this->input->getMessages(), JSON_THROW_ON_ERROR)
+            $input->isValid(),
+            'isValid() value not match. Detail . ' . json_encode($input->getMessages(), JSON_THROW_ON_ERROR)
         );
         self::assertEquals(
             $filtered,
-            $this->input->getValue()
+            $input->getValue()
         );
     }
 
     #[DataProvider('validSingleValueProvider')]
     public function testCanRetrieveRawValue(mixed $raw, mixed $filtered): void
     {
-        $this->input->setValue($raw);
-        $this->input->setFilterChain(TestHelper::createFilterChainFixture($raw, $filtered));
+        $input = $this->createFileInput(
+            'foo',
+            TestHelper::createFilterChainFixture($raw, $filtered),
+        );
+        $input->setValue($raw);
 
-        self::assertEquals($raw, $this->input->getRawValue());
+        self::assertEquals($raw, $input->getRawValue());
     }
 
     #[DataProvider('invalidSingleValueProvider')]
     public function testValidationOperatesBeforeFiltering(mixed $raw, mixed $filtered): void
     {
-        $this->input->setValue($raw);
+        $input = $this->createFileInput(
+            'foo',
+            TestHelper::createFilterChainFixture($raw, $filtered),
+            TestHelper::createValidatorChain($raw, false),
+        );
 
-        $this->input->setFilterChain(TestHelper::createFilterChainFixture($raw, $filtered));
-        $this->input->setValidatorChain(TestHelper::createValidatorChain($raw, false));
+        $input->setValue($raw);
 
-        self::assertFalse($this->input->isValid());
-        self::assertEquals($raw, $this->input->getValue());
+        self::assertFalse($input->isValid());
+        self::assertEquals($raw, $input->getValue());
     }
 
     public function testAutoPrependUploadValidatorIsOnByDefault(): void
     {
-        $input = $this->createFileInput('foo');
+        $input = new FileInput(TestHelper::createFilterChain(), TestHelper::createValidatorChain());
         self::assertTrue($input->getAutoPrependUploadValidator());
     }
 
@@ -197,11 +213,6 @@ final class FileInputTest extends TestCase
 
     public function testValidationsRunWithoutFileArrayDueToAjaxPost(): void
     {
-        $this->input->setAutoPrependUploadValidator(true);
-        self::assertTrue($this->input->getAutoPrependUploadValidator());
-        self::assertTrue($this->input->isRequired());
-        $this->input->setValue([]);
-
         $expectedNormalizedValue = [
             'tmp_name' => '',
             'name'     => '',
@@ -209,16 +220,22 @@ final class FileInputTest extends TestCase
             'type'     => '',
             'error'    => UPLOAD_ERR_NO_FILE,
         ];
-        $this->input->setValidatorChain(TestHelper::createValidatorChain($expectedNormalizedValue, false));
+
+        $input = $this->createFileInput(
+            'foo',
+            null,
+            TestHelper::createValidatorChain($expectedNormalizedValue, false),
+        );
+
+        $input->setAutoPrependUploadValidator(true);
+        self::assertTrue($input->getAutoPrependUploadValidator());
+        self::assertTrue($input->isRequired());
+        $input->setValue([]);
         self::assertFalse($this->input->isValid());
     }
 
     public function testValidationsRunWithoutFileArrayIsSend(): void
     {
-        $this->input->setAutoPrependUploadValidator(true);
-        self::assertTrue($this->input->getAutoPrependUploadValidator());
-        self::assertTrue($this->input->isRequired());
-        $this->input->setValue([]);
         $expectedNormalizedValue = [
             'tmp_name' => '',
             'name'     => '',
@@ -226,8 +243,18 @@ final class FileInputTest extends TestCase
             'type'     => '',
             'error'    => UPLOAD_ERR_NO_FILE,
         ];
-        $this->input->setValidatorChain(TestHelper::createValidatorChain($expectedNormalizedValue, false));
-        self::assertFalse($this->input->isValid());
+
+        $input = $this->createFileInput(
+            'foo',
+            null,
+            TestHelper::createValidatorChain($expectedNormalizedValue, false),
+        );
+
+        $input->setAutoPrependUploadValidator(true);
+        self::assertTrue($input->getAutoPrependUploadValidator());
+        self::assertTrue($input->isRequired());
+        $input->setValue([]);
+        self::assertFalse($input->isValid());
     }
 
     #[DataProvider('isEmptyProvider')]
@@ -304,20 +331,6 @@ final class FileInputTest extends TestCase
         $validators = $this->input->getValidatorChain();
         self::assertInstanceOf(ValidatorChain::class, $validators);
         self::assertCount(0, $validators);
-    }
-
-    public function testCanInjectFilterChain(): void
-    {
-        $chain = TestHelper::createFilterChain();
-        $this->input->setFilterChain($chain);
-        self::assertSame($chain, $this->input->getFilterChain());
-    }
-
-    public function testCanInjectValidatorChain(): void
-    {
-        $chain = new ValidatorChain();
-        $this->input->setValidatorChain($chain);
-        self::assertSame($chain, $this->input->getValidatorChain());
     }
 
     public function testInputIsMarkedAsRequiredByDefault(): void
@@ -517,16 +530,15 @@ final class FileInputTest extends TestCase
     public function testDoNotInjectNotEmptyValidator(mixed $raw, mixed $filtered): void
     {
         $filterChain    = TestHelper::createFilterChainFixture($raw, $filtered);
-        $validatorChain = $this->input->getValidatorChain();
-        self::assertInstanceOf(ValidatorChain::class, $validatorChain);
+        $validatorChain = TestHelper::createValidatorChain();
 
-        $this->input->setRequired(true);
-        $this->input->setFilterChain($filterChain);
-        $this->input->setValue($raw);
+        $input = $this->createFileInput('foo', $filterChain, $validatorChain);
+
+        $input->setValue($raw);
 
         $validatorChain->attach(TestHelper::createValidatorMock(true));
 
-        self::assertTrue($this->input->isValid());
+        self::assertTrue($input->isValid());
 
         self::assertCount(1, $validatorChain);
     }
@@ -742,13 +754,15 @@ final class FileInputTest extends TestCase
         $source->method('getFilterChain')->willReturn(TestHelper::createFilterChain());
         $source->method('getValidatorChain')->willReturn(new ValidatorChain());
 
-        $target = $this->input;
+        $target = $this->createFileInput(
+            'fooInput',
+            TestHelper::createFilterChain(),
+            TestHelper::createValidatorChain(),
+        );
         $target->setName('fooInput');
         $target->setErrorMessage('fooErrorMessage');
         $target->setBreakOnFailure(false);
         $target->setRequired(false);
-        $target->setFilterChain(TestHelper::createFilterChain());
-        $target->setValidatorChain(new ValidatorChain());
 
         $return = $target->merge($source);
         self::assertSame($target, $return, 'merge() must return it self');

--- a/test/InputTest.php
+++ b/test/InputTest.php
@@ -52,9 +52,15 @@ final class InputTest extends TestCase
         AbstractValidator::setDefaultTranslator(null);
     }
 
-    private function createInput(?string $name = null): Input
-    {
-        return new Input(TestHelper::createFilterChain(), TestHelper::createValidatorChain(), $name);
+    private function createInput(
+        ?string $name = null,
+        ?FilterChainInterface $filterChain = null,
+        ?ValidatorChainInterface $validatorChain = null,
+    ): Input {
+        $filterChain    ??= TestHelper::createFilterChain();
+        $validatorChain ??= TestHelper::createValidatorChain();
+
+        return new Input($filterChain, $validatorChain, $name);
     }
 
     public function assertRequiredValidationErrorMessage(Input $input, string $message = ''): void
@@ -125,20 +131,6 @@ final class InputTest extends TestCase
         $validators = $this->input->getValidatorChain();
         self::assertInstanceOf(ValidatorChain::class, $validators);
         self::assertCount(0, $validators);
-    }
-
-    public function testCanInjectFilterChain(): void
-    {
-        $chain = TestHelper::createFilterChain();
-        $this->input->setFilterChain($chain);
-        self::assertSame($chain, $this->input->getFilterChain());
-    }
-
-    public function testCanInjectValidatorChain(): void
-    {
-        $chain = new ValidatorChain();
-        $this->input->setValidatorChain($chain);
-        self::assertSame($chain, $this->input->getValidatorChain());
     }
 
     public function testInputIsMarkedAsRequiredByDefault(): void
@@ -212,11 +204,13 @@ final class InputTest extends TestCase
         bool $isValid,
         string $expectedValue,
     ): void {
-        $input = $this->input;
+        $input = $this->createInput(
+            'foo',
+            null,
+            TestHelper::createValidatorChain($originalValue, $isValid),
+        );
         $input->setContinueIfEmpty(true);
-
         $input->setRequired($required);
-        $input->setValidatorChain(TestHelper::createValidatorChain($originalValue, $isValid));
         $input->setFallbackValue($fallbackValue);
         $input->setValue($originalValue);
 
@@ -243,7 +237,6 @@ final class InputTest extends TestCase
         $input->setContinueIfEmpty(true);
 
         $input->setRequired($required);
-        $input->setValidatorChain(new ValidatorChain());
         $input->setFallbackValue($fallbackValue);
 
         self::assertTrue(
@@ -386,18 +379,15 @@ final class InputTest extends TestCase
         $valueFiltered = 'filtered';
 
         $filterChain = TestHelper::createFilterChainFixture($valueRaw, $valueFiltered);
+        $input       = $this->createInput('foo', $filterChain);
+        $input->setValue($valueRaw);
 
-        $this->input->setFilterChain($filterChain);
-        $this->input->setValue($valueRaw);
-
-        self::assertSame($valueFiltered, $this->input->getValue());
+        self::assertSame($valueFiltered, $input->getValue());
     }
 
     public function testCanRetrieveRawValue(): void
     {
         $valueRaw = 'foo';
-
-        $this->input->setFilterChain(TestHelper::createFilterChain());
         $this->input->setValue($valueRaw);
 
         self::assertEquals($valueRaw, $this->input->getRawValue());
@@ -408,15 +398,16 @@ final class InputTest extends TestCase
         $valueRaw      = 'foo';
         $valueFiltered = 'filtered';
 
-        $filterChain = TestHelper::createFilterChainFixture($valueRaw, $valueFiltered);
+        $input = $this->createInput(
+            'foo',
+            TestHelper::createFilterChainFixture($valueRaw, $valueFiltered),
+            TestHelper::createValidatorChain($valueFiltered, true)
+        );
 
-        $this->input->setAllowEmpty(true);
-        $this->input->setFilterChain($filterChain);
-        $this->input->setValidatorChain(TestHelper::createValidatorChain($valueFiltered, true));
-        $this->input->setValue($valueRaw);
+        $input->setValue($valueRaw);
 
         self::assertTrue(
-            $this->input->isValid(),
+            $input->isValid(),
             'isValid() value not match. Detail . ' . json_encode($this->input->getMessages(), JSON_THROW_ON_ERROR),
         );
     }
@@ -729,16 +720,11 @@ final class InputTest extends TestCase
         $source->method('getFilterChain')->willReturn(TestHelper::createFilterChain());
         $source->method('getValidatorChain')->willReturn(new ValidatorChain());
 
-        $targetFilterChain    = TestHelper::createFilterChain();
-        $targetValidatorChain = new ValidatorChain();
-
         $target = $this->input;
         $target->setName('fooInput');
         $target->setErrorMessage('fooErrorMessage');
         $target->setBreakOnFailure(false);
         $target->setRequired(false);
-        $target->setFilterChain($targetFilterChain);
-        $target->setValidatorChain($targetValidatorChain);
 
         $return = $target->merge($source);
         self::assertSame($target, $return, 'merge() must return it self');
@@ -1074,14 +1060,6 @@ final class InputTest extends TestCase
         self::assertSame(
             $this->input,
             $this->input->setValue('muppet'),
-        );
-        self::assertSame(
-            $this->input,
-            $this->input->setFilterChain(TestHelper::createFilterChain()),
-        );
-        self::assertSame(
-            $this->input,
-            $this->input->setValidatorChain(TestHelper::createValidatorChain()),
         );
     }
 }

--- a/test/TestAsset/InputInterfaceStub.php
+++ b/test/TestAsset/InputInterfaceStub.php
@@ -5,10 +5,8 @@ declare(strict_types=1);
 namespace LaminasTest\InputFilter\TestAsset;
 
 use Exception;
-use Laminas\Filter\FilterChainInterface;
 use Laminas\InputFilter\ErrorMessages;
 use Laminas\InputFilter\InputInterface;
-use Laminas\Validator\ValidatorChainInterface;
 
 use function func_get_arg;
 use function func_num_args;
@@ -45,22 +43,12 @@ final readonly class InputInterfaceStub implements InputInterface
         return $this;
     }
 
-    public function setFilterChain(FilterChainInterface $filterChain): never
-    {
-        throw new Exception('Not implemented');
-    }
-
     public function setName(string|int $name): never
     {
         throw new Exception('Not implemented');
     }
 
     public function setRequired(bool $required): never
-    {
-        throw new Exception('Not implemented');
-    }
-
-    public function setValidatorChain(ValidatorChainInterface $validatorChain): never
     {
         throw new Exception('Not implemented');
     }


### PR DESCRIPTION
Now that the filter chain and validator chain are constructor dependencies, setters are no longer necessary, so the following methods have been removed from all implementations of `InputInterface`

- `setFilterChain()`
- `setValidatorChain()`

