### PR TITLE
Initial implementation of stateless validation

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -40,9 +40,6 @@
     </MixedArgument>
   </file>
   <file src="src/FileInput.php">
-    <MixedAssignment>
-      <code><![CDATA[$rawValue]]></code>
-    </MixedAssignment>
     <MoreSpecificImplementedParamType>
       <code><![CDATA[$value]]></code>
       <code><![CDATA[$value]]></code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -25,11 +25,17 @@
     <MixedAssignment>
       <code><![CDATA[$value]]></code>
     </MixedAssignment>
+    <UndefinedAttributeClass>
+      <code><![CDATA[NoDiscard]]></code>
+    </UndefinedAttributeClass>
   </file>
   <file src="src/CollectionInputFilter.php">
     <PropertyTypeCoercion>
       <code><![CDATA[$name]]></code>
     </PropertyTypeCoercion>
+    <UndefinedAttributeClass>
+      <code><![CDATA[NoDiscard]]></code>
+    </UndefinedAttributeClass>
   </file>
   <file src="src/Factory.php">
     <MixedArgument>
@@ -44,6 +50,9 @@
       <code><![CDATA[$value]]></code>
       <code><![CDATA[$value]]></code>
     </MoreSpecificImplementedParamType>
+    <UndefinedAttributeClass>
+      <code><![CDATA[NoDiscard]]></code>
+    </UndefinedAttributeClass>
   </file>
   <file src="src/FileInput/HttpServerFileInputHandler.php">
     <MixedAssignment>
@@ -64,6 +73,11 @@
       <code><![CDATA[$rawValue]]></code>
     </MoreSpecificImplementedParamType>
   </file>
+  <file src="src/Input.php">
+    <UndefinedAttributeClass>
+      <code><![CDATA[NoDiscard]]></code>
+    </UndefinedAttributeClass>
+  </file>
   <file src="src/InputFilterAbstractServiceFactory.php">
     <MixedArgument>
       <code><![CDATA[$config]]></code>
@@ -77,6 +91,11 @@
       <code><![CDATA[$config]]></code>
     </MixedAssignment>
   </file>
+  <file src="src/InputFilterInterface.php">
+    <UndefinedAttributeClass>
+      <code><![CDATA[NoDiscard]]></code>
+    </UndefinedAttributeClass>
+  </file>
   <file src="src/InputFilterPluginManager.php">
     <MethodSignatureMismatch>
       <code><![CDATA[InputFilterPluginManager]]></code>
@@ -86,10 +105,30 @@
       <code><![CDATA[$instanceOf]]></code>
     </NonInvariantDocblockPropertyType>
   </file>
+  <file src="src/InputFilterValidationResult.php">
+    <UndefinedAttributeClass>
+      <code><![CDATA[NoDiscard]]></code>
+    </UndefinedAttributeClass>
+  </file>
+  <file src="src/InputInterface.php">
+    <UndefinedAttributeClass>
+      <code><![CDATA[NoDiscard]]></code>
+    </UndefinedAttributeClass>
+  </file>
+  <file src="src/InputValidationResult.php">
+    <UndefinedAttributeClass>
+      <code><![CDATA[NoDiscard]]></code>
+    </UndefinedAttributeClass>
+  </file>
   <file src="src/OptionalInputFilter.php">
     <ClassMustBeFinal>
       <code><![CDATA[OptionalInputFilter]]></code>
     </ClassMustBeFinal>
+  </file>
+  <file src="src/ValidationResultInterface.php">
+    <UndefinedAttributeClass>
+      <code><![CDATA[NoDiscard]]></code>
+    </UndefinedAttributeClass>
   </file>
   <file src="test/BaseInputFilterTest.php">
     <InvalidArgument>
@@ -152,5 +191,15 @@
      *     2: class-string<InputInterface>
      * }>]]></code>
     </MoreSpecificReturnType>
+  </file>
+  <file src="test/TestAsset/InputInterfaceImplementation.php">
+    <UndefinedAttributeClass>
+      <code><![CDATA[NoDiscard]]></code>
+    </UndefinedAttributeClass>
+  </file>
+  <file src="test/TestAsset/InputInterfaceStub.php">
+    <UndefinedAttributeClass>
+      <code><![CDATA[NoDiscard]]></code>
+    </UndefinedAttributeClass>
   </file>
 </files>

--- a/src/BaseInputFilter.php
+++ b/src/BaseInputFilter.php
@@ -223,10 +223,8 @@ class BaseInputFilter implements
     {
         $data    = iterator_to_array($data);
         $context = $context === [] ? $data : $context;
-        $inputs  = $this->validationGroup ?? array_keys($this->inputs);
         $results = [];
-        foreach ($inputs as $name) {
-            $input = $this->inputs[$name];
+        foreach ($this->inputs as $name => $input) {
             /** @psalm-var mixed $value */
             $value = $data[$name] ?? null;
 

--- a/src/BaseInputFilter.php
+++ b/src/BaseInputFilter.php
@@ -22,6 +22,7 @@ use function is_array;
 use function is_int;
 use function is_iterable;
 use function is_string;
+use function iterator_to_array;
 use function sprintf;
 
 /**
@@ -216,6 +217,37 @@ class BaseInputFilter implements
 
         $inputs = $this->validationGroup ?? array_keys($this->inputs);
         return $this->validateInputs($inputs, $this->data, $context);
+    }
+
+    public function validate(iterable|null $data, array|null $context = null): InputFilterValidationResult
+    {
+        $data      = iterator_to_array($data ?? []);
+        $context ??= $data;
+        $inputs    = $this->validationGroup ?? array_keys($this->inputs);
+        $results   = [];
+        foreach ($inputs as $name) {
+            $input = $this->inputs[$name];
+            /** @psalm-var mixed $value */
+            $value = $data[$name] ?? null;
+
+            if ($input instanceof InputFilterInterface) {
+                $value = is_iterable($value) ? iterator_to_array($value) : [];
+
+                $result = $input->validate($value, $context);
+                assert($result instanceof InputFilterValidationResult);
+                $results[$name] = $result;
+
+                continue;
+            }
+
+            $result         = $input->validate($value, $context);
+            $results[$name] = $result;
+            if (! $result->valid() && $input->breakOnFailure()) {
+                break;
+            }
+        }
+
+        return new InputFilterValidationResult($results);
     }
 
     /**

--- a/src/BaseInputFilter.php
+++ b/src/BaseInputFilter.php
@@ -219,12 +219,12 @@ class BaseInputFilter implements
         return $this->validateInputs($inputs, $this->data, $context);
     }
 
-    public function validate(iterable|null $data, array|null $context = null): InputFilterValidationResult
+    public function validate(iterable $data, array $context = []): InputFilterValidationResult
     {
-        $data      = iterator_to_array($data ?? []);
-        $context ??= $data;
-        $inputs    = $this->validationGroup ?? array_keys($this->inputs);
-        $results   = [];
+        $data    = iterator_to_array($data);
+        $context = $context === [] ? $data : $context;
+        $inputs  = $this->validationGroup ?? array_keys($this->inputs);
+        $results = [];
         foreach ($inputs as $name) {
             $input = $this->inputs[$name];
             /** @psalm-var mixed $value */

--- a/src/BaseInputFilter.php
+++ b/src/BaseInputFilter.php
@@ -8,6 +8,7 @@ use Laminas\InputFilter\Exception\InputNotFoundException;
 use Laminas\InputFilter\Exception\InvalidArgumentException;
 use Laminas\Stdlib\ArrayUtils;
 use Laminas\Stdlib\InitializableInterface;
+use NoDiscard;
 use Traversable;
 
 use function array_key_exists;
@@ -219,6 +220,7 @@ class BaseInputFilter implements
         return $this->validateInputs($inputs, $this->data, $context);
     }
 
+    #[NoDiscard]
     public function validate(iterable $data, array $context = []): InputFilterValidationResult
     {
         $data    = iterator_to_array($data);

--- a/src/CollectionInputFilter.php
+++ b/src/CollectionInputFilter.php
@@ -313,4 +313,39 @@ class CollectionInputFilter extends InputFilter
 
         return new ErrorMessages($validator->getMessages());
     }
+
+    public function validate(iterable $data, array $context = []): InputFilterValidationResult
+    {
+        $inputFilter = $this->getInputFilter();
+
+        $data    = iterator_to_array($data, false); // Cast to a list, keys are not relevant
+        $context = $context === [] ? $data : $context;
+
+        $minCount = max(
+            $this->isRequired ? 1 : 0,
+            $this->count ?? 0,
+        );
+
+        $iterations = max(
+            count($data),
+            $minCount,
+        );
+
+        $results = [];
+        for ($i = 0; $i < $iterations; $i++) {
+            /** @psalm-var iterable<array-key, mixed> $set */
+            $set = $data[$i] ?? [];
+            /** @psalm-var ValidationResultInterface<TFilteredValues> $result */
+            $result    = $inputFilter->validate($set, $context);
+            $results[] = $result;
+        }
+
+        /**
+         * This return type needs forcing, because it is effectively list<T>, but this class defines array<array-key, T>
+         * as its generic type.
+         *
+         * @psalm-var InputFilterValidationResult<array<array-key, TFilteredValues>>
+         */
+        return new InputFilterValidationResult($results);
+    }
 }

--- a/src/CollectionInputFilter.php
+++ b/src/CollectionInputFilter.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Laminas\InputFilter;
 
 use Laminas\Validator\NotEmpty;
+use NoDiscard;
 
 use function assert;
 use function count;
@@ -314,6 +315,7 @@ class CollectionInputFilter extends InputFilter
         return new ErrorMessages($validator->getMessages());
     }
 
