### PR TITLE
Make the `Input` name a constructor dependency

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -67,13 +67,6 @@
       <code><![CDATA[$rawValue]]></code>
     </MoreSpecificImplementedParamType>
   </file>
-  <file src="src/Input.php">
-    <LessSpecificReturnStatement>
-      <code><![CDATA[$this]]></code>
-      <code><![CDATA[$this]]></code>
-      <code><![CDATA[$this]]></code>
-    </LessSpecificReturnStatement>
-  </file>
   <file src="src/InputFilterAbstractServiceFactory.php">
     <MixedArgument>
       <code><![CDATA[$config]]></code>
@@ -118,7 +111,6 @@
     </MixedArgument>
     <MixedArgumentTypeCoercion>
       <code><![CDATA[$getMessages]]></code>
-      <code><![CDATA[$msg]]></code>
       <code><![CDATA[$msg]]></code>
     </MixedArgumentTypeCoercion>
     <MixedArrayAssignment>

--- a/src/BaseInputFilter.php
+++ b/src/BaseInputFilter.php
@@ -78,13 +78,37 @@ class BaseInputFilter implements
         return count($this->inputs);
     }
 
+    private function fromArray(
+        array $spec,
+        string|int|null $name,
+    ): InputInterface|InputFilterInterface {
+        if (! $this->factory->isInputSpecification($spec)) {
+            return $this->factory->createInputFilter($spec);
+        }
+
+        /**
+         * The name in the specification array takes precedence over the argument
+         */
+        $name = isset($spec['name']) && is_string($spec['name']) && $spec['name'] !== ''
+            ? $spec['name']
+            : $name;
+
+        if ($name === null || $name === '') {
+            throw new InvalidArgumentException('All inputs must have a non-empty-string or integer name');
+        }
+
+        $spec['name'] = $name;
+
+        return $this->factory->createInput($spec);
+    }
+
     /** @inheritDoc */
     public function add(
         InputInterface|InputFilterInterface|array $input,
         string|int|null $name = null,
     ): static {
         if (is_array($input)) {
-            $input = $this->factory->create($input);
+            $input = $this->fromArray($input, $name);
         }
 
         if ($input instanceof InputInterface && ($name === null || $name === '' || is_int($name))) {

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -10,6 +10,8 @@ use Laminas\Filter\FilterInterface;
 use Laminas\Filter\FilterPluginManager;
 use Laminas\InputFilter\Exception\InvalidArgumentException;
 use Laminas\InputFilter\Exception\RuntimeException;
+use Laminas\ServiceManager\Exception\ExceptionInterface as AnyPluginManagerException;
+use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\ServiceManager;
 use Laminas\Stdlib\ArrayUtils;
 use Laminas\Validator\ValidatorChain;
@@ -19,7 +21,6 @@ use Psr\Container\ContainerInterface;
 use Traversable;
 
 use function assert;
-use function class_exists;
 use function get_debug_type;
 use function in_array;
 use function is_a;
@@ -35,6 +36,7 @@ use function sprintf;
  * @psalm-import-type ValidatorSpecification from ValidatorChain
  * @psalm-import-type InputFilterSpecification from InputFilterInterface
  * @psalm-import-type CollectionSpecification from InputFilterInterface
+ * @psalm-type BuiltInInputType = class-string<Input>|class-string<ArrayInput>|class-string<FileInput>
  */
 final readonly class Factory
 {
@@ -73,23 +75,6 @@ final readonly class Factory
     }
 
     /**
-     * @param class-string $class
-     * @psalm-assert-if-true class-string<Input>|class-string<ArrayInput>|class-string<FileInput> $class
-     */
-    private function canCreateInputType(string $class): bool
-    {
-        return in_array(
-            $class,
-            [
-                Input::class,
-                ArrayInput::class,
-                FileInput::class,
-            ],
-            true,
-        );
-    }
-
-    /**
      * @param InputSpecification $spec
      * @return array{
      *     filterChain: FilterChainInterface,
@@ -105,6 +90,13 @@ final readonly class Factory
         if (! is_array($filters) && ! is_callable($filters) && ! $filters instanceof FilterInterface) {
             throw new InvalidArgumentException("filters must be an array, callable, or FilterInterface. Received: "
                 . get_debug_type($filters));
+        }
+
+        if (! is_array($validators) && ! $validators instanceof ValidatorChainInterface) {
+            throw new InvalidArgumentException(sprintf(
+                'The `validators` key must be an array or a ValidatorInterface. Received: %s',
+                get_debug_type($spec['validators'] ?? null),
+            ));
         }
 
         if (is_array($filters)) {
@@ -140,46 +132,10 @@ final readonly class Factory
 
         $class = $spec['type'] ?? Input::class;
 
-        /** @var mixed|null $customInput */
-        $customInput = $this->inputFilterPluginManager->has($class)
-            ? $this->inputFilterPluginManager->get($class)
-            : null;
-
-        if ($customInput === null && ! class_exists($class)) {
-            throw new RuntimeException(sprintf(
-                'Input factory expects the "type" to be a valid class or a plugin name; received "%s"',
-                $class,
-            ));
-        }
-
-        if ($customInput === null && ! $this->canCreateInputType($class)) {
-            throw new RuntimeException(sprintf(
-                'Only internal input types "Input", "ArrayInput" and "FileInput" can be created by the factory. '
-                . 'You will need to create your own factory for custom inputs because we cannot know what your '
-                . 'constructor arguments might be. Received the type: "%s"',
-                $class,
-            ));
-        }
-
-        if ($customInput === null) {
-            [
-                'filterChain'    => $filterChain,
-                'validatorChain' => $validatorChain,
-            ] = $this->buildChainsFromSpecification($spec);
-
-            /** @psalm-suppress UnsafeInstantiation */
-            $input = new $class($filterChain, $validatorChain);
+        if (! $this->isInternalInputType($class)) {
+            $input = $this->createCustomInput($class, $spec);
         } else {
-            /** @var mixed $input */
-            $input = $customInput;
-        }
-
-        if (! $input instanceof InputInterface) {
-            throw new RuntimeException(sprintf(
-                'Input factory expects the "type" to be a class implementing %s; received "%s"',
-                InputInterface::class,
-                get_debug_type($input),
-            ));
+            $input = $this->createBuiltInInput($class, $spec);
         }
 
         $this->applyInputOptions($input, $spec);
@@ -190,10 +146,6 @@ final readonly class Factory
     /** @param InputSpecification $spec */
     private function applyInputOptions(InputInterface $input, array $spec): void
     {
-        if (isset($spec['name'])) {
-            $input->setName($spec['name']);
-        }
-
         if (isset($spec['required'])) {
             $input->setRequired($spec['required']);
         }
@@ -223,9 +175,13 @@ final readonly class Factory
     }
 
     /**
+     * @internal
+     *
+     * @psalm-internal Laminas\InputFilter
+     * @psalm-internal LaminasTest\InputFilter
      * @psalm-assert-if-true InputSpecification $spec
      */
-    private function isInputSpecification(array $spec): bool
+    public function isInputSpecification(array $spec): bool
     {
         /** @var mixed $type */
         $type = $spec['type'] ?? null;
@@ -268,6 +224,12 @@ final readonly class Factory
         /** @psalm-var InputFilterSpecification $spec */
 
         return $this->createInputFilter($spec);
+    }
+
+    /** @psalm-assert-if-true BuiltInInputType $type */
+    private function isInternalInputType(string $type): bool
+    {
+        return in_array($type, [Input::class, ArrayInput::class, FileInput::class], true);
     }
 
     /**
@@ -366,5 +328,82 @@ final readonly class Factory
     public function getValidatorPluginManager(): ValidatorPluginManager
     {
         return $this->validatorPluginManager;
+    }
+
+    /**
+     * Create a user-defined input type from an array specification
+     *
+     * @param InputSpecification $spec
+     * @throws RuntimeException If the input cannot be instantiated (Built or retreived from the plugin manager).
+     */
+    private function createCustomInput(string $class, array $spec): InputInterface
+    {
+        if (! $this->inputFilterPluginManager->has($class)) {
+            throw new RuntimeException(sprintf(
+                'The input type "%s" cannot be created because it is not known in the Input Filter Plugin Manager. '
+                . 'Make sure you have registered a factory for the custom input type under `input_filters.factories`',
+                $class,
+            ));
+        }
+
+        $input    = null;
+        $previous = null;
+        try {
+            /** @psalm-var mixed $input */
+            $input = $this->inputFilterPluginManager->build($class, $spec);
+        } catch (AnyPluginManagerException $e) {
+            $previous = $e;
+        }
+
+        // Build failed - attempt get
+        if ($input === null) {
+            try {
+                /** @psalm-var mixed $input */
+                $input = $this->inputFilterPluginManager->get($class);
+            } catch (ServiceNotFoundException $e) {
+                $previous = $e;
+            }
+        }
+
+        if ($input === null) {
+            throw new RuntimeException(sprintf(
+                'The input type "%s" could neither be built, nor fetched from the plugin manager. '
+                . 'Make sure you have registered a factory for the input type under `input_filters.factories`',
+                $class,
+            ), 0, $previous);
+        }
+
+        if (! $input instanceof InputInterface) {
+            throw new RuntimeException(sprintf(
+                'The input type "%s" resolved to an instance of "%s", but it should resolve to an instance of "%s"',
+                $class,
+                get_debug_type($input),
+                InputInterface::class,
+            ), 0, $previous);
+        }
+
+        return $input;
+    }
+
+    /**
+     * @param BuiltInInputType $class
+     * @param InputSpecification $spec
+     */
+    private function createBuiltInInput(string $class, array $spec): InputInterface
+    {
+        $name = $spec['name'] ?? null;
+        if ((! is_string($name) && ! is_int($name)) || $name === '') {
+            throw new RuntimeException(
+                'The input name must be known in advance. Ensure you set the input name in the specification under '
+                . 'the `name` key',
+            );
+        }
+
+        [
+            'filterChain'    => $filterChain,
+            'validatorChain' => $validatorChain,
+        ] = $this->buildChainsFromSpecification($spec);
+
+        return new $class($filterChain, $validatorChain, $name);
     }
 }

--- a/src/Input.php
+++ b/src/Input.php
@@ -14,14 +14,17 @@ use Laminas\Validator\ValidatorChainInterface;
 
 use function assert;
 use function class_exists;
+use function get_debug_type;
 use function is_array;
+use function is_int;
+use function is_string;
 use function reset;
+use function sprintf;
 
 class Input implements
     InputInterface,
     EmptyContextInterface
 {
-    protected string|int|null $name = null;
     protected bool $allowEmpty      = false;
     protected bool $continueIfEmpty = false;
     protected bool $breakOnFailure  = false;
@@ -40,14 +43,13 @@ class Input implements
     protected mixed $fallbackValue;
     protected bool $hasFallback = false;
 
-    public function __construct(
+    /** @param non-empty-string|int $name */
+    final public function __construct(
         protected FilterChainInterface $filterChain,
         protected ValidatorChainInterface $validatorChain,
-        string|int|null $name = null
+        protected string|int $name,
     ) {
-        if ($name !== null) {
-            $this->setName($name);
-        }
+        $this->assertValidName($name);
     }
 
     public function setAllowEmpty(bool $allowEmpty): static
@@ -74,11 +76,26 @@ class Input implements
         return $this;
     }
 
+    /** @psalm-assert non-empty-string|int $name */
+    private function assertValidName(mixed $name): void
+    {
+        if ((is_string($name) && $name !== '') || is_int($name)) {
+            return;
+        }
+
+        $type = is_string($name)
+            ? 'an empty string'
+            : get_debug_type($name);
+
+        throw new InvalidArgumentException(sprintf(
+            'Input names must be integers or non-empty-string. Received %s',
+            $type,
+        ));
+    }
+
     public function setName(string|int $name): static
     {
-        if ($name === '') {
-            throw new InvalidArgumentException('Input names cannot be an empty string');
-        }
+        $this->assertValidName($name);
 
         $this->name = $name;
         return $this;
@@ -160,7 +177,7 @@ class Input implements
         return $this->filterChain;
     }
 
-    public function getName(): int|string|null
+    public function getName(): int|string
     {
         return $this->name;
     }
@@ -226,11 +243,8 @@ class Input implements
         if ($input instanceof Input) {
             $this->setContinueIfEmpty($input->continueIfEmpty());
         }
+        $this->setName($input->getName());
         $this->setErrorMessage($input->getErrorMessage());
-        $name = $input->getName();
-        if ($name !== null) {
-            $this->setName($name);
-        }
         $this->setRequired($input->isRequired());
         $this->setAllowEmpty($input->allowEmpty());
         if (! $input instanceof Input || $input->hasValue()) {

--- a/src/InputInterface.php
+++ b/src/InputInterface.php
@@ -15,6 +15,7 @@ interface InputInterface
 
     public function setErrorMessage(string|null $errorMessage): static;
 
+    /** @param non-empty-string|int $name */
     public function setName(string|int $name): static;
 
     public function setRequired(bool $required): static;
@@ -31,7 +32,8 @@ interface InputInterface
 
     public function getFilterChain(): FilterChainInterface;
 
-    public function getName(): int|string|null;
+    /** @return non-empty-string|int */
+    public function getName(): int|string;
 
     public function getRawValue(): mixed;
 

--- a/test/ArrayInputTest.php
+++ b/test/ArrayInputTest.php
@@ -58,8 +58,9 @@ final class ArrayInputTest extends TestCase
         AbstractValidator::setDefaultTranslator();
     }
 
+    /** @param non-empty-string $name */
     private function createArrayInput(
-        ?string $name = null,
+        string $name = 'foo',
         ?FilterChainInterface $filterChain = null,
         ?ValidatorChainInterface $validatorChain = null,
     ): ArrayInput {

--- a/test/BaseInputFilterTest.php
+++ b/test/BaseInputFilterTest.php
@@ -28,6 +28,7 @@ use stdClass;
 use function array_keys;
 use function array_merge;
 use function array_walk;
+use function assert;
 use function in_array;
 use function json_encode;
 use function sprintf;
@@ -51,7 +52,8 @@ final class BaseInputFilterTest extends TestCase
         $this->inputFilter = new BaseInputFilter($this->factory);
     }
 
-    private function createInput(?string $name = null): Input
+    /** @param non-empty-string $name */
+    private function createInput(string $name = 'foo'): Input
     {
         return new Input(TestHelper::createFilterChain(), TestHelper::createValidatorChain(), $name);
     }
@@ -455,12 +457,19 @@ final class BaseInputFilterTest extends TestCase
         $valid    = true;
         $bOnFail  = true;
 
-        /**
-         * @param array<string, string> $msg
-         * @return callable(): InputInterface
-         */
-        $input = fn(string $iName, bool $required, bool $bOnFail, bool $isValid, array $msg = []): callable =>
-            fn(array|null|string $context): InputInterface => self::createInputInterfaceMock(
+        $input = function (
+            string $iName,
+            bool $required,
+            bool $bOnFail,
+            bool $isValid,
+            array $msg = [],
+        ) use (
+            $vRaw,
+            $vFiltered
+        ): callable {
+            /** @psalm-var array<string, string> $msg */
+            assert($iName !== '');
+            return fn(array|null|string $context): InputInterface => self::createInputInterfaceMock(
                 $iName,
                 $required,
                 $isValid,
@@ -470,6 +479,7 @@ final class BaseInputFilterTest extends TestCase
                 $msg,
                 $bOnFail,
             );
+        };
 
         $inputFilter = fn(bool $isValid, array $msg = []): callable =>
             function () use ($isValid, $vRaw, $vFiltered, $msg): InputFilterInterface {
@@ -595,7 +605,10 @@ final class BaseInputFilterTest extends TestCase
         );
     }
 
-    /** @param array<string, string> $getMessages */
+    /**
+     * @param non-empty-string $name
+     * @param array<string, string> $getMessages
+     */
     public static function createInputInterfaceMock(
         string $name,
         bool|null $isRequired,

--- a/test/CollectionInputFilterTest.php
+++ b/test/CollectionInputFilterTest.php
@@ -614,6 +614,7 @@ final class CollectionInputFilterTest extends TestCase
                                 'type'         => CollectionInputFilter::class,
                                 'input_filter' => [
                                     'test_field1' => [
+                                        'name'       => 'test_field1',
                                         'required'   => false,
                                         'validators' => [
                                             [
@@ -630,6 +631,7 @@ final class CollectionInputFilterTest extends TestCase
                                         ],
                                     ],
                                     'price'       => [
+                                        'name'       => 'price',
                                         'required'   => false,
                                         'validators' => [
                                             [
@@ -776,7 +778,7 @@ final class CollectionInputFilterTest extends TestCase
         $factory = TestHelper::createInputFilterFactory();
 
         $baseInputFilter = (new BaseInputFilter($factory))
-            ->add(new Input(TestHelper::createFilterChain(), TestHelper::createValidatorChain()), 'bar');
+            ->add(new Input(TestHelper::createFilterChain(), TestHelper::createValidatorChain(), 'bar'));
 
         $collectionInputFilter = (new CollectionInputFilter($this->factory))->setInputFilter($baseInputFilter);
         $collectionInputFilter->setData($unfilteredArray);

--- a/test/FactoryTest.php
+++ b/test/FactoryTest.php
@@ -19,19 +19,19 @@ use Laminas\InputFilter\InputFilterPluginManager;
 use Laminas\InputFilter\InputFilterProviderInterface;
 use Laminas\InputFilter\InputInterface;
 use Laminas\InputFilter\InputProviderInterface;
+use Laminas\ServiceManager\ServiceManager;
 use Laminas\Validator\Digits;
-use Laminas\Validator\Exception\InvalidSpecificationArrayException;
 use Laminas\Validator\NotEmpty;
 use Laminas\Validator\StringLength;
 use Laminas\Validator\ValidatorChain;
 use Laminas\Validator\ValidatorChainInterface;
 use Laminas\Validator\ValidatorPluginManager;
 use LaminasTest\InputFilter\TestAsset\CustomInput;
+use LaminasTest\InputFilter\TestAsset\CustomInputFactory;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use Psr\Container\ContainerInterface;
 use ReflectionObject;
 use TypeError;
 
@@ -47,9 +47,9 @@ final class FactoryTest extends TestCase
         $factory->createInput('invalid_value');
     }
 
-    public function testCreateInputWithTypeAsAnUnknownPluginAndNotExistsAsClassNameThrowException(): void
+    public function testAnExceptionIsThrownForCustomInputTypeNotAvailableInThePluginManager(): void
     {
-        $container     = $this->createMock(ContainerInterface::class);
+        $container     = new ServiceManager();
         $pluginManager = new InputFilterPluginManager($container);
         $factory       = new Factory(
             new FilterPluginManager($container),
@@ -59,16 +59,17 @@ final class FactoryTest extends TestCase
 
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage(
-            'Input factory expects the "type" to be a valid class or a plugin name; received "foo"'
+            'The input type "foo" cannot be created because it is not known in the Input Filter Plugin Manager. '
+            . 'Make sure you have registered a factory for the custom input type under `input_filters.factories`',
         );
         $factory->createInput([
             'type' => 'foo',
         ]);
     }
 
-    public function testCreateInputWithTypeAsAnInvalidPluginInstanceThrowException(): void
+    public function testCustomInputsCanBeBuiltWhenAFactoryIsPresent(): void
     {
-        $container     = $this->createMock(ContainerInterface::class);
+        $container     = new ServiceManager();
         $pluginManager = new InputFilterPluginManager($container);
         $factory       = new Factory(
             new FilterPluginManager($container),
@@ -76,37 +77,63 @@ final class FactoryTest extends TestCase
             $pluginManager
         );
 
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage(
-            'Input factory expects the "type" to be a valid class or a plugin name; received "fooPlugin"'
-        );
-        $factory->createInput([
-            'type' => 'fooPlugin',
+        $pluginManager->configure([
+            'factories' => [
+                CustomInput::class => CustomInputFactory::class,
+            ],
         ]);
+
+        $input = $factory->createInput(['type' => CustomInput::class, 'name' => 'fred']);
+
+        self::assertInstanceOf(CustomInput::class, $input);
+        self::assertSame('fred', $input->getName());
     }
 
-    public function testCreateInputWithTypeAsAnInvalidClassInstanceThrowException(): void
+    public function testCustomInputsBuiltViaFactoryWillBeUpdatedAtRuntimeWithOptions(): void
     {
-        $factory = $this->createDefaultFactory();
-        $type    = 'stdClass';
-
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage(
-            'You will need to create your own factory for custom inputs '
-            . 'because we cannot know what your constructor arguments might be'
+        $container     = new ServiceManager();
+        $pluginManager = new InputFilterPluginManager($container);
+        $factory       = new Factory(
+            new FilterPluginManager($container),
+            new ValidatorPluginManager($container),
+            $pluginManager
         );
-        $factory->createInput([
-            'type' => $type,
+
+        $pluginManager->configure([
+            'factories' => [
+                CustomInput::class => CustomInputFactory::class,
+            ],
         ]);
+
+        $input = $factory->createInput([
+            'type'              => CustomInput::class,
+            'name'              => 'fred',
+            'required'          => false,
+            'allow_empty'       => true,
+            'continue_if_empty' => true,
+            'break_on_failure'  => true,
+            'fallback_value'    => 'foo',
+            'error_message'     => 'Bad News',
+        ]);
+
+        self::assertInstanceOf(CustomInput::class, $input);
+
+        self::assertSame('fred', $input->getName());
+        self::assertFalse($input->isRequired());
+        self::assertTrue($input->allowEmpty());
+        self::assertTrue($input->continueIfEmpty());
+        self::assertTrue($input->breakOnFailure());
+        self::assertSame('foo', $input->getFallbackValue());
+        self::assertSame('Bad News', $input->getErrorMessage());
     }
 
     public function testCreateInputWithInvalidFilterSpecType(): void
     {
         $factory = $this->createDefaultFactory();
-
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('filters must be an array, callable, or FilterInterface');
         /** @psalm-suppress InvalidArgument */
         $factory->createInput([
+            'name'    => 'foo',
             'filters' => 'invalid_value',
         ]);
     }
@@ -114,9 +141,12 @@ final class FactoryTest extends TestCase
     public function testCreateInputWithEmptyFilterSpecIsExceptional(): void
     {
         $factory = $this->createDefaultFactory();
-        $this->expectException(Filter\Exception\InvalidSpecificationArrayException::class);
+        $this->expectExceptionMessage(
+            'Individual filter array specifications must have the key `name` that references a filter',
+        );
         /** @psalm-suppress InvalidArgument */
         $factory->createInput([
+            'name'    => 'foo',
             'filters' => [
                 [
                     // empty
@@ -129,8 +159,11 @@ final class FactoryTest extends TestCase
     {
         $factory = $this->createDefaultFactory();
 
-        $this->expectException(Filter\Exception\InvalidSpecificationArrayException::class);
+        $this->expectExceptionMessage(
+            'Each member of the `filters` list must be array specification. Received string',
+        );
         $factory->createInput([
+            'name'    => 'foo',
             'filters' => [
                 'invalid value',
             ],
@@ -141,9 +174,14 @@ final class FactoryTest extends TestCase
     {
         $factory = $this->createDefaultFactory();
 
-        $this->expectException(TypeError::class);
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            'The `validators` key must be an array or a ValidatorInterface. Received: string',
+        );
+
         /** @psalm-suppress InvalidArgument */
         $factory->createInput([
+            'name'       => 'foo',
             'validators' => 'invalid_value',
         ]);
     }
@@ -151,9 +189,13 @@ final class FactoryTest extends TestCase
     public function testCreateInputWithValidatorsAsAnSpecificationWithMissingNameThrowsException(): void
     {
         $factory = $this->createDefaultFactory();
-        $this->expectException(InvalidSpecificationArrayException::class);
+        $this->expectExceptionMessage(
+            'The `name` key must be defined and should be a string representing the FQCN of a validator or an alias',
+        );
+
         /** @psalm-suppress InvalidArgument */
         $factory->createInput([
+            'name'       => 'foo',
             'validators' => [
                 [
                     // empty
@@ -165,9 +207,12 @@ final class FactoryTest extends TestCase
     public function testCreateInputWithValidatorsAsAnCollectionOfInvalidTypesThrowException(): void
     {
         $factory = $this->createDefaultFactory();
-        $this->expectException(InvalidSpecificationArrayException::class);
+        $this->expectExceptionMessage(
+            'Each item in a specification array must be either an array or a validator instance',
+        );
         /** @psalm-suppress InvalidArgument */
         $factory->createInput([
+            'name'       => 'foo',
             'validators' => [
                 'invalid value',
             ],
@@ -367,7 +412,7 @@ final class FactoryTest extends TestCase
     public function testFactoryAcceptsInputInterface(): void
     {
         $factory = $this->createDefaultFactory();
-        $input   = new Input(TestHelper::createFilterChain(), TestHelper::createValidatorChain());
+        $input   = new Input(TestHelper::createFilterChain(), TestHelper::createValidatorChain(), 'foo');
 
         $inputFilter = $factory->createInputFilter([
             'foo' => $input,
@@ -398,10 +443,7 @@ final class FactoryTest extends TestCase
         $inputFilterPluginManager = $serviceManager->get(InputFilterPluginManager::class);
         $inputFilterPluginManager->configure([
             'factories' => [
-                CustomInput::class => static fn (): CustomInput => new CustomInput(
-                    TestHelper::createFilterChain(),
-                    TestHelper::createValidatorChain(),
-                ),
+                CustomInput::class => CustomInputFactory::class,
             ],
         ]);
 
@@ -425,6 +467,7 @@ final class FactoryTest extends TestCase
                 ],
             ],
             'bar'  => [
+                'name'        => 'bar',
                 'allow_empty' => true,
                 'filters'     => [
                     [
@@ -457,6 +500,7 @@ final class FactoryTest extends TestCase
                     ],
                 ],
                 'bar'  => [
+                    'name'        => 'bar',
                     'allow_empty' => true,
                     'filters'     => [
                         [
@@ -708,6 +752,7 @@ final class FactoryTest extends TestCase
         $inputFilter = $factory->createInputFilter(
             [
                 'type' => [
+                    'name'     => 'foo',
                     'required' => true,
                 ],
             ]
@@ -733,9 +778,9 @@ final class FactoryTest extends TestCase
     {
         $factory = $this->createDefaultFactory();
 
-        self::assertTrue($factory->createInput(['break_on_failure' => true])->breakOnFailure());
+        self::assertTrue($factory->createInput(['name' => 'foo', 'break_on_failure' => true])->breakOnFailure());
 
-        self::assertFalse($factory->createInput(['break_on_failure' => false])->breakOnFailure());
+        self::assertFalse($factory->createInput(['name' => 'foo', 'break_on_failure' => false])->breakOnFailure());
     }
 
     public function testCanCreateInputFilterWithNullInputs(): void
@@ -799,13 +844,14 @@ final class FactoryTest extends TestCase
         self::assertInstanceOf(InputFilterInterface::class, $inputFilter);
     }
 
-    public function testSuggestedTypeMayBePluginNameInInputFilterPluginManager(): void
+    public function testCustomInputTypesCanBeRetrievedFromContainerServices(): void
     {
         $container     = TestHelper::getContainer();
         $pluginManager = $container->get(InputFilterPluginManager::class);
+        $service       = new Input(TestHelper::createFilterChain(), TestHelper::createValidatorChain(), 'fred');
         $pluginManager->configure([
             'services' => [
-                'bar' => new Input(TestHelper::createFilterChain(), TestHelper::createValidatorChain(), 'bar'),
+                'bar' => $service,
             ],
         ]);
         $factory = $container->get(Factory::class);
@@ -814,8 +860,7 @@ final class FactoryTest extends TestCase
             'type' => 'bar',
         ]);
 
-        self::assertInstanceOf(InputInterface::class, $input);
-        self::assertSame('bar', $input->getName());
+        self::assertSame($service, $input);
     }
 
     public function testInputFromPluginManagerMayBeFurtherConfiguredWithSpec(): void
@@ -925,7 +970,7 @@ final class FactoryTest extends TestCase
         $validatorChain = new ValidatorChain();
         $validatorChain->setPluginManager($validatorPlugins);
 
-        $input = new Input($filterChain, $validatorChain);
+        $input = new Input($filterChain, $validatorChain, 'foo');
 
         $inputFilterPluginManager->configure([
             'services' => [
@@ -933,7 +978,7 @@ final class FactoryTest extends TestCase
             ],
         ]);
 
-        $spec         = ['type' => 'Some\Test\Input'];
+        $spec         = ['name' => 'zed', 'type' => 'Some\Test\Input'];
         $createdInput = $factory->createInput($spec);
 
         self::assertSame(
@@ -976,6 +1021,17 @@ final class FactoryTest extends TestCase
         $inputFilter->setIsRequired(false);
         self::assertTrue($inputFilter->isValid());
         self::assertSame([], $inputFilter->getMessages()->toArray());
+    }
+
+    public function testYouCantCreateAnInputWithoutSpecifyingAName(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage(
+            'The input name must be known in advance. '
+            . 'Ensure you set the input name in the specification under the `name` key',
+        );
+
+        $this->createDefaultFactory()->createInput([]);
     }
 
     protected function createDefaultFactory(): Factory

--- a/test/FileInput/FileInputTest.php
+++ b/test/FileInput/FileInputTest.php
@@ -63,8 +63,9 @@ final class FileInputTest extends TestCase
         AbstractValidator::setDefaultTranslator();
     }
 
+    /** @param non-empty-string $name */
     private function createFileInput(
-        ?string $name = null,
+        string $name = 'foo',
         ?FilterChainInterface $filterChain = null,
         ?Validator\ValidatorChainInterface $validatorChain = null,
     ): FileInput {
@@ -146,7 +147,7 @@ final class FileInputTest extends TestCase
 
     public function testAutoPrependUploadValidatorIsOnByDefault(): void
     {
-        $input = new FileInput(TestHelper::createFilterChain(), TestHelper::createValidatorChain());
+        $input = new FileInput(TestHelper::createFilterChain(), TestHelper::createValidatorChain(), 'foo');
         self::assertTrue($input->getAutoPrependUploadValidator());
     }
 
@@ -856,7 +857,7 @@ final class FileInputTest extends TestCase
 
     public function testUploadValidatorIsAddedDuringIsValidWhenAutoPrependUploadValidatorIsEnabled(): void
     {
-        $input = new FileInput(TestHelper::createFilterChain(), TestHelper::createValidatorChain());
+        $input = new FileInput(TestHelper::createFilterChain(), TestHelper::createValidatorChain(), 'foo');
         $input->setAutoPrependUploadValidator(true);
         self::assertTrue($input->getAutoPrependUploadValidator());
         self::assertTrue($input->isRequired());

--- a/test/InputFilterInputMutationsTest.php
+++ b/test/InputFilterInputMutationsTest.php
@@ -253,17 +253,6 @@ final class InputFilterInputMutationsTest extends TestCase
         $inputFilter->add($nestedInputFilter);
     }
 
-    public function testYouCantAddAnInputWithoutSpecifyingAName(): void
-    {
-        $inputFilter = $this->createEmptyInputFilter();
-        $input       = $this->factory->createInput([]);
-
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Input or InputFilter name must be a non-empty string or an int, null given');
-
-        $inputFilter->add($input);
-    }
-
     public function testAddingAnInputWithAnExistingNameWillCauseTheInputsToBeMerged(): void
     {
         $inputFilter = $this->createEmptyInputFilter();

--- a/test/InputFilterTest.php
+++ b/test/InputFilterTest.php
@@ -37,6 +37,7 @@ final class InputFilterTest extends TestCase
         $filter1->add([
             'type'         => InputFilter::class,
             'nestedField1' => [
+                'name'     => 'foo',
                 'required' => false,
             ],
         ], 'nested');

--- a/test/InputTest.php
+++ b/test/InputTest.php
@@ -52,8 +52,9 @@ final class InputTest extends TestCase
         AbstractValidator::setDefaultTranslator(null);
     }
 
+    /** @param non-empty-string $name */
     private function createInput(
-        ?string $name = null,
+        string $name = 'foo',
         ?FilterChainInterface $filterChain = null,
         ?ValidatorChainInterface $validatorChain = null,
     ): Input {
@@ -85,20 +86,22 @@ final class InputTest extends TestCase
     public function testAnEmptyStringNameIsExceptionalViaTheConstructor(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Input names cannot be an empty string');
+        $this->expectExceptionMessage('Input names must be integers or non-empty-string. Received an empty string');
+        /** @psalm-suppress InvalidArgument */
         new Input(TestHelper::createFilterChain(), TestHelper::createValidatorChain(), '');
     }
 
     public function testAnEmptyStringNameInSetNameIsExceptional(): void
     {
-        $input = new Input(TestHelper::createFilterChain(), TestHelper::createValidatorChain(), null);
+        $input = new Input(TestHelper::createFilterChain(), TestHelper::createValidatorChain(), 'non-empty');
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Input names cannot be an empty string');
+        $this->expectExceptionMessage('Input names must be integers or non-empty-string. Received an empty string');
+        /** @psalm-suppress InvalidArgument */
         $input->setName('');
     }
 
-    /** @return list<array{0: string|int}> */
+    /** @return list<array{0: non-empty-string|int}> */
     public static function validNamesForSetName(): array
     {
         return [
@@ -110,12 +113,11 @@ final class InputTest extends TestCase
         ];
     }
 
+    /** @param non-empty-string|int $name */
     #[DataProvider('validNamesForSetName')]
     public function testValidInputNames(int|string $name): void
     {
-        $input = new Input(TestHelper::createFilterChain(), TestHelper::createValidatorChain(), null);
-        self::assertNull($input->getName());
-        $input->setName($name);
+        $input = new Input(TestHelper::createFilterChain(), TestHelper::createValidatorChain(), $name);
         self::assertSame($name, $input->getName());
     }
 
@@ -293,7 +295,7 @@ final class InputTest extends TestCase
 
     public function testRequiredWithoutFallbackAndValueNotSetProvidesAttachedNotEmptyValidatorIsEmptyErrorMessage(): void // phpcs:ignore
     {
-        $input = $this->createInput();
+        $input = $this->createInput('foo');
         $input->setRequired(true);
 
         $customMessage = [NotEmptyValidator::IS_EMPTY => "Custom message"];

--- a/test/TestAsset/CustomInputFactory.php
+++ b/test/TestAsset/CustomInputFactory.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\InputFilter\TestAsset;
+
+use Laminas\ServiceManager\Factory\FactoryInterface;
+use LaminasTest\InputFilter\TestHelper;
+use Psr\Container\ContainerInterface;
+
+use function assert;
+use function is_int;
+use function is_string;
+use function uniqid;
+
+final readonly class CustomInputFactory implements FactoryInterface
+{
+    public function __invoke(
+        ContainerInterface $container,
+        string $requestedName,
+        ?array $options = null,
+    ): CustomInput {
+        $options ??= [];
+
+        $name = $options['name'] ?? uniqid();
+        assert((is_string($name) && $name !== '') || is_int($name));
+        /** @psalm-var non-empty-string|int $name */
+
+        return new CustomInput(
+            TestHelper::createFilterChain(),
+            TestHelper::createValidatorChain(),
+            $name,
+        );
+    }
+}

--- a/test/TestAsset/InputInterfaceStub.php
+++ b/test/TestAsset/InputInterfaceStub.php
@@ -15,9 +15,12 @@ use function PHPUnit\Framework\assertNotNull;
 
 final readonly class InputInterfaceStub implements InputInterface
 {
-    /** @param array<string, string> $getMessages */
+    /**
+     * @param non-empty-string|int $name
+     * @param array<string, string> $getMessages
+     */
     public function __construct(
-        private string $name,
+        private string|int $name,
         private bool|null $isRequired,
         private bool|null $isValid = null,
         private array|string|null $context = null,
@@ -83,7 +86,7 @@ final readonly class InputInterfaceStub implements InputInterface
         throw new Exception('Not implemented');
     }
 
-    public function getName(): string
+    public function getName(): string|int
     {
         return $this->name;
     }


### PR DESCRIPTION
This patch makes it impossible to create an input with an empty name.

Name is now a constructor dependency, and it is validated to be `non-empty-string|int`