+    #[NoDiscard]
     public function validate(iterable $data, array $context = []): InputFilterValidationResult
     {
         $inputFilter = $this->getInputFilter();

--- a/src/FileInput.php
+++ b/src/FileInput.php
@@ -100,37 +100,32 @@ final class FileInput extends Input
     /** @inheritDoc */
     public function isValid(array|null $context = null): bool
     {
-        $rawValue        = $this->getRawValue();
-        $hasValue        = $this->hasValue();
-        $empty           = $this->isEmptyFile($rawValue);
-        $required        = $this->isRequired();
-        $allowEmpty      = $this->allowEmpty();
-        $continueIfEmpty = $this->continueIfEmpty();
+        $empty = $this->isEmptyFile($this->value);
 
-        if (! $hasValue && ! $required) {
+        if (! $this->hasValue && ! $this->required) {
             return true;
         }
 
-        if (! $hasValue && ! $this->hasFallback()) { // required, no value, and no fallback
+        if (! $this->hasValue && ! $this->hasFallback()) { // required, no value, and no fallback
             if ($this->errorMessage === null) {
                 $this->errorMessage = $this->prepareRequiredValidationFailureMessage();
             }
             return false;
         }
 
-        if ($empty && ! $required && ! $continueIfEmpty) {
+        if ($empty && ! $this->required && ! $this->continueIfEmpty) {
             return true;
         }
 
-        if ($empty && $allowEmpty && ! $continueIfEmpty) {
+        if ($empty && $this->allowEmpty && ! $this->continueIfEmpty) {
             return true;
         }
 
         assert($this->handler !== null);
         $this->isValid = $this->handler->isValid(
-            $rawValue,
+            $this->value,
             $this->injectUploadValidator($this->getValidatorChain()),
-            $context
+            $context,
         );
         return $this->isValid;
     }

--- a/src/FileInput.php
+++ b/src/FileInput.php
@@ -8,6 +8,7 @@ use Laminas\InputFilter\FileInput\FileInputHandlerInterface;
 use Laminas\Validator\File\UploadFile as UploadValidator;
 use Laminas\Validator\ValidatorChain;
 use Laminas\Validator\ValidatorChainInterface;
+use NoDiscard;
 use Psr\Http\Message\UploadedFileInterface;
 
 use function array_merge;
@@ -132,6 +133,7 @@ final class FileInput extends Input
         return $this->isValid;
     }
 
+    #[NoDiscard]
     public function validate(mixed $value, array $context): InputValidationResult
     {
         $isEmpty = $value === '' || $value === [] || $value === null || $this->isEmptyFile($value);

--- a/src/FileInput.php
+++ b/src/FileInput.php
@@ -10,8 +10,10 @@ use Laminas\Validator\ValidatorChain;
 use Laminas\Validator\ValidatorChainInterface;
 use Psr\Http\Message\UploadedFileInterface;
 
+use function array_merge;
 use function assert;
 use function is_array;
+use function sprintf;
 
 /**
  * FileInput is a special Input type for handling uploaded files.
@@ -128,6 +130,70 @@ final class FileInput extends Input
             $context,
         );
         return $this->isValid;
+    }
+
+    public function validate(mixed $value, array $context): InputValidationResult
+    {
+        $isEmpty = $value === '' || $value === [] || $value === null || $this->isEmptyFile($value);
+        $handler = $this->createHandler($value);
+
+        if (
+            // We have a valid result when a value is empty, but a fallback is present
+            ($isEmpty && $this->hasFallback)
+            ||
+            // Empty values are valid when they are not required and validation should not continue for empty values
+            ($isEmpty && ! $this->required && ! $this->continueIfEmpty)
+            ||
+            // Empty is valid when allowEmpty is true and continue if empty is false
+            ($isEmpty && $this->allowEmpty && ! $this->continueIfEmpty)
+        ) {
+            return InputValidationResult::pass(
+                $this->name,
+                $value,
+                $handler->filterValue($value, true, $this->filterChain),
+            );
+        }
+
+        $validatorChain = $this->injectUploadValidator($this->validatorChain);
+
+        $isValid  = $handler->isValid(
+            $value,
+            $validatorChain,
+            $context,
+        );
+        $messages = $this->validatorChain->getMessages();
+
+        /**
+         * An empty value should not be considered valid in this situation, regardless
+         * of what the validator chain says.
+         * Instead of mutating the chain, fail validation with a validation failure message that advises the user to
+         * customise the validation chain with a NotEmpty validator.
+         */
+        if ($isValid && $isEmpty) {
+            $isValid  = false;
+            $messages = array_merge([
+                InputInterface::EMPTY_FAILURE_VALIDATION_KEY => sprintf(
+                    'The value for "%s" was empty, but its configuration prohibits an empty value. '
+                    . 'Enable the auto-prepend of a "UploadFile" validator to this input’s chain, '
+                    . 'or configure one manually in order to customise '
+                    . 'this validation failure message',
+                    $this->name,
+                ),
+            ], $messages);
+        }
+
+        return $isValid
+            ? InputValidationResult::pass(
+                $this->name,
+                $value,
+                $handler->filterValue($value, true, $this->filterChain),
+            )
+            : InputValidationResult::fail(
+                $this->name,
+                $value,
+                $handler->filterValue($value, false, $this->filterChain),
+                new ErrorMessages($messages),
+            );
     }
 
     public function merge(InputInterface $input): static

--- a/src/FileInput/HttpServerFileInputHandler.php
+++ b/src/FileInput/HttpServerFileInputHandler.php
@@ -7,6 +7,8 @@ namespace Laminas\InputFilter\FileInput;
 use Laminas\Filter\FilterChainInterface;
 use Laminas\Validator\ValidatorChainInterface;
 
+use function array_key_exists;
+use function assert;
 use function count;
 use function is_array;
 
@@ -96,12 +98,15 @@ final class HttpServerFileInputHandler implements FileInputHandlerInterface
             ];
         }
 
-        if (isset($rawValue['tmp_name'])) {
+        if (array_key_exists('tmp_name', $rawValue)) {
             // Single file input
             return $validatorChain->isValid($rawValue, $context);
         }
 
-        if (isset($rawValue[0]['tmp_name'])) {
+        $first = $rawValue[0] ?? [];
+        assert(is_array($first));
+
+        if (array_key_exists('tmp_name', $first)) {
             // Multi file input (multiple attribute set)
             foreach ($rawValue as $value) {
                 if (! $validatorChain->isValid($value, $context)) {

--- a/src/Input.php
+++ b/src/Input.php
@@ -11,6 +11,7 @@ use Laminas\ServiceManager\AbstractPluginManager;
 use Laminas\Validator\NotEmpty;
 use Laminas\Validator\ValidatorChain;
 use Laminas\Validator\ValidatorChainInterface;
+use NoDiscard;
 
 use function array_merge;
 use function assert;
@@ -278,6 +279,7 @@ class Input implements MutableInputInterface
         return $this;
     }
 
+    #[NoDiscard]
     public function validate(mixed $value, array $context): InputValidationResult
     {
         $isEmpty = $value === '' || $value === null || $value === [];

--- a/src/Input.php
+++ b/src/Input.php
@@ -12,6 +12,7 @@ use Laminas\Validator\NotEmpty;
 use Laminas\Validator\ValidatorChain;
 use Laminas\Validator\ValidatorChainInterface;
 
+use function array_merge;
 use function assert;
 use function class_exists;
 use function get_debug_type;
@@ -277,6 +278,62 @@ class Input implements MutableInputInterface
         return $this;
     }
 
+    public function validate(mixed $value, array $context): InputValidationResult
+    {
+        $isEmpty = $value === '' || $value === null || $value === [];
+        /** @psalm-var mixed $resolvedValue */
+        $resolvedValue = $isEmpty && $this->hasFallback ? $this->fallbackValue : $value;
+        /**
+         * Behaviour Change: The fallback value is filtered where previously it was returned verbatim
+         *
+         * @psalm-var mixed $filteredValue
+         */
+        $filteredValue = $this->filterChain->filter($resolvedValue);
+
+        if (
+            // We have a valid result when a value is empty, but a fallback is present
+            ($isEmpty && $this->hasFallback)
+            ||
+            // Empty values are valid when they are not required and validation should not continue for empty values
+            ($isEmpty && ! $this->required && ! $this->continueIfEmpty)
+            ||
+            // Empty is valid when allowEmpty is true and continue if empty is false
+            ($isEmpty && $this->allowEmpty && ! $this->continueIfEmpty)
+        ) {
+            return InputValidationResult::pass($this->name, $value, $filteredValue);
+        }
+
+        $isValid  = $this->validatorChain->isValid($filteredValue, $context);
+        $messages = $this->validatorChain->getMessages();
+
+        /**
+         * An empty value should not be considered valid in this situation, regardless
+         * of what the validator chain says.
+         * Instead of mutating the chain, fail validation with a validation failure message that advises the user to
+         * customise the validation chain with a NotEmpty validator.
+         */
+        if ($isValid && $isEmpty) {
+            $isValid  = false;
+            $messages = array_merge([
+                InputInterface::EMPTY_FAILURE_VALIDATION_KEY => sprintf(
+                    'The value for "%s" was empty, but its configuration prohibits an empty value. '
+                    . 'Prepend a "NotEmpty" validator to this input’s chain in order to customise '
+                    . 'this validation failure message',
+                    $this->name,
+                ),
+            ], $messages);
+        }
+
+        return $isValid
+            ? InputValidationResult::pass($this->name, $value, $filteredValue)
+            : InputValidationResult::fail(
+                $this->name,
+                $value,
+                $filteredValue,
+                new ErrorMessages($messages),
+            );
+    }
+
     /** @inheritDoc */
     public function isValid(array|null $context = null): bool
     {
@@ -340,8 +397,7 @@ class Input implements MutableInputInterface
             return new ErrorMessages([]);
         }
 
-        $validator = $this->getValidatorChain();
-        return new ErrorMessages($validator->getMessages());
+        return new ErrorMessages($this->validatorChain->getMessages());
     }
 
     protected function injectNotEmptyValidator(): void

--- a/src/InputFilterInterface.php
+++ b/src/InputFilterInterface.php
@@ -76,7 +76,7 @@ interface InputFilterInterface extends Countable
     /**
      * Set data to use when validating and filtering
      *
-     * @param  iterable<array-key, mixed>|null $data
+     * @param iterable<array-key, mixed>|null $data
      */
     public function setData(iterable|null $data): static;
 
@@ -92,6 +92,7 @@ interface InputFilterInterface extends Countable
      *
      * @param iterable<array-key, mixed> $data
      * @param array<array-key, mixed> $context
+     * @return InputFilterValidationResult<TFilteredValues>
      */
     public function validate(iterable $data, array $context = []): InputFilterValidationResult;
 

--- a/src/InputFilterInterface.php
+++ b/src/InputFilterInterface.php
@@ -88,6 +88,14 @@ interface InputFilterInterface extends Countable
     public function isValid(array|null $context = null): bool;
 
     /**
+     * Is the data set valid?
+     *
+     * @param iterable<array-key, mixed>|null $data
+     * @param array<array-key, mixed>|null $context
+     */
+    public function validate(iterable|null $data, array|null $context = null): InputFilterValidationResult;
+
+    /**
      * Provide a list of one or more elements indicating the complete set to validate
      *
      * When provided, calls to {@link isValid()} will only validate the provided set.

--- a/src/InputFilterInterface.php
+++ b/src/InputFilterInterface.php
@@ -90,10 +90,10 @@ interface InputFilterInterface extends Countable
     /**
      * Is the data set valid?
      *
-     * @param iterable<array-key, mixed>|null $data
-     * @param array<array-key, mixed>|null $context
+     * @param iterable<array-key, mixed> $data
+     * @param array<array-key, mixed> $context
      */
-    public function validate(iterable|null $data, array|null $context = null): InputFilterValidationResult;
+    public function validate(iterable $data, array $context = []): InputFilterValidationResult;
 
     /**
      * Provide a list of one or more elements indicating the complete set to validate

--- a/src/InputFilterInterface.php
+++ b/src/InputFilterInterface.php
@@ -89,7 +89,18 @@ interface InputFilterInterface extends Countable
     public function isValid(array|null $context = null): bool;
 
     /**
-     * Is the data set valid?
+     * Validate a payload using the configured validator and filter chains
+     *
+     * This method performs stateless validation, returning a result value rather than a boolean. Calling validate()
+     * does not mutate the internal state of the input filter, therefore it is safe to call multiple times for different
+     * payloads.
+     *
+     * The result of this method should not be ignored. Calls to `isValid()` are irrelevant when using this api and the
+     * result value returned encapsulates all validation information, filtered and unfiltered values.
+     *
+     * Note that validation groups are ignored and the entire data set is validated against all configured inputs.
+     *
+     * Before migrating to this method, please familiarise yourself with the migration guide for version 3.x
      *
      * @param iterable<array-key, mixed> $data
      * @param array<array-key, mixed> $context

--- a/src/InputFilterInterface.php
+++ b/src/InputFilterInterface.php
@@ -5,11 +5,12 @@ declare(strict_types=1);
 namespace Laminas\InputFilter;
 
 use Countable;
-use Laminas\Filter\FilterChain; // phpcs:ignore
-use Laminas\Filter\FilterInterface; // phpcs:ignore
+use Laminas\Filter\FilterChain;
+use Laminas\Filter\FilterInterface;
 use Laminas\InputFilter\Exception\InputNotFoundException;
-use Laminas\Validator\ValidatorChain; // phpcs:ignore
-use Laminas\Validator\ValidatorInterface; // phpcs:ignore
+use Laminas\Validator\ValidatorChain;
+use Laminas\Validator\ValidatorInterface;
+use NoDiscard;
 
 /**
  * @template TFilteredValues
@@ -94,6 +95,7 @@ interface InputFilterInterface extends Countable
      * @param array<array-key, mixed> $context
      * @return InputFilterValidationResult<TFilteredValues>
      */
+    #[NoDiscard]
     public function validate(iterable $data, array $context = []): InputFilterValidationResult;
 
     /**

--- a/src/InputFilterValidationResult.php
+++ b/src/InputFilterValidationResult.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\InputFilter;
+
+use Laminas\InputFilter\Exception\InputNotFoundException;
+
+final readonly class InputFilterValidationResult implements ValidationResultInterface
+{
+    /** @param array<array-key, self|InputValidationResult> $results */
+    public function __construct(
+        public array $results,
+    ) {
+    }
+
+    public function valid(): bool
+    {
+        foreach ($this->results as $result) {
+            if ($result->valid()) {
+                continue;
+            }
+
+            return false;
+        }
+
+        return true;
+    }
+
+    public function getMessages(): ErrorMessages
+    {
+        $messages = [];
+        foreach ($this->results as $key => $result) {
+            $name            = $this->keyName($key, $result);
+            $messages[$name] = $result->getMessages();
+        }
+
+        return new ErrorMessages($messages);
+    }
+
+    /** @psalm-suppress MixedAssignment */
+    public function rawValue(): array
+    {
+        $value = [];
+        foreach ($this->results as $key => $result) {
+            $name         = $this->keyName($key, $result);
+            $value[$name] = $result->rawValue();
+        }
+
+        return $value;
+    }
+
+    /** @psalm-suppress MixedAssignment */
+    public function value(): array
+    {
+        $value = [];
+        foreach ($this->results as $key => $result) {
+            $name         = $this->keyName($key, $result);
+            $value[$name] = $result->value();
+        }
+
+        return $value;
+    }
+
+    /** @throws InputNotFoundException */
+    public function resultFor(string|int $key): ValidationResultInterface
+    {
+        $result = $this->results[$key] ?? null;
+        if (! $result instanceof ValidationResultInterface) {
+            throw InputNotFoundException::forKey($key);
+        }
+
+        return $result;
+    }
+
+    private function keyName(string|int $key, ValidationResultInterface $result): string|int
+    {
+        return $result instanceof InputValidationResult
+            ? $result->name()
+            : $key;
+    }
+}

--- a/src/InputFilterValidationResult.php
+++ b/src/InputFilterValidationResult.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Laminas\InputFilter;
 
 use Laminas\InputFilter\Exception\InputNotFoundException;
+use NoDiscard;
 
 /**
  * @template T
@@ -18,6 +19,7 @@ final readonly class InputFilterValidationResult implements ValidationResultInte
     ) {
     }
 
+    #[NoDiscard]
     public function valid(): bool
     {
         foreach ($this->results as $result) {

--- a/src/InputFilterValidationResult.php
+++ b/src/InputFilterValidationResult.php
@@ -6,6 +6,10 @@ namespace Laminas\InputFilter;
 
 use Laminas\InputFilter\Exception\InputNotFoundException;
 
+/**
+ * @template T
+ * @implements ValidationResultInterface<T>
+ */
 final readonly class InputFilterValidationResult implements ValidationResultInterface
 {
     /** @param array<array-key, self|InputValidationResult> $results */
@@ -50,7 +54,6 @@ final readonly class InputFilterValidationResult implements ValidationResultInte
         return $value;
     }
 
-    /** @psalm-suppress MixedAssignment */
     public function value(): array
     {
         $value = [];

--- a/src/InputFilterValidationResult.php
+++ b/src/InputFilterValidationResult.php
@@ -12,7 +12,7 @@ use Laminas\InputFilter\Exception\InputNotFoundException;
  */
 final readonly class InputFilterValidationResult implements ValidationResultInterface
 {
-    /** @param array<array-key, self|InputValidationResult> $results */
+    /** @param array<array-key, ValidationResultInterface> $results */
     public function __construct(
         public array $results,
     ) {
@@ -42,12 +42,12 @@ final readonly class InputFilterValidationResult implements ValidationResultInte
         return new ErrorMessages($messages);
     }
 
-    /** @psalm-suppress MixedAssignment */
     public function rawValue(): array
     {
         $value = [];
         foreach ($this->results as $key => $result) {
-            $name         = $this->keyName($key, $result);
+            $name = $this->keyName($key, $result);
+            /** @psalm-suppress MixedAssignment - Yep. This is mixed… */
             $value[$name] = $result->rawValue();
         }
 
@@ -58,7 +58,8 @@ final readonly class InputFilterValidationResult implements ValidationResultInte
     {
         $value = [];
         foreach ($this->results as $key => $result) {
-            $name         = $this->keyName($key, $result);
+            $name = $this->keyName($key, $result);
+            /** @psalm-suppress MixedAssignment This _is_ effectively mixed, but our overall return type is still T */
             $value[$name] = $result->value();
         }
 

--- a/src/InputInterface.php
+++ b/src/InputInterface.php
@@ -6,6 +6,7 @@ namespace Laminas\InputFilter;
 
 use Laminas\Filter\FilterChainInterface;
 use Laminas\Validator\ValidatorChainInterface;
+use NoDiscard;
 
 interface InputInterface
 {
@@ -37,6 +38,7 @@ interface InputInterface
     public function isValid(array|null $context = null): bool;
 
     /** @param array<array-key, mixed> $context */
+    #[NoDiscard]
     public function validate(mixed $value, array $context): InputValidationResult;
 
     public function getMessages(): ErrorMessages;

--- a/src/InputInterface.php
+++ b/src/InputInterface.php
@@ -37,7 +37,19 @@ interface InputInterface
     /** @param array<array-key, mixed>|null $context */
     public function isValid(array|null $context = null): bool;
 
-    /** @param array<array-key, mixed> $context */
+    /**
+     * Validate a value for this input
+     *
+     * This method performs stateless validation, returning a result object that exposes whether validation was
+     * successful, any error messages, the filtered, and un-filtered values.
+     *
+     * This method does not modify the internal state of the input, therefore it is not necessary to `setValue()`, and
+     * subsequent calls to `getValue()`, `isValid()`, `getMessages()` and others will not yield the expected results.
+     *
+     * Before migrating to this method, please familiarise yourself with the migration guide for version 3.x
+     *
+     * @param array<array-key, mixed> $context
+     */
     #[NoDiscard]
     public function validate(mixed $value, array $context): InputValidationResult;
 

--- a/src/InputInterface.php
+++ b/src/InputInterface.php
@@ -9,6 +9,9 @@ use Laminas\Validator\ValidatorChainInterface;
 
 interface InputInterface
 {
+    /** @internal */
+    public const EMPTY_FAILURE_VALIDATION_KEY = '__inputEmptyValueFailure';
+
     public function setValue(mixed $value): static;
 
     public function allowEmpty(): bool;
@@ -32,6 +35,9 @@ interface InputInterface
 
     /** @param array<array-key, mixed>|null $context */
     public function isValid(array|null $context = null): bool;
+
+    /** @param array<array-key, mixed> $context */
+    public function validate(mixed $value, array $context): InputValidationResult;
 
     public function getMessages(): ErrorMessages;
 

--- a/src/InputValidationResult.php
+++ b/src/InputValidationResult.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\InputFilter;
+
+final readonly class InputValidationResult implements ValidationResultInterface
+{
+    private function __construct(
+        private int|string $name,
+        private mixed $rawValue,
+        private mixed $value,
+        private bool $valid,
+        private ErrorMessages $errorMessages,
+    ) {
+    }
+
+    public static function pass(
+        int|string $name,
+        mixed $rawValue,
+        mixed $value,
+    ): self {
+        return new self($name, $rawValue, $value, true, new ErrorMessages([]));
+    }
+
+    public static function fail(
+        int|string $name,
+        mixed $rawValue,
+        mixed $value,
+        ErrorMessages $errorMessages,
+    ): self {
+        return new self($name, $rawValue, $value, false, $errorMessages);
+    }
+
+    public function name(): int|string
+    {
+        return $this->name;
+    }
+
+    public function valid(): bool
+    {
+        return $this->valid;
+    }
+
+    public function getMessages(): ErrorMessages
+    {
+        return $this->errorMessages;
+    }
+
+    public function rawValue(): mixed
+    {
+        return $this->rawValue;
+    }
+
+    public function value(): mixed
+    {
+        return $this->value;
+    }
+}

--- a/src/InputValidationResult.php
+++ b/src/InputValidationResult.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Laminas\InputFilter;
 
+use NoDiscard;
+
 /**
  * @template T
  * @implements ValidationResultInterface<T>
@@ -47,6 +49,7 @@ final readonly class InputValidationResult implements ValidationResultInterface
         return $this->name;
     }
 
+    #[NoDiscard]
     public function valid(): bool
     {
         return $this->valid;

--- a/src/InputValidationResult.php
+++ b/src/InputValidationResult.php
@@ -4,8 +4,13 @@ declare(strict_types=1);
 
 namespace Laminas\InputFilter;
 
+/**
+ * @template T
+ * @implements ValidationResultInterface<T>
+ */
 final readonly class InputValidationResult implements ValidationResultInterface
 {
+    /** @param T $value */
     private function __construct(
         private int|string $name,
         private mixed $rawValue,
@@ -15,6 +20,11 @@ final readonly class InputValidationResult implements ValidationResultInterface
     ) {
     }
 
+    /**
+     * @param T1 $value
+     * @return self<T1>
+     * @template T1
+     */
     public static function pass(
         int|string $name,
         mixed $rawValue,

--- a/src/ValidationResultInterface.php
+++ b/src/ValidationResultInterface.php
@@ -4,9 +4,12 @@ declare(strict_types=1);
 
 namespace Laminas\InputFilter;
 
+use NoDiscard;
+
 /** @template T */
 interface ValidationResultInterface
 {
+    #[NoDiscard]
     public function valid(): bool;
 
     public function getMessages(): ErrorMessages;

--- a/src/ValidationResultInterface.php
+++ b/src/ValidationResultInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\InputFilter;
+
+interface ValidationResultInterface
+{
+    public function valid(): bool;
+
+    public function getMessages(): ErrorMessages;
+
+    public function rawValue(): mixed;
+
+    public function value(): mixed;
+}

--- a/src/ValidationResultInterface.php
+++ b/src/ValidationResultInterface.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Laminas\InputFilter;
 
+/** @template T */
 interface ValidationResultInterface
 {
     public function valid(): bool;
@@ -12,5 +13,6 @@ interface ValidationResultInterface
 
     public function rawValue(): mixed;
 
+    /** @return T */
     public function value(): mixed;
 }

--- a/test/FileInput/FileInputTest.php
+++ b/test/FileInput/FileInputTest.php
@@ -96,7 +96,7 @@ final class FileInputTest extends TestCase
         self::assertEquals($filtered, $input->getValue());
     }
 
-    #[DAtaProvider('validMultiValueProvider')]
+    #[DataProvider('validMultiValueProvider')]
     public function testCanFilterArrayOfMultiFileData(array $raw, array $filtered): void
     {
         $map = [];

--- a/test/FileInput/FileInputValidateTest.php
+++ b/test/FileInput/FileInputValidateTest.php
@@ -1,0 +1,304 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\InputFilter\FileInput;
+
+use Laminas\Filter\FilterChainInterface;
+use Laminas\InputFilter\FileInput;
+use Laminas\InputFilter\InputInterface;
+use Laminas\Validator\File\UploadFile;
+use Laminas\Validator\ValidatorChain;
+use Laminas\Validator\ValidatorChainInterface;
+use LaminasTest\InputFilter\TestAsset\UploadedFileInterfaceStub;
+use LaminasTest\InputFilter\TestHelper;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\UploadedFileInterface;
+
+use function count;
+use function json_encode;
+use function sprintf;
+
+use const JSON_THROW_ON_ERROR;
+use const UPLOAD_ERR_NO_FILE;
+use const UPLOAD_ERR_OK;
+
+final class FileInputValidateTest extends TestCase
+{
+    /** @param non-empty-string $name */
+    private function createFileInput(
+        string $name = 'foo',
+        ?FilterChainInterface $filterChain = null,
+        ?ValidatorChainInterface $validatorChain = null,
+    ): FileInput {
+        $filterChain    ??= TestHelper::createFilterChain();
+        $validatorChain ??= TestHelper::createValidatorChain();
+
+        $input = new FileInput($filterChain, $validatorChain, $name);
+        // Upload validator does not work in CLI test environment, disable
+        $input->setAutoPrependUploadValidator(false);
+
+        return $input;
+    }
+
+    /**
+     * @return array<string, array{
+     *      raw: array|UploadedFileInterface,
+     *      filtered: array|UploadedFileInterface
+     *  }>
+     */
+    public static function validSingleValueProvider(): array
+    {
+        return [
+            'HttpServer single value' => [
+                'raw'      => ['tmp_name' => 'foo', 'name' => 'foo', 'error' => UPLOAD_ERR_OK],
+                'filtered' => ['tmp_name' => 'bar'],
+            ],
+            'Psr7 single value'       => [
+                'raw'      => new UploadedFileInterfaceStub(),
+                'filtered' => new UploadedFileInterfaceStub(),
+            ],
+        ];
+    }
+
+    #[DataProvider('validSingleValueProvider')]
+    public function testRetrievingValueFiltersTheValueOnlyAfterValidating(
+        mixed $raw,
+        mixed $filtered,
+    ): void {
+        $input = $this->createFileInput(
+            'foo',
+            TestHelper::createFilterChainFixture($raw, $filtered),
+        );
+
+        $result = $input->validate($raw, []);
+
+        self::assertEquals($raw, $result->rawValue());
+        self::assertTrue(
+            $result->valid(),
+            sprintf(
+                'Expected a valid result. Messages: %s',
+                json_encode($result->getMessages()->toArray(), JSON_THROW_ON_ERROR),
+            ),
+        );
+        self::assertEquals($filtered, $result->value());
+    }
+
+    /**
+     * @return array<string, array{
+     *      raw: array,
+     *      filtered: array
+     *  }>
+     */
+    public static function validMultiValueProvider(): array
+    {
+        return [
+            'HttpServer multi value' => [
+                'raw'      => [
+                    ['tmp_name' => 'foo', 'error' => UPLOAD_ERR_OK],
+                    ['tmp_name' => 'bar', 'error' => UPLOAD_ERR_OK],
+                    ['tmp_name' => 'baz', 'error' => UPLOAD_ERR_OK],
+                ],
+                'filtered' => [
+                    ['tmp_name' => 'new foo'],
+                    ['tmp_name' => 'new bar'],
+                    ['tmp_name' => 'new baz'],
+                ],
+            ],
+            'Psr7 multi value'       => [
+                'raw'      => [
+                    new UploadedFileInterfaceStub(),
+                    new UploadedFileInterfaceStub(),
+                    new UploadedFileInterfaceStub(),
+                ],
+                'filtered' => [
+                    new UploadedFileInterfaceStub(),
+                    new UploadedFileInterfaceStub(),
+                    new UploadedFileInterfaceStub(),
+                ],
+            ],
+        ];
+    }
+
+    #[DataProvider('validMultiValueProvider')]
+    public function testCanFilterArrayOfMultiFileData(array $raw, array $filtered): void
+    {
+        $map = [];
+        for ($i = 0; $i < count($filtered); $i += 1) {
+            $map[] = [$raw[$i], $filtered[$i]];
+        }
+
+        $input  = $this->createFileInput('foo', TestHelper::createFilterChainFixtureFromMap($map));
+        $result = $input->validate($raw, []);
+
+        self::assertEquals($raw, $result->rawValue());
+        self::assertTrue(
+            $result->valid(),
+            'valid() value not match. Detail . ' . json_encode($result->getMessages(), JSON_THROW_ON_ERROR),
+        );
+        self::assertEquals(
+            $filtered,
+            $result->value(),
+        );
+    }
+
+    #[DataProvider('validSingleValueProvider')]
+    public function testCanRetrieveRawValueFromValidationResult(mixed $raw, mixed $filtered): void
+    {
+        $input  = $this->createFileInput(
+            'foo',
+            TestHelper::createFilterChainFixture($raw, $filtered),
+        );
+        $result = $input->validate($raw, []);
+
+        self::assertEquals($raw, $result->rawValue());
+    }
+
+    /**
+     * @return array<string, array{
+     *      raw: array|UploadedFileInterface,
+     *      filtered: array|UploadedFileInterface
+     *  }>
+     */
+    public static function invalidSingleValueProvider(): array
+    {
+        return [
+            'HttpServer invalid value' => [
+                'raw'      => ['tmp_name' => 'foo', 'name' => 'foo', 'error' => UPLOAD_ERR_NO_FILE],
+                'filtered' => ['tmp_name' => 'new foo'],
+            ],
+            'Psr7 invalid value'       => [
+                'raw'      => new UploadedFileInterfaceStub(UPLOAD_ERR_NO_FILE),
+                'filtered' => new UploadedFileInterfaceStub(),
+            ],
+        ];
+    }
+
+    #[DataProvider('invalidSingleValueProvider')]
+    public function testValidationOperatesBeforeFiltering(mixed $raw, mixed $filtered): void
+    {
+        $input = $this->createFileInput(
+            'foo',
+            TestHelper::createFilterChainFixture($raw, $filtered),
+            TestHelper::createValidatorChain($raw, false),
+        );
+
+        $result = $input->validate($raw, []);
+
+        self::assertFalse($result->valid());
+        self::assertEquals($raw, $result->rawValue());
+        self::assertEquals($raw, $result->value());
+    }
+
+    public function testUploadValidatorIsAddedWhenIsValidateIsCalled(): void
+    {
+        $input = $this->createFileInput();
+        $input->setAutoPrependUploadValidator(true);
+        self::assertTrue($input->getAutoPrependUploadValidator());
+        self::assertTrue($input->isRequired());
+
+        $validatorChain = $input->getValidatorChain();
+        self::assertInstanceOf(ValidatorChain::class, $validatorChain);
+        self::assertCount(0, $validatorChain->getValidators());
+
+        $result = $input->validate(null, []);
+
+        self::assertFalse($result->valid());
+        $validators = $validatorChain->getValidators();
+        self::assertCount(1, $validators);
+        self::assertInstanceOf(UploadFile::class, $validators[0]['instance']);
+    }
+
+    public function testUploadValidatorIsNotAddedWhenNotDesired(): void
+    {
+        $input = $this->createFileInput();
+        self::assertFalse($input->getAutoPrependUploadValidator());
+        self::assertTrue($input->isRequired());
+        $result         = $input->validate(['tmp_name' => 'bar'], []);
+        $validatorChain = $input->getValidatorChain();
+        self::assertInstanceOf(ValidatorChain::class, $validatorChain);
+        self::assertCount(0, $validatorChain->getValidators());
+        self::assertTrue($result->valid());
+        self::assertCount(0, $validatorChain->getValidators());
+    }
+
+    /** @return list<array{0: mixed}> */
+    public static function emptyValueProvider(): array
+    {
+        return [
+            [''],
+            [[]],
+            [null],
+        ];
+    }
+
+    #[DataProvider('emptyValueProvider')]
+    public function testEmptyValidationFailureMessageIsPresentWhenEmptyValuesPassValidation(mixed $empty): void
+    {
+        $input = $this->createFileInput();
+        $input->setRequired(true);
+        $input->setAllowEmpty(false);
+        $input->setContinueIfEmpty(true);
+
+        $result = $input->validate($empty, []);
+        self::assertFalse($result->valid());
+        self::assertCount(1, $result->getMessages());
+        self::assertArrayHasKey(InputInterface::EMPTY_FAILURE_VALIDATION_KEY, $result->getMessages()->toArray());
+        self::assertSame(
+            'The value for "foo" was empty, but its configuration prohibits an empty value. '
+            . 'Enable the auto-prepend of a "UploadFile" validator to this input’s chain, '
+            . 'or configure one manually in order to customise '
+            . 'this validation failure message',
+            $result->getMessages()[InputInterface::EMPTY_FAILURE_VALIDATION_KEY],
+        );
+    }
+
+    public function testEmptyValidationFailureMessageIsNotPresentWhenUploadValidatorIsPresent(): void
+    {
+        $input = $this->createFileInput();
+        $input->setRequired(true);
+        $input->setAllowEmpty(false);
+        $input->setContinueIfEmpty(true);
+        $input->setAutoPrependUploadValidator(true);
+
+        $result = $input->validate('', ['foo' => '']);
+        self::assertFalse($result->valid());
+        $messages = $result->getMessages()->toArray();
+        self::assertCount(1, $messages);
+        self::assertArrayHasKey(UploadFile::NO_FILE, $messages);
+        self::assertArrayNotHasKey(InputInterface::EMPTY_FAILURE_VALIDATION_KEY, $messages);
+    }
+
+    /** @return list<array{0: mixed, 1: bool, 2: bool, 3: bool}> */
+    public static function emptinessMatrix(): array
+    {
+        return [
+            ['', false, true, false],
+            [[], false, true, false],
+            [null, false, true, false],
+            ['', true, true, false],
+            [[], true, true, false],
+            [null, true, true, false],
+            ['', false, false, false],
+            [[], false, false, false],
+            [null, false, false, false],
+        ];
+    }
+
+    #[DataProvider('emptinessMatrix')]
+    public function testPassWhenEmptinessOptionsPermit(
+        mixed $value,
+        bool $required,
+        bool $allowEmpty,
+        bool $continue,
+    ): void {
+        $input = $this->createFileInput();
+        $input->setRequired($required);
+        $input->setAllowEmpty($allowEmpty);
+        $input->setContinueIfEmpty($continue);
+
+        $result = $input->validate($value, ['foo' => '']);
+        self::assertTrue($result->valid());
+    }
+}

--- a/test/InputFilterSpecificationTest.php
+++ b/test/InputFilterSpecificationTest.php
@@ -8,6 +8,7 @@ use Laminas\InputFilter\Factory;
 use Laminas\InputFilter\InputFilterInterface;
 use Laminas\InputFilter\InputFilterValidationResult;
 use Laminas\InputFilter\ValidationResultInterface;
+use LaminasTest\InputFilter\Spec\BasicCollections;
 use LaminasTest\InputFilter\Spec\BasicFilterAndValidate;
 use LaminasTest\InputFilter\Spec\Expectation;
 use LaminasTest\InputFilter\Spec\InputFilterTestSpecInterface;
@@ -26,6 +27,7 @@ final class InputFilterSpecificationTest extends TestCase
     {
         return [
             BasicFilterAndValidate::class,
+            BasicCollections::class,
         ];
     }
 
@@ -56,8 +58,24 @@ final class InputFilterSpecificationTest extends TestCase
 
         $result = $inputFilter->validate($expectation->input);
 
-        self::assertSame($expectation->valid, $result->valid());
-        self::assertSame($expectation->expect, $result->value());
+        self::assertSame($expectation->valid, $result->valid(), sprintf(
+            'The result was expected to be %s, but it was %s',
+            $expectation->valid ? 'valid' : 'invalid',
+            $result->valid() ? 'valid' : 'not valid',
+        ));
+
+        self::assertSame(
+            $expectation->expect,
+            $result->value(),
+            'The filtered and validated data did not match expectations'
+        );
+
+        self::assertSame(
+            $expectation->expectRaw,
+            $result->rawValue(),
+            'The raw values should be identical to the input',
+        );
+
         self::assertValidEntry($result, $expectation->validKeys);
         self::assertInvalidEntry($result, $expectation->invalidKeys);
     }

--- a/test/InputFilterSpecificationTest.php
+++ b/test/InputFilterSpecificationTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\InputFilter;
+
+use Laminas\InputFilter\Factory;
+use Laminas\InputFilter\InputFilterInterface;
+use Laminas\InputFilter\InputFilterValidationResult;
+use Laminas\InputFilter\ValidationResultInterface;
+use LaminasTest\InputFilter\Spec\BasicFilterAndValidate;
+use LaminasTest\InputFilter\Spec\Expectation;
+use LaminasTest\InputFilter\Spec\InputFilterTestSpecInterface;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+use function array_pop;
+use function explode;
+use function sprintf;
+
+/** @psalm-import-type InputFilterSpecification from InputFilterInterface */
+final class InputFilterSpecificationTest extends TestCase
+{
+    /** @return list<class-string<InputFilterTestSpecInterface>> */
+    public static function specList(): array
+    {
+        return [
+            BasicFilterAndValidate::class,
+        ];
+    }
+
+    /** @return iterable<string, array{0: InputFilterSpecification, 1: Expectation}> */
+    public static function specDataProvider(): iterable
+    {
+        foreach (self::specList() as $class) {
+            $parts = explode('\\', $class);
+            $name  = array_pop($parts);
+
+            $spec = new $class();
+
+            foreach ($spec->expectations() as $key => $expectation) {
+                yield sprintf('%s - %s', $name, $key) => [
+                    $spec->spec(),
+                    $expectation,
+                ];
+            }
+        }
+    }
+
+    /** @param InputFilterSpecification $spec */
+    #[DataProvider('specDataProvider')]
+    public function testValidate(array $spec, Expectation $expectation): void
+    {
+        $factory     = TestHelper::getContainer()->get(Factory::class);
+        $inputFilter = $factory->createInputFilter($spec);
+
+        $result = $inputFilter->validate($expectation->input);
+
+        self::assertSame($expectation->valid, $result->valid());
+        self::assertSame($expectation->expect, $result->value());
+        self::assertValidEntry($result, $expectation->validKeys);
+        self::assertInvalidEntry($result, $expectation->invalidKeys);
+    }
+
+    /** @param list<string> $validKeys */
+    private static function assertValidEntry(ValidationResultInterface $result, array $validKeys): void
+    {
+        foreach ($validKeys as $keys) {
+            $itemResult = self::fetchResultFromDotSeparatedKey($keys, $result);
+            self::assertTrue(
+                $itemResult->valid(),
+                sprintf(
+                    'The input `%s` was expected to be valid, but it was invalid',
+                    $keys,
+                ),
+            );
+        }
+    }
+
+    /** @param list<string> $invalidKeys */
+    private static function assertInvalidEntry(ValidationResultInterface $result, array $invalidKeys): void
+    {
+        foreach ($invalidKeys as $keys) {
+            $itemResult = self::fetchResultFromDotSeparatedKey($keys, $result);
+            self::assertFalse(
+                $itemResult->valid(),
+                sprintf(
+                    'The input `%s` was expected to be invalid, but it was valid',
+                    $keys,
+                ),
+            );
+        }
+    }
+
+    private static function fetchResultFromDotSeparatedKey(
+        string $key,
+        ValidationResultInterface $result,
+    ): ValidationResultInterface {
+        $return = $result;
+        foreach (explode('.', $key) as $itemKey) {
+            self::assertInstanceOf(InputFilterValidationResult::class, $return);
+            $return = $return->resultFor($itemKey);
+        }
+
+        return $return;
+    }
+}

--- a/test/InputTest.php
+++ b/test/InputTest.php
@@ -32,9 +32,6 @@ use function sprintf;
 
 use const JSON_THROW_ON_ERROR;
 
-/**
- * @psalm-suppress DeprecatedMethod
- */
 final class InputTest extends TestCase
 {
     private const EMPTY_ERROR_MESSAGE_KEY = 'isEmpty';
@@ -403,7 +400,7 @@ final class InputTest extends TestCase
         $input = $this->createInput(
             'foo',
             TestHelper::createFilterChainFixture($valueRaw, $valueFiltered),
-            TestHelper::createValidatorChain($valueFiltered, true)
+            TestHelper::createValidatorChain($valueFiltered, true),
         );
 
         $input->setValue($valueRaw);

--- a/test/InputValidateMethodTest.php
+++ b/test/InputValidateMethodTest.php
@@ -1,0 +1,357 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\InputFilter;
+
+use Laminas\Filter\StringTrim;
+use Laminas\InputFilter\Factory;
+use Laminas\InputFilter\Input;
+use Laminas\InputFilter\InputFilterInterface;
+use Laminas\InputFilter\InputInterface;
+use Laminas\Validator\NotEmpty;
+use Laminas\Validator\Regex;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/** @psalm-import-type InputSpecification from InputFilterInterface */
+final class InputValidateMethodTest extends TestCase
+{
+    /** @return iterable<string, array{0: InputSpecification, 1: mixed, 2: bool}> */
+    public static function validateDataProviderWithEmptyValues(): iterable
+    {
+        foreach (['Empty String' => '', 'null' => null, 'Empty Array' => []] as $valueKey => $value) {
+            yield from [
+                'Req: T, Allow F, Cont: F: (' . $valueKey . ')' => [
+                    [
+                        'name'              => 'foo',
+                        'required'          => true,
+                        'allow_empty'       => false,
+                        'continue_if_empty' => false,
+                    ],
+                    $value,
+                    false,
+                ],
+                'Req: T, Allow T, Cont: F: (' . $valueKey . ')' => [
+                    [
+                        'name'              => 'foo',
+                        'required'          => true,
+                        'allow_empty'       => true,
+                        'continue_if_empty' => false,
+                    ],
+                    $value,
+                    true,
+                ],
+                'Req: T, Allow T, Cont: T: (' . $valueKey . ')' => [
+                    [
+                        'name'              => 'foo',
+                        'required'          => true,
+                        'allow_empty'       => true,
+                        'continue_if_empty' => true,
+                    ],
+                    $value,
+                    false,
+                ],
+                'Req: F, Allow T, Cont: T: (' . $valueKey . ')' => [
+                    [
+                        'name'              => 'foo',
+                        'required'          => false,
+                        'allow_empty'       => true,
+                        'continue_if_empty' => true,
+                    ],
+                    $value,
+                    false,
+                ],
+                'Req: F, Allow F, Cont: T: (' . $valueKey . ')' => [
+                    [
+                        'name'              => 'foo',
+                        'required'          => false,
+                        'allow_empty'       => false,
+                        'continue_if_empty' => true,
+                    ],
+                    $value,
+                    false,
+                ],
+                'Req: F, Allow F, Cont: F: (' . $valueKey . ')' => [
+                    [
+                        'name'              => 'foo',
+                        'required'          => false,
+                        'allow_empty'       => false,
+                        'continue_if_empty' => false,
+                    ],
+                    $value,
+                    true,
+                ],
+            ];
+        }
+    }
+
+    /** @return iterable<string, array{0: InputSpecification, 1: mixed, 2: bool}> */
+    public static function validateDataProviderWithNonEmptyValues(): iterable
+    {
+        $nonEmptyValues = [
+            'Non-Empty String' => 'Kermit',
+            'Int 0'            => 0,
+            'Int 1'            => 1,
+            'Float 0.0'        => 0.0,
+            'Float 1.0'        => 1.0,
+            'Zero String'      => '0',
+            'Non Empty Array'  => ['Miss', 'Piggy'],
+        ];
+
+        foreach ($nonEmptyValues as $valueKey => $value) {
+            yield from [
+                'Req: T, Allow F, Cont: F: (' . $valueKey . ')' => [
+                    [
+                        'name'              => 'foo',
+                        'required'          => true,
+                        'allow_empty'       => false,
+                        'continue_if_empty' => false,
+                    ],
+                    $value,
+                    true,
+                ],
+                'Req: T, Allow T, Cont: F: (' . $valueKey . ')' => [
+                    [
+                        'name'              => 'foo',
+                        'required'          => true,
+                        'allow_empty'       => true,
+                        'continue_if_empty' => false,
+                    ],
+                    $value,
+                    true,
+                ],
+                'Req: T, Allow T, Cont: T: (' . $valueKey . ')' => [
+                    [
+                        'name'              => 'foo',
+                        'required'          => true,
+                        'allow_empty'       => true,
+                        'continue_if_empty' => true,
+                    ],
+                    $value,
+                    true,
+                ],
+                'Req: F, Allow T, Cont: T: (' . $valueKey . ')' => [
+                    [
+                        'name'              => 'foo',
+                        'required'          => false,
+                        'allow_empty'       => true,
+                        'continue_if_empty' => true,
+                    ],
+                    $value,
+                    true,
+                ],
+                'Req: F, Allow F, Cont: T: (' . $valueKey . ')' => [
+                    [
+                        'name'              => 'foo',
+                        'required'          => false,
+                        'allow_empty'       => false,
+                        'continue_if_empty' => true,
+                    ],
+                    $value,
+                    true,
+                ],
+                'Req: F, Allow F, Cont: F: (' . $valueKey . ')' => [
+                    [
+                        'name'              => 'foo',
+                        'required'          => false,
+                        'allow_empty'       => false,
+                        'continue_if_empty' => false,
+                    ],
+                    $value,
+                    true,
+                ],
+            ];
+        }
+    }
+
+    /** @param InputSpecification $spec */
+    #[DataProvider('validateDataProviderWithEmptyValues')]
+    #[DataProvider('validateDataProviderWithNonEmptyValues')]
+    public function testValidateWithEmptyValues(array $spec, mixed $inputData, bool $valid): void
+    {
+        $factory = TestHelper::getContainer()->get(Factory::class);
+        $input   = $factory->createInput($spec);
+
+        $name = $spec['name'] ?? null;
+        self::assertIsString($name);
+        $result = $input->validate($inputData, [$name => $inputData]);
+
+        self::assertSame($valid, $result->valid());
+        self::assertSame($inputData, $result->rawValue(), 'Raw value should be identical to the input');
+        self::assertSame($inputData, $result->value(), 'Filtered value should be identical to the input');
+        $expectedErrorCount = $valid ? 0 : 1;
+        self::assertCount($expectedErrorCount, $result->getMessages());
+        self::assertSame($name, $result->name());
+    }
+
+    public function testEmptyValidationFailureMessageIsPresentWhenEmptyValuesPassValidation(): void
+    {
+        $factory = TestHelper::getContainer()->get(Factory::class);
+        $input   = $factory->createInput([
+            'name'              => 'Gonzo',
+            'required'          => false,
+            'allow_empty'       => true,
+            'continue_if_empty' => true,
+        ]);
+
+        $result = $input->validate('', ['Gonzo' => '']);
+        self::assertFalse($result->valid());
+        self::assertCount(1, $result->getMessages());
+        self::assertArrayHasKey(InputInterface::EMPTY_FAILURE_VALIDATION_KEY, $result->getMessages()->toArray());
+        self::assertSame(
+            'The value for "Gonzo" was empty, but its configuration prohibits an empty value. '
+            . 'Prepend a "NotEmpty" validator to this input’s chain in order to customise '
+            . 'this validation failure message',
+            $result->getMessages()[InputInterface::EMPTY_FAILURE_VALIDATION_KEY],
+        );
+    }
+
+    public function testEmptyValidationFailureMessageIsNotPresentWhenNotEmptyValidatorIsPresent(): void
+    {
+        $factory = TestHelper::getContainer()->get(Factory::class);
+        $input   = $factory->createInput([
+            'name'              => 'Gonzo',
+            'required'          => false,
+            'allow_empty'       => true,
+            'continue_if_empty' => true,
+            'validators'        => [
+                ['name' => NotEmpty::class],
+            ],
+        ]);
+
+        $result = $input->validate('', ['Gonzo' => '']);
+        self::assertFalse($result->valid());
+        self::assertCount(1, $result->getMessages());
+        self::assertArrayHasKey(NotEmpty::IS_EMPTY, $result->getMessages()->toArray());
+        self::assertArrayNotHasKey(InputInterface::EMPTY_FAILURE_VALIDATION_KEY, $result->getMessages()->toArray());
+    }
+
+    public function testFiltersAreAppliedToTheInput(): void
+    {
+        $factory = TestHelper::getContainer()->get(Factory::class);
+        $input   = $factory->createInput([
+            'name'              => 'foo',
+            'required'          => true,
+            'allow_empty'       => false,
+            'continue_if_empty' => false,
+            'filters'           => [
+                ['name' => StringTrim::class],
+            ],
+        ]);
+
+        $result = $input->validate(' fred ', ['foo' => ' fred ']);
+        self::assertTrue($result->valid());
+        self::assertSame(' fred ', $result->rawValue());
+        self::assertSame('fred', $result->value());
+        self::assertCount(0, $result->getMessages());
+    }
+
+    public function testFallbackValueIsFilteredWhenGiven(): void
+    {
+        $factory = TestHelper::getContainer()->get(Factory::class);
+        $input   = $factory->createInput([
+            'name'              => 'foo',
+            'required'          => true,
+            'allow_empty'       => false,
+            'continue_if_empty' => true,
+            'fallback_value'    => ' Marge ',
+            'filters'           => [
+                ['name' => StringTrim::class],
+            ],
+        ]);
+
+        $result = $input->validate('', ['foo' => '']);
+        self::assertTrue($result->valid());
+        self::assertSame('', $result->rawValue());
+        self::assertSame('Marge', $result->value());
+        self::assertCount(0, $result->getMessages());
+    }
+
+    public function testFallbackValueIsNotValidatedWhenGiven(): void
+    {
+        $factory = TestHelper::getContainer()->get(Factory::class);
+        $input   = $factory->createInput([
+            'name'              => 'foo',
+            'required'          => true,
+            'allow_empty'       => false,
+            'continue_if_empty' => true,
+            'fallback_value'    => 'Marge',
+            'validators'        => [
+                [
+                    'name'    => Regex::class,
+                    'options' => [
+                        'pattern' => '/^[0-9]+$/',
+                    ],
+                ],
+            ],
+        ]);
+
+        $result = $input->validate('', ['foo' => '']);
+        self::assertTrue($result->valid());
+        self::assertSame('', $result->rawValue());
+        self::assertSame('Marge', $result->value());
+        self::assertCount(0, $result->getMessages());
+    }
+
+    public function testAnyFailingValidationDoesNotTriggerBuiltInEmptyChecks(): void
+    {
+        $factory = TestHelper::getContainer()->get(Factory::class);
+        $input   = $factory->createInput([
+            'name'              => 'foo',
+            'required'          => true,
+            'allow_empty'       => false,
+            'continue_if_empty' => true,
+            'validators'        => [
+                [
+                    'name'    => Regex::class,
+                    'options' => [
+                        'pattern' => '/^[0-9]+$/',
+                    ],
+                ],
+            ],
+        ]);
+
+        $result = $input->validate('foo', ['foo' => 'foo']);
+        self::assertFalse($result->valid());
+        self::assertSame('foo', $result->rawValue());
+        self::assertSame('foo', $result->value());
+        self::assertCount(1, $result->getMessages());
+        self::assertArrayHasKey(Regex::NOT_MATCH, $result->getMessages()->toArray());
+    }
+
+    public function testValidateMethodDoesNotAffectInternals(): void
+    {
+        $factory = TestHelper::getContainer()->get(Factory::class);
+        $input   = $factory->createInput([
+            'name'              => 'foo',
+            'required'          => true,
+            'allow_empty'       => false,
+            'continue_if_empty' => true,
+            'validators'        => [
+                [
+                    'name'    => Regex::class,
+                    'options' => [
+                        'pattern' => '/^[0-9]+$/',
+                    ],
+                ],
+            ],
+        ]);
+        self::assertInstanceOf(Input::class, $input);
+
+        $result = $input->validate('foo', ['foo' => 'foo']);
+        self::assertFalse($result->valid());
+        $this->assertInternalsAreNotMutated($input);
+
+        $result = $input->validate('123', ['foo' => '123']);
+        self::assertTrue($result->valid());
+        $this->assertInternalsAreNotMutated($input);
+    }
+
+    private function assertInternalsAreNotMutated(Input $input): void
+    {
+        self::assertNull($input->getValue());
+        self::assertNull($input->getRawValue());
+        self::assertFalse($input->hasValue());
+    }
+}

--- a/test/Spec/BasicCollections.php
+++ b/test/Spec/BasicCollections.php
@@ -1,0 +1,383 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\InputFilter\Spec;
+
+use Laminas\Filter\StringTrim;
+use Laminas\Filter\ToNull;
+use Laminas\InputFilter\CollectionInputFilter;
+use Laminas\InputFilter\InputFilter;
+use Laminas\InputFilter\InputFilterInterface;
+use Laminas\Validator\Ip;
+use Laminas\Validator\NotEmpty;
+
+/** @psalm-import-type InputFilterSpecification from InputFilterInterface */
+final readonly class BasicCollections implements InputFilterTestSpecInterface
+{
+    public function __construct()
+    {
+    }
+
+    /** @inheritDoc */
+    public function spec(): array
+    {
+        /** @psalm-var InputFilterSpecification */
+        return [
+            'type'    => InputFilter::class,
+            'collect' => [
+                'type'         => CollectionInputFilter::class,
+                'required'     => true,
+                'count'        => 2,
+                'input_filter' => [
+                    'type' => InputFilter::class,
+                    'a'    => [
+                        'name'       => 'a',
+                        'required'   => true,
+                        'filters'    => [
+                            ['name' => StringTrim::class],
+                            ['name' => ToNull::class],
+                        ],
+                        'validators' => [
+                            ['name' => NotEmpty::class],
+                            ['name' => Ip::class],
+                        ],
+                    ],
+                    'b'    => [
+                        'name'       => 'b',
+                        'required'   => true,
+                        'filters'    => [
+                            ['name' => StringTrim::class],
+                            ['name' => ToNull::class],
+                        ],
+                        'validators' => [
+                            ['name' => NotEmpty::class],
+                            ['name' => Ip::class],
+                        ],
+                    ],
+                    'c'    => [
+                        'name'       => 'c',
+                        'required'   => true,
+                        'filters'    => [
+                            ['name' => StringTrim::class],
+                            ['name' => ToNull::class],
+                        ],
+                        'validators' => [
+                            ['name' => NotEmpty::class],
+                            ['name' => Ip::class],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @inheritDoc
+     * phpcs:disable WebimpressCodingStandard.Arrays.DoubleArrow.SpacesBefore
+     */
+    public function expectations(): array
+    {
+        return [
+            'Valid Payload' => new Expectation(
+                [
+                    'collect' => [
+                        0 => [
+                            'a' => '1.1.1.1',
+                            'b' => '1.1.1.2',
+                            'c' => '1.1.1.3',
+                        ],
+                        1 => [
+                            'a' => '1.1.1.4',
+                            'b' => '1.1.1.5',
+                            'c' => '1.1.1.6',
+                        ],
+                    ],
+                ],
+                true,
+                [],
+                [
+                    'collect.0.a',
+                    'collect.0.b',
+                    'collect.0.c',
+                    'collect.1.a',
+                    'collect.1.b',
+                    'collect.1.c',
+                ],
+                [
+                    'collect' => [
+                        0 => [
+                            'a' => '1.1.1.1',
+                            'b' => '1.1.1.2',
+                            'c' => '1.1.1.3',
+                        ],
+                        1 => [
+                            'a' => '1.1.1.4',
+                            'b' => '1.1.1.5',
+                            'c' => '1.1.1.6',
+                        ],
+                    ],
+                ],
+                [
+                    'collect' => [
+                        0 => [
+                            'a' => '1.1.1.1',
+                            'b' => '1.1.1.2',
+                            'c' => '1.1.1.3',
+                        ],
+                        1 => [
+                            'a' => '1.1.1.4',
+                            'b' => '1.1.1.5',
+                            'c' => '1.1.1.6',
+                        ],
+                    ],
+                ],
+            ),
+            'Not enough items, but otherwise valid' => new Expectation(
+                [
+                    'collect' => [
+                        0 => [
+                            'a' => '1.1.1.1',
+                            'b' => '1.1.1.2',
+                            'c' => '1.1.1.3',
+                        ],
+                    ],
+                ],
+                false,
+                [
+                    'collect.1.a',
+                    'collect.1.b',
+                    'collect.1.c',
+                ],
+                [
+                    'collect.0.a',
+                    'collect.0.b',
+                    'collect.0.c',
+                ],
+                [
+                    'collect' => [
+                        0 => [
+                            'a' => '1.1.1.1',
+                            'b' => '1.1.1.2',
+                            'c' => '1.1.1.3',
+                        ],
+                        1 => [
+                            'a' => null,
+                            'b' => null,
+                            'c' => null,
+                        ],
+                    ],
+                ],
+                [
+                    'collect' => [
+                        0 => [
+                            'a' => '1.1.1.1',
+                            'b' => '1.1.1.2',
+                            'c' => '1.1.1.3',
+                        ],
+                        1 => [
+                            'a' => null,
+                            'b' => null,
+                            'c' => null,
+                        ],
+                    ],
+                ],
+            ),
+            'Not enough items, also invalid values' => new Expectation(
+                [
+                    'collect' => [
+                        0 => [
+                            'a' => 'Fred',
+                            'b' => '1.1.1.2',
+                            'c' => '1.1.1.3',
+                        ],
+                    ],
+                ],
+                false,
+                [
+                    'collect.0.a',
+                    'collect.1.a',
+                    'collect.1.b',
+                    'collect.1.c',
+                ],
+                [
+                    'collect.0.b',
+                    'collect.0.c',
+                ],
+                [
+                    'collect' => [
+                        0 => [
+                            'a' => 'Fred',
+                            'b' => '1.1.1.2',
+                            'c' => '1.1.1.3',
+                        ],
+                        1 => [
+                            'a' => null,
+                            'b' => null,
+                            'c' => null,
+                        ],
+                    ],
+                ],
+                [
+                    'collect' => [
+                        0 => [
+                            'a' => 'Fred',
+                            'b' => '1.1.1.2',
+                            'c' => '1.1.1.3',
+                        ],
+                        1 => [
+                            'a' => null,
+                            'b' => null,
+                            'c' => null,
+                        ],
+                    ],
+                ],
+            ),
+            'More than minimum count, but all valid' => new Expectation(
+                [
+                    'collect' => [
+                        0 => [
+                            'a' => '1.1.1.1',
+                            'b' => '1.1.1.2',
+                            'c' => '1.1.1.3',
+                        ],
+                        1 => [
+                            'a' => '1.1.1.4',
+                            'b' => '1.1.1.5',
+                            'c' => '1.1.1.6',
+                        ],
+                        2 => [
+                            'a' => '1.1.1.7',
+                            'b' => '1.1.1.8',
+                            'c' => '1.1.1.9',
+                        ],
+                    ],
+                ],
+                true,
+                [],
+                [
+                    'collect.0.a',
+                    'collect.0.b',
+                    'collect.0.c',
+                    'collect.1.a',
+                    'collect.1.b',
+                    'collect.1.c',
+                    'collect.2.a',
+                    'collect.2.b',
+                    'collect.2.c',
+                ],
+                [
+                    'collect' => [
+                        0 => [
+                            'a' => '1.1.1.1',
+                            'b' => '1.1.1.2',
+                            'c' => '1.1.1.3',
+                        ],
+                        1 => [
+                            'a' => '1.1.1.4',
+                            'b' => '1.1.1.5',
+                            'c' => '1.1.1.6',
+                        ],
+                        2 => [
+                            'a' => '1.1.1.7',
+                            'b' => '1.1.1.8',
+                            'c' => '1.1.1.9',
+                        ],
+                    ],
+                ],
+                [
+                    'collect' => [
+                        0 => [
+                            'a' => '1.1.1.1',
+                            'b' => '1.1.1.2',
+                            'c' => '1.1.1.3',
+                        ],
+                        1 => [
+                            'a' => '1.1.1.4',
+                            'b' => '1.1.1.5',
+                            'c' => '1.1.1.6',
+                        ],
+                        2 => [
+                            'a' => '1.1.1.7',
+                            'b' => '1.1.1.8',
+                            'c' => '1.1.1.9',
+                        ],
+                    ],
+                ],
+            ),
+            'More than minimum count, 3rd item invalid' => new Expectation(
+                [
+                    'collect' => [
+                        0 => [
+                            'a' => '1.1.1.1',
+                            'b' => '1.1.1.2',
+                            'c' => '1.1.1.3',
+                        ],
+                        1 => [
+                            'a' => '1.1.1.4',
+                            'b' => '1.1.1.5',
+                            'c' => '1.1.1.6',
+                        ],
+                        2 => [
+                            'a' => '1.1.1.7',
+                            'b' => 'Granny',
+                            'c' => '1.1.1.9',
+                        ],
+                    ],
+                ],
+                false,
+                [
+                    'collect.2.b',
+                ],
+                [
+                    'collect.0.a',
+                    'collect.0.b',
+                    'collect.0.c',
+                    'collect.1.a',
+                    'collect.1.b',
+                    'collect.1.c',
+                    'collect.2.a',
+                    'collect.2.c',
+                ],
+                [
+                    'collect' => [
+                        0 => [
+                            'a' => '1.1.1.1',
+                            'b' => '1.1.1.2',
+                            'c' => '1.1.1.3',
+                        ],
+                        1 => [
+                            'a' => '1.1.1.4',
+                            'b' => '1.1.1.5',
+                            'c' => '1.1.1.6',
+                        ],
+                        2 => [
+                            'a' => '1.1.1.7',
+                            'b' => 'Granny',
+                            'c' => '1.1.1.9',
+                        ],
+                    ],
+                ],
+                [
+                    'collect' => [
+                        0 => [
+                            'a' => '1.1.1.1',
+                            'b' => '1.1.1.2',
+                            'c' => '1.1.1.3',
+                        ],
+                        1 => [
+                            'a' => '1.1.1.4',
+                            'b' => '1.1.1.5',
+                            'c' => '1.1.1.6',
+                        ],
+                        2 => [
+                            'a' => '1.1.1.7',
+                            'b' => 'Granny',
+                            'c' => '1.1.1.9',
+                        ],
+                    ],
+                ],
+            ),
+        ];
+    }
+}

--- a/test/Spec/BasicFilterAndValidate.php
+++ b/test/Spec/BasicFilterAndValidate.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\InputFilter\Spec;
+
+use Laminas\Filter\StringTrim;
+use Laminas\Filter\ToNull;
+use Laminas\InputFilter\InputFilter;
+use Laminas\InputFilter\InputFilterInterface;
+use Laminas\Validator\Ip;
+use Laminas\Validator\NotEmpty;
+
+/** @psalm-import-type InputFilterSpecification from InputFilterInterface */
+final readonly class BasicFilterAndValidate implements InputFilterTestSpecInterface
+{
+    public function __construct()
+    {
+    }
+
+    /** @inheritDoc */
+    public function spec(): array
+    {
+        /** @psalm-var InputFilterSpecification */
+        return [
+            'type' => InputFilter::class,
+            'a'    => [
+                'name'       => 'a',
+                'required'   => true,
+                'filters'    => [
+                    ['name' => StringTrim::class],
+                    ['name' => ToNull::class],
+                ],
+                'validators' => [
+                    ['name' => NotEmpty::class],
+                    ['name' => Ip::class],
+                ],
+            ],
+            'b'    => [
+                'type' => InputFilter::class,
+                'c'    => [
+                    'name'       => 'c',
+                    'required'   => true,
+                    'filters'    => [
+                        ['name' => StringTrim::class],
+                        ['name' => ToNull::class],
+                    ],
+                    'validators' => [
+                        ['name' => NotEmpty::class],
+                        ['name' => Ip::class],
+                    ],
+                ],
+                'd'    => [
+                    'name'        => 'd',
+                    'required'    => false,
+                    'allow_empty' => true,
+                    'filters'     => [
+                        ['name' => StringTrim::class],
+                        ['name' => ToNull::class],
+                    ],
+                    'validators'  => [],
+                ],
+            ],
+        ];
+    }
+
+    /** @inheritDoc */
+    public function expectations(): array
+    {
+        return [
+            'Valid Payload'      => new Expectation(
+                [
+                    'a' => ' 123.123.123.123 ',
+                    'b' => [
+                        'c' => '1.1.1.1',
+                        'd' => '',
+                    ],
+                ],
+                true,
+                [],
+                [
+                    'a',
+                    'b.c',
+                    'b.d',
+                ],
+                [
+                    'a' => '123.123.123.123',
+                    'b' => [
+                        'c' => '1.1.1.1',
+                        'd' => null,
+                    ],
+                ],
+            ),
+            'Empty Payload'      => new Expectation(
+                [],
+                false,
+                [
+                    'a',
+                    'b.c',
+                ],
+                [
+                    'b.d',
+                ],
+                [
+                    'a' => null,
+                    'b' => [
+                        'c' => null,
+                        'd' => null,
+                    ],
+                ],
+            ),
+            'Non-empty, Invalid' => new Expectation(
+                [
+                    'a' => 'fred',
+                    'b' => [
+                        'c' => 'wilma',
+                        'd' => 'barney',
+                    ],
+                ],
+                false,
+                [
+                    'a',
+                    'b.c',
+                ],
+                [
+                    'b.d',
+                ],
+                [
+                    'a' => 'fred',
+                    'b' => [
+                        'c' => 'wilma',
+                        'd' => 'barney',
+                    ],
+                ],
+            ),
+        ];
+    }
+}

--- a/test/Spec/BasicFilterAndValidate.php
+++ b/test/Spec/BasicFilterAndValidate.php
@@ -90,6 +90,13 @@ final readonly class BasicFilterAndValidate implements InputFilterTestSpecInterf
                         'd' => null,
                     ],
                 ],
+                [
+                    'a' => ' 123.123.123.123 ',
+                    'b' => [
+                        'c' => '1.1.1.1',
+                        'd' => '',
+                    ],
+                ],
             ),
             'Empty Payload'      => new Expectation(
                 [],
@@ -100,6 +107,13 @@ final readonly class BasicFilterAndValidate implements InputFilterTestSpecInterf
                 ],
                 [
                     'b.d',
+                ],
+                [
+                    'a' => null,
+                    'b' => [
+                        'c' => null,
+                        'd' => null,
+                    ],
                 ],
                 [
                     'a' => null,
@@ -124,6 +138,13 @@ final readonly class BasicFilterAndValidate implements InputFilterTestSpecInterf
                 ],
                 [
                     'b.d',
+                ],
+                [
+                    'a' => 'fred',
+                    'b' => [
+                        'c' => 'wilma',
+                        'd' => 'barney',
+                    ],
                 ],
                 [
                     'a' => 'fred',

--- a/test/Spec/Expectation.php
+++ b/test/Spec/Expectation.php
@@ -11,6 +11,7 @@ final readonly class Expectation
      * @param list<string> $invalidKeys
      * @param list<string> $validKeys
      * @param array<array-key, mixed> $expect
+     * @param array<array-key, mixed> $expectRaw
      */
     public function __construct(
         public iterable $input,
@@ -18,6 +19,7 @@ final readonly class Expectation
         public array $invalidKeys,
         public array $validKeys,
         public array $expect,
+        public array $expectRaw,
     ) {
     }
 }

--- a/test/Spec/Expectation.php
+++ b/test/Spec/Expectation.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\InputFilter\Spec;
+
+final readonly class Expectation
+{
+    /**
+     * @param iterable<array-key, mixed> $input
+     * @param list<string> $invalidKeys
+     * @param list<string> $validKeys
+     * @param array<array-key, mixed> $expect
+     */
+    public function __construct(
+        public iterable $input,
+        public bool $valid,
+        public array $invalidKeys,
+        public array $validKeys,
+        public array $expect,
+    ) {
+    }
+}

--- a/test/Spec/InputFilterTestSpecInterface.php
+++ b/test/Spec/InputFilterTestSpecInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\InputFilter\Spec;
+
+use Laminas\InputFilter\InputFilterInterface;
+
+/**
+ * @psalm-import-type InputFilterSpecification from InputFilterInterface
+ * @psalm-consistent-constructor
+ */
+interface InputFilterTestSpecInterface
+{
+    /**
+     * This constructor is interfaced to ensure implementations can be 'newed' without arguments
+     *
+     * @psalm-suppress PossiblyUnusedMethod
+     */
+    public function __construct();
+
+    /** @return InputFilterSpecification */
+    public function spec(): array;
+
+    /** @return array<string, Expectation> */
+    public function expectations(): array;
+}

--- a/test/StaticAnalysis/ValidationResultValuesHavePreciseInference.php
+++ b/test/StaticAnalysis/ValidationResultValuesHavePreciseInference.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\InputFilter\StaticAnalysis;
+
+final readonly class ValidationResultValuesHavePreciseInference
+{
+    public function __construct(private NestedInputFilterWithTemplatedValues $inputFilter)
+    {
+    }
+
+    /** @return non-empty-string */
+    public function fetchFromNestedResult(array $input): string
+    {
+        $result = $this->inputFilter->validate($input);
+
+        return $result->value()['nested']['someString'];
+    }
+}

--- a/test/TestAsset/InputInterfaceImplementation.php
+++ b/test/TestAsset/InputInterfaceImplementation.php
@@ -11,6 +11,7 @@ use Laminas\InputFilter\InputFilterInterface;
 use Laminas\InputFilter\InputInterface;
 use Laminas\InputFilter\InputValidationResult;
 use Laminas\Validator\ValidatorChainInterface;
+use NoDiscard;
 
 /** @psalm-import-type InputSpecification from InputFilterInterface */
 final class InputInterfaceImplementation implements InputInterface
@@ -119,6 +120,7 @@ final class InputInterfaceImplementation implements InputInterface
         return $this->hasFallback;
     }
 
+    #[NoDiscard]
     public function validate(mixed $value, array $context): InputValidationResult
     {
         throw new Exception('Not implemented');

--- a/test/TestAsset/InputInterfaceImplementation.php
+++ b/test/TestAsset/InputInterfaceImplementation.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace LaminasTest\InputFilter\TestAsset;
 
+use Exception;
 use Laminas\Filter\FilterChainInterface;
 use Laminas\InputFilter\ErrorMessages;
 use Laminas\InputFilter\InputFilterInterface;
 use Laminas\InputFilter\InputInterface;
+use Laminas\InputFilter\InputValidationResult;
 use Laminas\Validator\ValidatorChainInterface;
 
 /** @psalm-import-type InputSpecification from InputFilterInterface */
@@ -115,5 +117,10 @@ final class InputInterfaceImplementation implements InputInterface
     public function hasFallback(): bool
     {
         return $this->hasFallback;
+    }
+
+    public function validate(mixed $value, array $context): InputValidationResult
+    {
+        throw new Exception('Not implemented');
     }
 }

--- a/test/TestAsset/InputInterfaceStub.php
+++ b/test/TestAsset/InputInterfaceStub.php
@@ -7,6 +7,7 @@ namespace LaminasTest\InputFilter\TestAsset;
 use Exception;
 use Laminas\InputFilter\ErrorMessages;
 use Laminas\InputFilter\InputInterface;
+use Laminas\InputFilter\InputValidationResult;
 
 use function func_get_arg;
 use function func_num_args;
@@ -114,5 +115,10 @@ final readonly class InputInterfaceStub implements InputInterface
     public function hasFallback(): bool
     {
         return false;
+    }
+
+    public function validate(mixed $value, array $context): InputValidationResult
+    {
+        throw new Exception('Not implemented');
     }
 }

--- a/test/TestAsset/InputInterfaceStub.php
+++ b/test/TestAsset/InputInterfaceStub.php
@@ -8,6 +8,7 @@ use Exception;
 use Laminas\InputFilter\ErrorMessages;
 use Laminas\InputFilter\InputInterface;
 use Laminas\InputFilter\InputValidationResult;
+use NoDiscard;
 
 use function func_get_arg;
 use function func_num_args;
@@ -117,6 +118,7 @@ final readonly class InputInterfaceStub implements InputInterface
         return false;
     }
 
+    #[NoDiscard]
     public function validate(mixed $value, array $context): InputValidationResult
     {
         throw new Exception('Not implemented');

--- a/tools/crc/config.json
+++ b/tools/crc/config.json
@@ -1,2 +1,5 @@
 {
+    "symbol-whitelist" : [
+        "NoDiscard"
+    ]
 }


### PR DESCRIPTION
Adds a `validate()` method to the input filter and input types that will each return a subtype of `ValidationResultInterface`.

The result carries error messages, the un-filtered input and the filtered values in success and failure conditions.

If this is implemented alongside the existing `isValid()` stateful validation process, it can provide a path for input filter to become more-or-less stateless.

One advantage is that translation can be implemented externally by passing the result objects into a translation tool.

The way that validation of missing/empty values is handled here is by inserting an obvious message into the error stack for the relevant input as opposed to mutating the validator chain. In future, we will be able to drop this as users move towards explicitly adding a `NotEmpty` validator to their specifications, in turn, meaning we can drop the complexity of `allow_empty`, `required`, `continue_if_empty` option shenanigans.

Still to do:

- Implement validation groups
- More thorough tests
- Implementation in collections to be checked

